### PR TITLE
feat: Implement Real Device & Peripheral Discovery

### DIFF
--- a/backend/src/homepot/agent/utils/device_dna.py
+++ b/backend/src/homepot/agent/utils/device_dna.py
@@ -8,6 +8,8 @@ import uuid
 import httpx
 import psutil
 
+from homepot.agent.utils.real_device_discovery import get_connected_peripherals
+
 # Public IP lookup is best-effort metadata collection and depends on external services.
 PUBLIC_IP_SERVICES = (
     "https://api.ipify.org",
@@ -64,7 +66,7 @@ def get_mac_address() -> Optional[str]:
         return None
 
 
-def collect_device_dna(payload: Any = None) -> Dict[str, Optional[str]]:
+def collect_device_dna(payload: Any = None) -> Dict[str, Any]:
     """Collect device identification data and return it as a dictionary."""
     _ = payload  # Backward-compatible argument for existing call-sites/tests.
     return {
@@ -73,4 +75,5 @@ def collect_device_dna(payload: Any = None) -> Dict[str, Optional[str]]:
         "mac_address": get_mac_address(),
         "os_name": platform.system(),
         "os_version": platform.release(),
+        "peripherals": get_connected_peripherals(),
     }

--- a/backend/src/homepot/agent/utils/real_device_discovery.py
+++ b/backend/src/homepot/agent/utils/real_device_discovery.py
@@ -1,13 +1,13 @@
 """Real device and peripheral discovery utility for the HomePot Agent.
 
-This module discovers connected physical peripherals (printers, scanners, 
-card readers, etc.) via OS-level commands. It also includes an emulator 
+This module discovers connected physical peripherals (printers, scanners,
+card readers, etc.) via OS-level commands. It also includes an emulator
 toggle to generate realistic mock payloads for fleet load testing.
 """
 
 import os
 import platform
-import subprocess
+import subprocess  # noqa: S404
 from typing import Any, Dict, List
 
 # A flag we can set during simulated runs to bypass actual OS checks
@@ -17,7 +17,7 @@ USE_HARDWARE_EMULATOR = os.getenv("USE_HARDWARE_EMULATOR", "False").lower() == "
 
 def get_connected_peripherals() -> Dict[str, List[Dict[str, Any]]]:
     """Retrieve all connected peripherals, either real or emulated.
-    
+
     Returns:
         A dictionary containing lists of detected hardware categories.
     """
@@ -47,7 +47,7 @@ def _discover_printers() -> List[Dict[str, Any]]:
 def _get_windows_printers() -> List[Dict[str, Any]]:
     """Collect printers from Windows using PowerShell Get-Printer."""
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # noqa: S603, S607
             [
                 "powershell",
                 "-Command",
@@ -60,8 +60,8 @@ def _get_windows_printers() -> List[Dict[str, Any]]:
         if result.returncode != 0 or not result.stdout.strip():
             return []
 
-        # MVP: For now we just return the raw JSON string wrapper. 
-        # In a production iteration, we would `json.loads(result.stdout)` 
+        # MVP: For now we just return the raw JSON string wrapper.
+        # In a production iteration, we would `json.loads(result.stdout)`
         # and normalize the keys to match the expected schema.
         return [{"raw_output": result.stdout.strip(), "source": "windows_powershell"}]
     except Exception as exc:
@@ -71,7 +71,7 @@ def _get_windows_printers() -> List[Dict[str, Any]]:
 def _get_cups_printers() -> List[Dict[str, Any]]:
     """Collect printers from Linux/macOS using CUPS lpstat."""
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # noqa: S603, S607
             ["lpstat", "-p"],
             capture_output=True,
             text=True,

--- a/backend/src/homepot/agent/utils/real_device_discovery.py
+++ b/backend/src/homepot/agent/utils/real_device_discovery.py
@@ -1,0 +1,129 @@
+"""Real device and peripheral discovery utility for the HomePot Agent.
+
+This module discovers connected physical peripherals (printers, scanners, 
+card readers, etc.) via OS-level commands. It also includes an emulator 
+toggle to generate realistic mock payloads for fleet load testing.
+"""
+
+import os
+import platform
+import subprocess
+from typing import Any, Dict, List
+
+# A flag we can set during simulated runs to bypass actual OS checks
+# and instead generate massive randomized loads for testing API/DB throughput.
+USE_HARDWARE_EMULATOR = os.getenv("USE_HARDWARE_EMULATOR", "False").lower() == "true"
+
+
+def get_connected_peripherals() -> Dict[str, List[Dict[str, Any]]]:
+    """Retrieve all connected peripherals, either real or emulated.
+    
+    Returns:
+        A dictionary containing lists of detected hardware categories.
+    """
+    if USE_HARDWARE_EMULATOR:
+        return _get_emulated_peripherals()
+
+    return {
+        "printers": _discover_printers(),
+        "scanners": [],  # Placeholder for future scanner integration
+        "card_readers": [],  # Placeholder for future card reader integration
+    }
+
+
+def _discover_printers() -> List[Dict[str, Any]]:
+    """Discover real physical printers connected to the local OS."""
+    os_name = platform.system().lower()
+
+    if os_name == "windows":
+        return _get_windows_printers()
+
+    if os_name in ("linux", "darwin"):
+        return _get_cups_printers()
+
+    return []
+
+
+def _get_windows_printers() -> List[Dict[str, Any]]:
+    """Collect printers from Windows using PowerShell Get-Printer."""
+    try:
+        result = subprocess.run(
+            [
+                "powershell",
+                "-Command",
+                "Get-Printer | Select-Object Name,DriverName,PortName,PrinterStatus | ConvertTo-Json",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return []
+
+        # MVP: For now we just return the raw JSON string wrapper. 
+        # In a production iteration, we would `json.loads(result.stdout)` 
+        # and normalize the keys to match the expected schema.
+        return [{"raw_output": result.stdout.strip(), "source": "windows_powershell"}]
+    except Exception as exc:
+        return [{"error": str(exc)}]
+
+
+def _get_cups_printers() -> List[Dict[str, Any]]:
+    """Collect printers from Linux/macOS using CUPS lpstat."""
+    try:
+        result = subprocess.run(
+            ["lpstat", "-p"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return []
+
+        printers = []
+        for line in result.stdout.splitlines():
+            if line.startswith("printer "):
+                parts = line.split()
+                if len(parts) > 1:
+                    name = parts[1]
+                    status = "disabled" if "disabled" in line.lower() else "online"
+                    printers.append(
+                        {
+                            "name": name,
+                            "type": "printer",
+                            "status": status,
+                            "connection_type": "CUPS",
+                            "is_default": False,
+                            "source": "cups_lpstat",
+                        }
+                    )
+        return printers
+    except Exception as exc:
+        return [{"error": str(exc)}]
+
+
+def _get_emulated_peripherals() -> Dict[str, List[Dict[str, Any]]]:
+    """Return realistic mocked peripheral data for fleet simulation loads."""
+    return {
+        "printers": [
+            {
+                "name": "EPSON TM-T88VI (EMULATED)",
+                "manufacturer": "Epson",
+                "model": "TM-T88VI",
+                "connection_type": "USB",
+                "driver_name": "EPSON Receipt Printer",
+                "port": "USB001",
+                "status": "online",
+                "is_default": True,
+            }
+        ],
+        "scanners": [
+            {
+                "name": "Zebra DS2200 (EMULATED)",
+                "type": "barcode_scanner",
+                "connection_type": "USB",
+                "status": "online",
+            }
+        ],
+        "card_readers": [],
+    }

--- a/backend/src/homepot/app/repositories/agent_repository.py
+++ b/backend/src/homepot/app/repositories/agent_repository.py
@@ -64,6 +64,7 @@ class AgentRepository:
         os_details: Optional[str],
         local_ip: Optional[str],
         wan_ip: Optional[str],
+        peripherals: Optional[dict] = None,
     ) -> Device:
         """Update device DNA fields during registration."""
         device_obj = cast(Any, device)
@@ -71,6 +72,8 @@ class AgentRepository:
         device_obj.os_details = os_details
         device_obj.local_ip = local_ip
         device_obj.wan_ip = wan_ip
+        if peripherals is not None:
+            device_obj.peripherals = peripherals
         self.db.add(device)
         self.db.commit()
         self.db.refresh(device)

--- a/backend/src/homepot/app/schemas/agent.py
+++ b/backend/src/homepot/app/schemas/agent.py
@@ -23,6 +23,9 @@ class AgentRegisterRequest(BaseModel):
     )
     local_ip: Optional[str] = Field(None, description="Local network IP address")
     wan_ip: Optional[str] = Field(None, description="Public/WAN IP address")
+    peripherals: Optional[dict] = Field(
+        None, description="Detailed dictionary of attached peripherals like printers"
+    )
     site_id: Optional[str] = Field(
         None, description="Business site ID (required when creating a new device)"
     )

--- a/backend/src/homepot/app/services/agent_service.py
+++ b/backend/src/homepot/app/services/agent_service.py
@@ -40,6 +40,7 @@ class AgentService:
                     os_details=payload.os_details,
                     local_ip=payload.local_ip,
                     wan_ip=payload.wan_ip,
+                    peripherals=payload.peripherals,
                 )
 
                 return {
@@ -49,6 +50,7 @@ class AgentService:
                     "os_details": updated.os_details,
                     "local_ip": updated.local_ip,
                     "wan_ip": updated.wan_ip,
+                    "peripherals": updated.peripherals,
                     "created": False,
                 }
 

--- a/backend/src/homepot/models.py
+++ b/backend/src/homepot/models.py
@@ -166,6 +166,7 @@ class Device(Base):
     firmware_version = Column(String(50), nullable=True)
     last_seen = Column(DateTime(timezone=True), nullable=True)
     last_heartbeat_at = Column(DateTime(timezone=True), nullable=True)
+    peripherals = Column(JSON, nullable=True)  # Attached device hardware
 
     # Configuration
     config = Column(JSON, nullable=True)  # Device-specific configuration

--- a/backend/tests/test_device_dna.py
+++ b/backend/tests/test_device_dna.py
@@ -84,6 +84,11 @@ def test_collect_device_dna_aggregates_sources(monkeypatch):
     monkeypatch.setattr(device_dna, "get_mac_address", lambda: "aa:bb:cc:dd:ee:ff")
     monkeypatch.setattr(device_dna.platform, "system", lambda: "TestOS")
     monkeypatch.setattr(device_dna.platform, "release", lambda: "2026.1")
+    monkeypatch.setattr(
+        device_dna,
+        "get_connected_peripherals",
+        lambda: {"printers": [], "scanners": [], "card_readers": []},
+    )
 
     assert device_dna.collect_device_dna({"device_id": "x"}) == {
         "local_ip": "10.0.0.5",
@@ -91,4 +96,5 @@ def test_collect_device_dna_aggregates_sources(monkeypatch):
         "mac_address": "aa:bb:cc:dd:ee:ff",
         "os_name": "TestOS",
         "os_version": "2026.1",
+        "peripherals": {"printers": [], "scanners": [], "card_readers": []},
     }

--- a/docs/peripheral-discovery.md
+++ b/docs/peripheral-discovery.md
@@ -1,0 +1,57 @@
+# Peripheral Discovery Architecture
+
+## Overview
+As the HOMEPOT platform expands into hardware integrations beyond the primary compute endpoint, dealing with "dumb" peripherals (devices without an independent Operating System, such as receipt printers, barcode scanners, and RFID card readers) presents a challenge.
+
+These devices cannot run the HomePot Agent, authenticate using SSO/JWT, or connect directly to the internet to report telemetry. 
+
+To bridge this gap, HOMEPOT utilizes a **Gateway Pattern via Peripheral Discovery**.
+
+## The Gateway Pattern
+Instead of attempting direct cloud-to-peripheral communication, the system leverages the primary compute node (the Point-of-Sale terminal, Kiosk, or back-office PC) as a proxy.
+
+1. **Host Registration**: The physical compute node running the GetFudo User App / HomePot Agent registers with the backend normally.
+2. **Peripheral Polling**: Periodically, the Agent scans the host Operating System for attached hardware (USB, COM ports, localized networked devices like CUPS printers).
+3. **Payload Piggybacking**: The detected hardware profiles are packaged into the `peripherals` dictionary and transmitted alongside the Agent's standard Device DNA and telemetry heartbeats.
+4. **Dashboard Representation**: The HOMEPOT backend detects the nested peripheral items and correctly associates them as child components to the parent Host Device within a given Site.
+
+## `real_device_discovery.py`
+The orchestration of this polling logic resides in `backend/src/homepot/agent/utils/real_device_discovery.py`. 
+
+This module adheres to the Open-Closed Principle, serving as a unified entry point to execute OS-specific scripts:
+- **Windows**: Executes `Get-Printer` via PowerShell.
+- **Linux/macOS**: Executes `lpstat -p` via CUPS.
+
+It currently exports a unified dictionary schema:
+```json
+{
+  "printers": [
+    {
+      "name": "EPSON TM-T88VI",
+      "type": "printer",
+      "status": "online",
+      "connection_type": "CUPS",
+      "...": "..."
+    }
+  ],
+  "scanners": [],
+  "card_readers": []
+}
+```
+
+## The Hardware Emulator
+During development, UI creation, or fleet load simulation, acquiring hundreds of physical USB printers is impractical. 
+
+The discovery utility implements a seamless override flag: `USE_HARDWARE_EMULATOR=true`. 
+
+When this environment variable is detected:
+1. All host OS polling (e.g., PowerShell / CUPS) is bypassed.
+2. The agent immediately returns a pre-configured dictionary of "fake" attached hardware (e.g., an "EPSON TM-T88VI (EMULATED)" printer, and a "Zebra DS2200 (EMULATED)" scanner).
+3. The fake payloads flow identically through the network architecture, allowing backend engineers and frontend Dealdio React developers to design their logic securely without needing physical hardware.
+
+## Future Roadmap (Phases)
+Based on R&D integration specifications, peripheral support is rolling out in distinct phases:
+- **Phase 1 - Discovery MVP (Current):** Extend Device DNA to collect and transmit connected peripherals to the backend.
+- **Phase 2 - Dashboard Visibility:** Render the extracted JSON arrays securely under the parent device view on the React dashboard.
+- **Phase 3 - Test Print / Command Execution:** Implement reverse-proxy command handling (e.g., Dashboard -> Agent -> Printer).
+- **Phase 4 - Advanced Health Monitoring:** Monitor specialized edge conditions like "Out of Paper" using customized pycups or pywin32 integration.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -152,6 +152,7 @@ nav:
       - Device Management:
           - Registration: device-registration.md
           - Metrics Collection: device-metrics-collection.md
+          - Peripheral Discovery: peripheral-discovery.md
           - Configuration (MDM): device-configuration-mdm.md
       - Platform Integration:
           - Mobivisor (Android): mobivisor-integration.md


### PR DESCRIPTION
## Description
This PR implements the generic peripheral discovery architecture allowing the HomePot Agent to natively detect attached physical hardware (such as Printers, Scanners, and Card Readers) and nested it within the Device DNA payload.

## Key Changes
1. **`real_device_discovery.py`**: 
   - Uses OS-level commands (e.g., `lpstat` for CUPS on Linux/Mac, `Get-Printer` on Windows) to detect physically connected printers.
   - Designed cleanly using the Open-Closed principle with placeholders for future Barcode Scanners and RFID hardware.
   - Includes a `USE_HARDWARE_EMULATOR=true` flag that bypasses OS checks to output highly realistic mocked configurations (useful for our new Fleet Load Simulator).
2. **`device_dna.py` Update**: 
   - Collects the aggregated peripheral dictionary and ships it inside the `peripherals` key in the standard device telemetry payload.

## Quality
- All `flake8` security checks for `subprocess` calls properly audited and annotated with `noqa: S404, S603, S607`.
- Tested natively and successfully returned the mocked JSON layout used in Phase 1 MVP preparations.
