### PR TITLE
fix: remove unused import and apply Black formatting to database.py

### DIFF
--- a/src/homepot_client/database.py
+++ b/src/homepot_client/database.py
@@ -8,7 +8,6 @@ import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, AsyncGenerator, Dict, List, Optional
-from urllib.parse import urlparse
 
 from sqlalchemy import Result
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -71,7 +70,7 @@ class DatabaseService:
                 db_path = db_url.replace("sqlite:///", "")
                 if db_path.startswith("./"):
                     db_path = db_path[2:]
-                
+
                 # Create parent directory if it doesn't exist
                 db_file = Path(db_path)
                 db_file.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
This PR addresses code quality issues found by the validation script:

### Changes
- Removed unused \`urllib.parse.urlparse\` import from \`database.py\`
- Applied Black formatting (fixed trailing whitespace on line 73)

### Validation Results
- **Black formatting**: PASSED
- **Import sorting (isort)**: PASSED  
- **Linting (flake8)**: PASSED
- **Type checking (mypy)**: Skipped (missing stubs - expected)
- **Security scan (bandit)**: 3 warnings about 0.0.0.0 binding (acceptable for server apps)