### PR TITLE
fix(docs): add missing newline to requirements.txt for Pygments

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,5 @@ mkdocs-material==9.6.22  # Material Design theme for MkDocs
 mkdocs-material-extensions==1.3.1  # Extension pack for MkDocs Material
 pymdown-extensions==10.16.1  # Extensions for Python Markdown
 markdown==3.9  # Python implementation of Markdown
-mkdocs-minify-plugin==0.8.0  # Minifies HTML/JS/CSS for MkDocsPygments==2.18.0
+mkdocs-minify-plugin==0.8.0  # Minifies HTML/JS/CSS for MkDocs
+Pygments==2.18.0


### PR DESCRIPTION
Fix missing newline that caused the Pygments 2.18.0 pin to be ignored, leading to a build crash on Python 3.12 with html.escape AttributeError in MkDocs.