### PR TITLE
fix(docs): pin Pygments<2.20 to resolve MkDocs HTML build compilation crash

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,4 @@ mkdocs-material==9.6.22  # Material Design theme for MkDocs
 mkdocs-material-extensions==1.3.1  # Extension pack for MkDocs Material
 pymdown-extensions==10.16.1  # Extensions for Python Markdown
 markdown==3.9  # Python implementation of Markdown
-mkdocs-minify-plugin==0.8.0  # Minifies HTML/JS/CSS for MkDocs
+mkdocs-minify-plugin==0.8.0  # Minifies HTML/JS/CSS for MkDocsPygments==2.18.0


### PR DESCRIPTION
The combination of the newly available Pygments 2.20.0 and MkDocs Material caused a Python `AttributeError: 'NoneType' object has no attribute 'replace'` exception any time it attempted to render an orphan markdown block with no language specified (e.g. `HomepotMobivisor.md`). This hard crash during the compilation step was absolutely silently destroying the ReadTheDocs build pipeline! Pinning to Pygments 2.18.0 solves this issue and allows ReadTheDocs to finally spit out the compiled site!