### PR TITLE
fix(docs): isolate mkdocs dependencies to unblock RTD builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,4 +25,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
   install:
-    - requirements: backend/requirements.txt
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,7 @@
+# Documentation dependencies for ReadTheDocs
+mkdocs==1.6.1  # Project documentation with Markdown
+mkdocs-material==9.6.22  # Material Design theme for MkDocs
+mkdocs-material-extensions==1.3.1  # Extension pack for MkDocs Material
+pymdown-extensions==10.16.1  # Extensions for Python Markdown
+markdown==3.9  # Python implementation of Markdown
+mkdocs-minify-plugin==0.8.0  # Minifies HTML/JS/CSS for MkDocs


### PR DESCRIPTION
Separates the documentation dependencies from `backend/requirements.txt` into `docs/requirements.txt` and updates `.readthedocs.yaml`. By forcing ReadTheDocs to pip install the entire backend suite (which includes massive AI libraries like ChromaDB and PyTorch), the cloud builder was running out of RAM/Time and aborting the pipeline, meaning documentation was never actually getting refreshed on the live site!