### PR TITLE
feat:prepare Android POS enrollment foundation

### DIFF
--- a/backend/src/homepot/agent/agent-config.json
+++ b/backend/src/homepot/agent/agent-config.json
@@ -1,8 +1,11 @@
 {
   "backend_url": "http://localhost:8000",
-  "device_id": "physical-pos-001",
+  "device_id": "android-pos-001",
   "site_id": "site-1234",
   "api_key": "replace-with-provisioned-secret",
+  "device_name": "Android POS 1",
+  "device_type": "pos_terminal",
+  "os_details": "Android 13",
   "heartbeat_interval_seconds": 30,
   "telemetry_interval_seconds": 30,
   "retry_flush_interval_seconds": 60,

--- a/backend/src/homepot/agent/real_device_agent.py
+++ b/backend/src/homepot/agent/real_device_agent.py
@@ -30,7 +30,7 @@ def load_agent_config() -> Dict[str, Any]:
     with config_path.open("r", encoding="utf-8") as f:
         data = cast(Dict[str, Any], json.load(f))
 
-    required = ["backend_url", "device_id", "site_id"]
+    required = ["backend_url", "device_id", "api_key", "site_id"]
     missing = [field for field in required if not data.get(field)]
     if missing:
         raise ValueError(f"Missing required config fields: {', '.join(missing)}")
@@ -44,12 +44,23 @@ def load_agent_config() -> Dict[str, Any]:
     return data
 
 
+def get_auth_headers(config: Dict[str, Any]) -> Dict[str, str]:
+    """Build the device credential headers required by agent endpoints."""
+    return {
+        "X-Device-ID": str(config["device_id"]),
+        "X-API-Key": str(config["api_key"]),
+    }
+
+
 async def post_json(
-    client: httpx.AsyncClient, url: str, payload: Dict[str, Any]
+    client: httpx.AsyncClient,
+    url: str,
+    payload: Dict[str, Any],
+    headers: Dict[str, str],
 ) -> bool:
     """Send JSON payload to backend and return True on HTTP success."""
     try:
-        response = await client.post(url, json=payload, timeout=10.0)
+        response = await client.post(url, json=payload, headers=headers, timeout=10.0)
         response.raise_for_status()
         return True
     except Exception as e:
@@ -66,12 +77,12 @@ async def send_registration(
     try:
         # Payload sent to POST /api/v1/agent/device-dna
         # {
-        #   "device_id": "physical-pos-001",
+        #   "device_id": "android-pos-001",
         #   "site_id": "site-1234",
         #   "device_name": "Front POS",
-        #   "device_type": "physical_terminal",
+        #   "device_type": "pos_terminal",
         #   "mac_address": "00:11:22:33:44:55",
-        #   "os_details": "Windows 11",
+        #   "os_details": "Android 13",
         #   "local_ip": "192.168.1.20",
         #   "wan_ip": "203.0.113.10"
         # }
@@ -79,14 +90,14 @@ async def send_registration(
             "device_id": config["device_id"],
             "site_id": config["site_id"],
             "device_name": config.get("device_name"),
-            "device_type": config.get("device_type", "physical_terminal"),
+            "device_type": config.get("device_type", "pos_terminal"),
             "mac_address": get_mac_address(),
             "os_details": config.get("os_details"),
             "local_ip": get_local_ip(),
             "wan_ip": get_wan_ip(),
         }
         register_url = f"{config['backend_url'].rstrip('/')}/api/v1/agent/device-dna"
-        if not await post_json(client, register_url, payload):
+        if not await post_json(client, register_url, payload, get_auth_headers(config)):
             retry_queue.enqueue({"url": register_url, "payload": payload})
     except Exception as e:
         logger.error("Registration payload build/send failed: %s", e, exc_info=True)
@@ -105,7 +116,7 @@ async def heartbeat_loop(
         try:
             # Payload sent to POST /api/v1/agent/heartbeat
             # {
-            #   "device_id": "physical-pos-001",
+            #   "device_id": "android-pos-001",
             #   "site_id": "site-1234",
             #   "status": "ONLINE",
             #   "timestamp": "2026-04-13T12:00:00Z"
@@ -115,7 +126,7 @@ async def heartbeat_loop(
                 site_id=config["site_id"],
                 status="ONLINE",
             )
-            ok = await post_json(client, url, payload)
+            ok = await post_json(client, url, payload, get_auth_headers(config))
             if ok:
                 if ipc_server is not None:
                     update_local_agent_state(
@@ -148,7 +159,7 @@ async def telemetry_loop(
         try:
             # Payload sent to POST /api/v1/agent/telemetry
             # {
-            #   "device_id": "physical-pos-001",
+            #   "device_id": "android-pos-001",
             #   "site_id": "site-1234",
             #   "cpu_usage": 20.1,
             #   "memory_usage": 55.4,
@@ -157,7 +168,7 @@ async def telemetry_loop(
             # }
             payload = build_telemetry_payload(config["device_id"])
             payload["site_id"] = config["site_id"]
-            ok = await post_json(client, url, payload)
+            ok = await post_json(client, url, payload, get_auth_headers(config))
             if ok and ipc_server is not None:
                 update_local_agent_state(
                     ipc_server.config.app,  # type: ignore[arg-type]
@@ -182,7 +193,12 @@ async def retry_flush_loop(
             queued_items = retry_queue.dequeue_all()
             pending: list[dict] = []
             for item in queued_items:
-                ok = await post_json(client, item["url"], item["payload"])
+                ok = await post_json(
+                    client,
+                    item["url"],
+                    item["payload"],
+                    get_auth_headers(config),
+                )
                 if not ok:
                     pending.append(item)
             if pending:

--- a/backend/src/homepot/app/api/API_v1/Endpoints/AgentHeartbeatEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/AgentHeartbeatEndpoint.py
@@ -6,9 +6,11 @@ from typing import Any, Dict
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
+from homepot.app.auth_utils import get_current_device
 from homepot.app.schemas.agent import AgentHeartbeatRequest
 from homepot.app.services.agent_service import AgentService
 from homepot.database import get_db
+from homepot.models import Device
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -16,11 +18,18 @@ router = APIRouter()
 
 @router.post("/heartbeat", tags=["Agent"])
 def update_heartbeat(
-    payload: AgentHeartbeatRequest, db: Session = Depends(get_db)
+    payload: AgentHeartbeatRequest,
+    current_device: Device = Depends(get_current_device),
+    db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
     """Update heartbeat timestamp for a registered device."""
     logger.info("Heartbeat request received for device_id=%s", payload.device_id)
     try:
+        if current_device.device_id != payload.device_id:
+            raise HTTPException(
+                status_code=403,
+                detail="Authenticated device does not match payload device_id",
+            )
         service = AgentService(db)
         result = service.update_heartbeat(payload)
         return {

--- a/backend/src/homepot/app/api/API_v1/Endpoints/AgentRegisterEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/AgentRegisterEndpoint.py
@@ -6,9 +6,11 @@ from typing import Any, Dict
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
+from homepot.app.auth_utils import get_current_device
 from homepot.app.schemas.agent import AgentRegisterRequest
 from homepot.app.services.agent_service import AgentService
 from homepot.database import get_db
+from homepot.models import Device
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -16,11 +18,18 @@ router = APIRouter()
 
 @router.post("/device-dna", tags=["Agent"])
 def register_and_update_device_dna(
-    payload: AgentRegisterRequest, db: Session = Depends(get_db)
+    payload: AgentRegisterRequest,
+    current_device: Device = Depends(get_current_device),
+    db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
-    """Register a device or update its DNA payload."""
+    """Update the authenticated device's DNA payload."""
     logger.info("Agent register request received for device_id=%s", payload.device_id)
     try:
+        if current_device.device_id != payload.device_id:
+            raise HTTPException(
+                status_code=403,
+                detail="Authenticated device does not match payload device_id",
+            )
         service = AgentService(db)
         result = service.update_device(payload)
         return {

--- a/backend/src/homepot/app/api/API_v1/Endpoints/AgentTelemetryEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/AgentTelemetryEndpoint.py
@@ -6,9 +6,11 @@ from typing import Any, Dict, List, Union
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
+from homepot.app.auth_utils import get_current_device
 from homepot.app.schemas.agent import AgentTelemetryRequest
 from homepot.app.services.agent_service import AgentService
 from homepot.database import get_db
+from homepot.models import Device
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -17,10 +19,14 @@ router = APIRouter()
 @router.post("/telemetry", tags=["Agent"])
 def save_telemetry(
     payload: Union[AgentTelemetryRequest, List[AgentTelemetryRequest]],
+    current_device: Device = Depends(get_current_device),
     db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
     """Save one or many telemetry records for a device."""
     try:
+        if isinstance(payload, list) and not payload:
+            raise ValueError("Telemetry payload list cannot be empty")
+
         telemetry_count = len(payload) if isinstance(payload, list) else 1
         device_ref = (
             payload[0].device_id if isinstance(payload, list) else payload.device_id
@@ -30,6 +36,16 @@ def save_telemetry(
             device_ref,
             telemetry_count,
         )
+        device_ids = (
+            {item.device_id for item in payload}
+            if isinstance(payload, list)
+            else {payload.device_id}
+        )
+        if device_ids != {current_device.device_id}:
+            raise HTTPException(
+                status_code=403,
+                detail="Authenticated device does not match payload device_id",
+            )
 
         service = AgentService(db)
         result = service.save_telemetry(payload)

--- a/backend/src/homepot/app/schemas/agent.py
+++ b/backend/src/homepot/app/schemas/agent.py
@@ -30,7 +30,7 @@ class AgentRegisterRequest(BaseModel):
         None, description="Human-friendly device name for new records"
     )
     device_type: str = Field(
-        default="physical_terminal", description="Device type for new records"
+        default="pos_terminal", description="Device type for new records"
     )
 
     model_config = ConfigDict(
@@ -43,7 +43,7 @@ class AgentRegisterRequest(BaseModel):
                 "wan_ip": "203.0.113.10",
                 "site_id": "site-001",
                 "device_name": "Front Desk POS 1",
-                "device_type": "physical_terminal",
+                "device_type": "pos_terminal",
             }
         }
     )

--- a/backend/src/homepot/app/schemas/provision.py
+++ b/backend/src/homepot/app/schemas/provision.py
@@ -20,7 +20,10 @@ class DeviceProvisionRequest(BaseModel):
         None, description="Optional display name for the new device"
     )
     device_type: str = Field(
-        default="physical_terminal", description="Device type for provisioning"
+        default="pos_terminal", description="Device type for provisioning"
+    )
+    os_details: Optional[str] = Field(
+        None, description="Operating system name and version reported by the device"
     )
 
     model_config = ConfigDict(
@@ -30,7 +33,8 @@ class DeviceProvisionRequest(BaseModel):
                 "site_id": "site-001",
                 "user_identity": "agent.setup@dealdio.com",
                 "device_name": "Kitchen POS A",
-                "device_type": "physical_terminal",
+                "device_type": "pos_terminal",
+                "os_details": "Android 13",
             }
         }
     )
@@ -50,7 +54,7 @@ class DeviceProvisionResponse(BaseModel):
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
-                "device_id": "physical-terminal-a1b2c3d4",
+                "device_id": "pos-terminal-a1b2c3d4",
                 "api_key": "mM2....",
                 "secret_key": "mM2....",
                 "device_token": "XQw2....",

--- a/backend/src/homepot/app/services/agent_service.py
+++ b/backend/src/homepot/app/services/agent_service.py
@@ -185,7 +185,7 @@ class AgentService:
                 device_type=payload.device_type,
                 site_pk=int(site.id),
                 mac_address=None,
-                os_details=None,
+                os_details=payload.os_details,
                 local_ip=None,
                 wan_ip=None,
             )
@@ -202,6 +202,7 @@ class AgentService:
                     "provisioning_method": (
                         "sso" if payload.sso_token else "manual_identity"
                     ),
+                    "os": payload.os_details,
                     "device_token": device_token,
                 }
             )

--- a/backend/tests/test_agent_api.py
+++ b/backend/tests/test_agent_api.py
@@ -9,6 +9,7 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from homepot.app.auth_utils import hash_password
 from homepot.config import reload_settings
 import homepot.database
 from homepot.models import Base, Device, Site
@@ -64,8 +65,12 @@ def _seed_site(site_code: str = "site-agent-1") -> Site:
         db.close()
 
 
-def test_device_dna_requires_site_for_new_device(client: TestClient):
-    """Creating a new device without site_id should fail validation."""
+def _device_headers(device_id: str, api_key: str) -> dict[str, str]:
+    return {"X-Device-ID": device_id, "X-API-Key": api_key}
+
+
+def test_device_dna_requires_device_credentials(client: TestClient):
+    """Device DNA updates require credentials issued during provisioning."""
     response = client.post(
         "/api/v1/agent/device-dna",
         json={
@@ -77,13 +82,28 @@ def test_device_dna_requires_site_for_new_device(client: TestClient):
         },
     )
 
-    assert response.status_code == 400
-    assert "site_id" in response.json()["detail"]
+    assert response.status_code == 401
 
 
-def test_device_dna_creates_new_device(client: TestClient):
-    """Device DNA endpoint should create new records when device does not exist."""
-    _seed_site("site-agent-1")
+def test_device_dna_updates_provisioned_device(client: TestClient):
+    """Device DNA endpoint should update a device created during provisioning."""
+    site = _seed_site("site-agent-1")
+    api_key = "test-api-key"
+    db = homepot.database.SessionLocal()
+    try:
+        db.add(
+            Device(
+                device_id="agent-device-1",
+                name="Front POS",
+                device_type="pos_terminal",
+                site_id=int(site.id),
+                api_key_hash=hash_password(api_key),
+                is_active=True,
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
 
     response = client.post(
         "/api/v1/agent/device-dna",
@@ -91,19 +111,20 @@ def test_device_dna_creates_new_device(client: TestClient):
             "device_id": "agent-device-1",
             "site_id": "site-agent-1",
             "device_name": "Front POS",
-            "device_type": "physical_terminal",
+            "device_type": "pos_terminal",
             "mac_address": "00:11:22:33:44:55",
             "os_details": "Windows 11",
             "local_ip": "192.168.1.20",
             "wan_ip": "203.0.113.10",
         },
+        headers=_device_headers("agent-device-1", api_key),
     )
 
     assert response.status_code == 200
     payload = response.json()
     assert payload["status"] == "success"
     assert payload["data"]["device_id"] == "agent-device-1"
-    assert payload["data"]["created"] is True
+    assert payload["data"]["created"] is False
 
 
 def test_device_dna_updates_existing_device(client: TestClient):
@@ -115,8 +136,9 @@ def test_device_dna_updates_existing_device(client: TestClient):
         device = Device(
             device_id="agent-device-2",
             name="Agent Device",
-            device_type="physical_terminal",
+            device_type="pos_terminal",
             site_id=int(site.id),
+            api_key_hash=hash_password("test-api-key"),
             is_active=True,
         )
         db.add(device)
@@ -133,6 +155,7 @@ def test_device_dna_updates_existing_device(client: TestClient):
             "local_ip": "10.0.0.20",
             "wan_ip": "198.51.100.20",
         },
+        headers=_device_headers("agent-device-2", "test-api-key"),
     )
 
     assert response.status_code == 200

--- a/backend/tests/test_agent_endpoints.py
+++ b/backend/tests/test_agent_endpoints.py
@@ -10,6 +10,7 @@ import pytest
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker
 
+from homepot.app.auth_utils import hash_password
 from homepot.app.models.AnalyticsModel import DeviceMetrics
 from homepot.config import reload_settings
 import homepot.database
@@ -66,56 +67,65 @@ def _create_site(site_code: str = "site-agent-1") -> Site:
         db.close()
 
 
-def _create_device(device_id: str, site_pk: int) -> None:
+def _create_device(device_id: str, site_pk: int, api_key: str = "test-api-key") -> str:
     """Create a device row linked to a site primary key."""
     db = homepot.database.SessionLocal()
     try:
         device = Device(
             device_id=device_id,
             name="Agent Device",
-            device_type="physical_terminal",
+            device_type="pos_terminal",
             site_id=site_pk,
+            api_key_hash=hash_password(api_key),
             is_active=True,
         )
         db.add(device)
         db.commit()
     finally:
         db.close()
+    return api_key
 
 
-def test_register_creates_device(client: TestClient):
-    """POST /api/v1/agent/device-dna should create a device if not present."""
-    _create_site("site-agent-1")
+def _device_headers(device_id: str, api_key: str) -> dict[str, str]:
+    return {"X-Device-ID": device_id, "X-API-Key": api_key}
+
+
+def test_register_updates_authenticated_device(client: TestClient):
+    """POST /api/v1/agent/device-dna should update the provisioned device."""
+    site = _create_site("site-agent-1")
+    api_key = _create_device("agent-device-1", int(site.id))
     response = client.post(
         "/api/v1/agent/device-dna",
         json={
             "device_id": "agent-device-1",
             "site_id": "site-agent-1",
             "device_name": "Front POS",
-            "device_type": "physical_terminal",
+            "device_type": "pos_terminal",
             "mac_address": "00:11:22:33:44:55",
             "os_details": "Windows 11",
             "local_ip": "192.168.1.20",
             "wan_ip": "203.0.113.10",
         },
+        headers=_device_headers("agent-device-1", api_key),
     )
 
     assert response.status_code == 200
     payload = response.json()
     assert payload["status"] == "success"
     assert payload["data"]["device_id"] == "agent-device-1"
-    assert payload["data"]["created"] is True
+    assert payload["data"]["created"] is False
 
 
 def test_heartbeat_updates_last_heartbeat(client: TestClient):
     """POST /api/v1/agent/heartbeat should update last heartbeat timestamp."""
     site = _create_site("site-heartbeat")
-    _create_device("heartbeat-device-1", int(site.id))
+    api_key = _create_device("heartbeat-device-1", int(site.id))
 
     now = datetime.now(timezone.utc).isoformat()
     response = client.post(
         "/api/v1/agent/heartbeat",
         json={"device_id": "heartbeat-device-1", "timestamp": now},
+        headers=_device_headers("heartbeat-device-1", api_key),
     )
 
     assert response.status_code == 200
@@ -128,7 +138,7 @@ def test_heartbeat_updates_last_heartbeat(client: TestClient):
 def test_telemetry_single_is_saved(client: TestClient):
     """POST /api/v1/agent/telemetry should persist a single telemetry record."""
     site = _create_site("site-telemetry-single")
-    _create_device("telemetry-device-1", int(site.id))
+    api_key = _create_device("telemetry-device-1", int(site.id))
 
     response = client.post(
         "/api/v1/agent/telemetry",
@@ -139,6 +149,7 @@ def test_telemetry_single_is_saved(client: TestClient):
             "disk_usage": 44.8,
             "timestamp": datetime.now(timezone.utc).isoformat(),
         },
+        headers=_device_headers("telemetry-device-1", api_key),
     )
 
     assert response.status_code == 200
@@ -155,7 +166,7 @@ def test_telemetry_single_is_saved(client: TestClient):
 def test_telemetry_bulk_is_saved(client: TestClient):
     """POST /api/v1/agent/telemetry should persist multiple telemetry records."""
     site = _create_site("site-telemetry-bulk")
-    _create_device("telemetry-device-2", int(site.id))
+    api_key = _create_device("telemetry-device-2", int(site.id))
 
     now = datetime.now(timezone.utc)
     response = client.post(
@@ -176,6 +187,7 @@ def test_telemetry_bulk_is_saved(client: TestClient):
                 "timestamp": (now + timedelta(seconds=30)).isoformat(),
             },
         ],
+        headers=_device_headers("telemetry-device-2", api_key),
     )
 
     assert response.status_code == 200
@@ -192,7 +204,8 @@ def test_provision_returns_credentials_and_hashes_key(client: TestClient):
             "site_id": "site-provision",
             "user_identity": "setup.user@dealdio.com",
             "device_name": "Provisioned POS",
-            "device_type": "physical_terminal",
+            "device_type": "pos_terminal",
+            "os_details": "Android 13",
         },
     )
 
@@ -212,6 +225,8 @@ def test_provision_returns_credentials_and_hashes_key(client: TestClient):
         )
         assert device is not None
         assert device.api_key_hash is not None
+        assert device.device_type == "pos_terminal"
+        assert device.os_details == "Android 13"
     finally:
         db.close()
 
@@ -219,15 +234,38 @@ def test_provision_returns_credentials_and_hashes_key(client: TestClient):
 def test_status_returns_online_when_recent_heartbeat_exists(client: TestClient):
     """GET /api/v1/agent/{device_id}/status should return ONLINE for fresh heartbeat."""
     site = _create_site("site-status")
-    _create_device("status-device-1", int(site.id))
+    api_key = _create_device("status-device-1", int(site.id))
 
     recent = datetime.now(timezone.utc).isoformat()
     hb_response = client.post(
         "/api/v1/agent/heartbeat",
         json={"device_id": "status-device-1", "timestamp": recent},
+        headers=_device_headers("status-device-1", api_key),
     )
     assert hb_response.status_code == 200
 
     status_response = client.get("/api/v1/agent/status-device-1/status")
     assert status_response.status_code == 200
     assert status_response.json()["data"]["status"] == "ONLINE"
+
+
+def test_agent_telemetry_requires_matching_device_credentials(client: TestClient):
+    """Agent telemetry must reject missing or mismatched device credentials."""
+    site = _create_site("site-agent-auth")
+    api_key = _create_device("authenticated-device", int(site.id))
+    payload = {
+        "device_id": "authenticated-device",
+        "cpu_usage": 20.0,
+        "memory_usage": 30.0,
+        "disk_usage": 40.0,
+    }
+
+    missing_credentials = client.post("/api/v1/agent/telemetry", json=payload)
+    assert missing_credentials.status_code == 401
+
+    mismatched_device = client.post(
+        "/api/v1/agent/telemetry",
+        json=payload,
+        headers=_device_headers("other-device", api_key),
+    )
+    assert mismatched_device.status_code == 401

--- a/backend/utils/seed_data.py
+++ b/backend/utils/seed_data.py
@@ -495,6 +495,23 @@ async def init_database():
             "version": "1.0.0",
         },
     )
+    await get_or_create_device(
+        "site1-android-pos-06",
+        "Android POS 1-6",
+        DeviceType.POS_TERMINAL,
+        site1.id,
+        "10.1.6.10",
+        {
+            "os": "android",
+            "device_model": "Android POS Terminal",
+            "kiosk_mode": True,
+            "push_platform": "fcm_android",
+            "agent_version": "1.0.0-sim",
+            "version": "1.0.0",
+        },
+        is_monitored=True,
+        enrollment_method="self-enrolled",
+    )
 
     # Site 2 Devices
     print("--- Site 2 Devices ---")

--- a/user_app/.env.example
+++ b/user_app/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8000/api/v1

--- a/user_app/src/config/api.ts
+++ b/user_app/src/config/api.ts
@@ -1,0 +1,5 @@
+const configuredApiBaseUrl = import.meta.env.VITE_API_BASE_URL
+
+export const apiBaseUrl = (
+  configuredApiBaseUrl || 'http://localhost:8000/api/v1'
+).replace(/\/$/, '')

--- a/user_app/src/views/SetupWizard.tsx
+++ b/user_app/src/views/SetupWizard.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useApp } from '../context/AppContext'
+import { apiBaseUrl } from '../config/api'
 
 const STEPS = ['Device Setup', 'SSO Login', 'Complete']
 
@@ -178,21 +179,21 @@ function Step3({ siteId, deviceName, deviceType, deviceOs, onBack, onComplete }:
   onComplete: () => void
 }) {
   const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
 
   async function handleComplete() {
     setLoading(true)
+    setError('')
     try {
-      const deviceId = 'dev-' + Date.now()
       const reqBody = {
-        device_id: deviceId,
         site_id: siteId,
-        name: deviceName || 'My Device',
+        user_identity: 'user-app-setup',
+        device_name: deviceName || 'My Device',
         device_type: deviceType,
-        os_details: deviceOs,
-        enrollment_method: 'self-enrolled'
+        os_details: deviceOs
       }
 
-      const response = await fetch(`http://localhost:8000/api/v1/devices/sites/${siteId}/devices`, {
+      const response = await fetch(`${apiBaseUrl}/devices/provision`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
@@ -201,32 +202,30 @@ function Step3({ siteId, deviceName, deviceType, deviceOs, onBack, onComplete }:
       })
 
       if (!response.ok) {
-        throw new Error('Failed to register device via API')
+        throw new Error('Provisioning failed. Check the site ID and backend connection.')
       }
 
       const data = await response.json()
+      const provisionedDevice = data.data
+      if (!provisionedDevice?.device_id || !provisionedDevice?.api_key) {
+        throw new Error('Provisioning response did not include device credentials.')
+      }
       
-      localStorage.setItem('homepot_token', data.device_id || deviceId)
+      localStorage.setItem('homepot_token', provisionedDevice.device_id)
+      localStorage.setItem('homepot_device_id', provisionedDevice.device_id)
       localStorage.setItem('homepot_site_id', siteId)
       localStorage.setItem('homepot_device_name', deviceName || 'My Device')
       localStorage.setItem('homepot_device_type', deviceType)
       localStorage.setItem('homepot_device_os', deviceOs)
       localStorage.setItem('homepot_enrollment_method', 'self-enrolled')
+      sessionStorage.setItem('homepot_api_key', provisionedDevice.api_key)
       
       setLoading(false)
       onComplete()
     } catch (error) {
       console.error(error)
-      // Fallback for UI demonstration 
-      localStorage.setItem('homepot_token', 'mock-token-' + Date.now())
-      localStorage.setItem('homepot_site_id', siteId)
-      localStorage.setItem('homepot_device_name', deviceName || 'My Device')
-      localStorage.setItem('homepot_device_type', deviceType)
-      localStorage.setItem('homepot_device_os', deviceOs)
-      localStorage.setItem('homepot_enrollment_method', 'self-enrolled')
-      
+      setError(error instanceof Error ? error.message : 'Provisioning failed.')
       setLoading(false)
-      onComplete()
     }
   }
 
@@ -283,6 +282,7 @@ function Step3({ siteId, deviceName, deviceType, deviceOs, onBack, onComplete }:
           )}
         </button>
       </div>
+      {error && <p className="w-full text-left text-xs text-red-400">{error}</p>}
     </div>
   )
 }
@@ -297,10 +297,10 @@ export default function SetupWizard() {
   // Auto-detect Operating System for default selection
   const detectOS = () => {
     const ua = navigator.userAgent.toLowerCase()
+    if (ua.includes('android')) return 'android'
     if (ua.includes('win')) return 'windows'
     if (ua.includes('mac')) return 'mac'
     if (ua.includes('linux')) return 'linux'
-    if (ua.includes('android')) return 'android'
     if (ua.includes('iphone') || ua.includes('ipad')) return 'ios'
     return 'web'
   }


### PR DESCRIPTION
## Summary

- prepare the device enrollment foundation for an Android POS-style User App
- add a seeded Android POS device fixture for local testing
- require provisioned device credentials for heartbeat, telemetry, and device DNA calls
- update the User App setup flow to call the backend provisioning endpoint instead of relying on a mock success path

## Notes

This PR intentionally keeps the scope Linux/server-oriented. Windows installer, validation, and documentation work has been left out so the emulator foundation does not introduce a new Windows support maintenance commitment.

## Validation

- Focused backend agent tests passed locally: `10 passed`
- Backend quality checks were run before the Windows-specific work was removed: Black, isort, flake8, and mypy passed

Full project validation should still be confirmed in GitHub Actions.
