### PR TITLE
fix(docs): remove malicious polyfill.io CDN reference

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -197,5 +197,4 @@ extra_css:
 
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js


### PR DESCRIPTION
Resolves #157. Removes the compromised polyfill.io CDN from MkDocs to fix the security issue and unexpected sign-in popups.