### PR TITLE
docs: add user app implementation tasks for Dealdio and GetFudo

### DIFF
--- a/docs/dealdio-user-app-tasks.md
+++ b/docs/dealdio-user-app-tasks.md
@@ -1,0 +1,56 @@
+# Dealdio: Real Device Pilot & User App Preparations
+
+**Owner:** Dealdio Engineering Team  
+**Status:** In Progress  
+**Objective:** Validate the "Hybrid Fleet" architecture, package the real device agent, and prepare the underlying backend and local APIs for the GetFudo User App implementation.
+
+---
+
+## Part 1: Core Agent Packaging (From Original Spec)
+
+### 1.1 Dependency Isolation
+*   Create a minimal `requirements-app.txt` containing only necessary libraries for the agent (e.g., `httpx`, `psutil`, `asyncio`).
+*   Ensure full backend dependencies (`fastapi`, `sqlalchemy`) are excluded from the agent's footprint.
+
+### 1.2 Enhanced Data Collection (Device DNA)
+*   Update `real_device_agent.py` to collect static entries:
+    *   **IP Address:** Local and WAN IP.
+    *   **MAC Address:** Physical address of the primary interface.
+    *   **OS Details:** OS Name and Version (e.g., "Ubuntu 22.04" or "Windows 11").
+*   Send this payload on startup/registration and include it in the heartbeat.
+
+### 1.3 Configuration Handling
+*   Modify `real_device_agent.py` to accept configuration via a simple JSON file (`agent-config.json`) instead of relying solely on environment variables.
+*   Required fields: `backend_url`, `device_id`, `api_key`, `site_id`.
+
+### 1.4 Executable Generation
+*   Use `pyinstaller` (or similar) to create standalone binaries for Linux and Windows to simplify deployment.
+
+---
+
+## Part 2: Preparatory Tasks for GetFudo Collaboration
+
+### 2.1 Build the Agent's Local Inter-Process Communication (IPC)
+*   Implement a local communication layer in `real_device_agent.py` (e.g., a lightweight local FastAPI server on `localhost` or a UNIX Domain Socket).
+*   **Goal:** Allow GetFudo's Electron/React UI to query local device status without needing OS-level access.
+
+### 2.2 Scaffold Backend Database & Endpoints for "Device DNA"
+*   Update core backend (SQLAlchemy models) to store `os_details`, `mac_address`, and `wan_ip`.
+*   Establish and document the `/api/v1/agent/telemetry` endpoints in Swagger/OpenAPI.
+
+### 2.3 Extend the Setup Wizard Capabilities (Backend Auto-Provisioning)
+*   Create a new backend endpoint (e.g., `POST /api/v1/devices/provision`) that accepts an SSO token/user identity and dynamically issues a `device_id` and `api_key`.
+*   **Goal:** Replace manual provisioning for the User App.
+
+### 2.4 Create "Agent Stubs" & Mock Payloads
+*   Export canonical `mock_dna.json` and `mock_telemetry.json` representing exactly what the agent and backend will output.
+*   **Goal:** Unblock GetFudo so they can mock their UI against frozen data contracts.
+
+---
+
+## Part 3: Pilot Deployment & Verification (From Original Spec)
+
+*   **Manual Provisioning:** Register 5 new "Real Devices" (`physical_terminal`) in the web admin.
+*   **Agent Installation:** Deploy the binaries and `agent-config.json` to 5 physical Linux/Windows machines.
+*   **Service Setup:** Configure the agent as a system service (`systemd` / Windows Service).
+*   **Verification:** Confirm Dashboard reflects Online status, real-time telemetry, Device DNA, and consistent heartbeats.

--- a/docs/getfudo-user-app-tasks.md
+++ b/docs/getfudo-user-app-tasks.md
@@ -1,0 +1,48 @@
+# GetFudo: User App UI/UX & Frontend Implementation
+
+**Owner:** GetFudo Design & Frontend Team  
+**Status:** Pending (Awaiting Return)  
+**Objective:** Design and build the lightweight native client agent ("Digital Security Badge") that runs on employee devices (Android, Windows, Linux, macOS).
+
+---
+
+## Part 1: Design Requirements
+
+**Philosophy**: Ensure the app looks secure, stable, unobtrusive. High Trust Design.  
+**Stack Alignment**: Tailwind CSS + Radix UI (Match the Dashboard's aesthetics/dark mode).
+
+### Required High-Fidelity Views
+1.  **The "Digital Badge" (Home)**
+    *   Large reassuring status ring/shield (Green/Red).
+    *   Prominent User Avatar/Identity.
+    *   Actions: "Sync Now" and "Corporate Files".
+2.  **The Setup Wizard (Onboarding)**
+    *   Server URL input -> User Login (SSO/OIDC) -> OS Admin Permissions explanation.
+    *   Note: Use Trust Design principles for the Permissions request.
+3.  **Device DNA (Details)**
+    *   Clean list format showing: OS Version, IP Address, Policy Version, Last Heartbeat Timestamp.
+4.  **System Tray / Widget**
+    *   A minimized view of the app for Desktop (Windows/macOS/Linux).
+
+---
+
+## Part 2: Technical Frontend Implementation
+
+**Architecture Model**: Hybrid Monolith (Single codebase across 5 OS's)
+*   **Directory**: Initialize in `/workspace/homepot-client/user-app/` (Sibling to `frontend/`).
+*   **Core stack**: React 19 + Vite.
+*   **Desktop Shell**: Electron (Windows/macOS/Linux).
+*   **Mobile Shell**: Capacitor 8 (Android).
+*   **Database**: SQLite (`@capacitor-community/sqlite` and `better-sqlite3`).
+
+### Key Delivery Milestones
+*   **Milestone 1: Scaffold Infrastructure**
+    *   Initialize the Vite/React workspace in the new `user-app/` directory.
+    *   Configure Electron build wrappers and Capacitor hooks.
+*   **Milestone 2: Agent IPC Integration**
+    *   Connect the React frontend to the local API / Socket established by the **Dealdio** engine.
+    *   Alternatively, initialize development using Dealdio's `mock_dna.json` and `mock_telemetry.json` payloads.
+*   **Milestone 3: UI Component Build**
+    *   Implement Digital Badge, Onboarding, and Details views.
+*   **Milestone 4: Native Capabilities**
+    *   Wire up native alerts, background polling hooks, and Tray components.


### PR DESCRIPTION
This PR introduces the detailed breakdown of responsibilities and implementation tasks for the new HOMEPOT "User App" (Digital Security Badge).

The requirements have been split into two distinct, actionable Markdown documents to guide the engineering teams, replacing the need to distribute external PDF specifications. 

### What's Included

*   **`docs/dealdio-user-app-tasks.md`**: Tracks Dealdio's responsibilities for packaging the headless Python agent (`real_device_agent.py`), building out the "Device DNA" telemetry collection, establishing a local IPC layer for the frontend, and extending backend auto-provisioning.
*   **`docs/getfudo-user-app-tasks.md`**: Outlines GetFudo's UI/UX requirements and architecture milestones for building the Hybrid Monolith (React/Vite + Electron/Capacitor) User App frontend that will interface with Dealdio's agent.

By merging these task lists into the main documentation structure, both teams can gain immediate visibility into the "Hybrid Fleet" architecture goals, clearly track dependencies between backend/agent capabilities and UI elements, and easily reference requirements directly alongside the code in the repository.