### PR TITLE
feat: Integrate peripheral discovery into Real Device Agent startup payload

### DIFF
--- a/backend/src/homepot/agent/real_device_agent.py
+++ b/backend/src/homepot/agent/real_device_agent.py
@@ -17,6 +17,7 @@ from homepot.agent.utils.local_ipc import (
     create_local_ipc_app,
     update_local_agent_state,
 )
+from homepot.agent.utils.real_device_discovery import get_connected_peripherals
 from homepot.agent.utils.retry_queue import RetryQueue
 from homepot.agent.utils.telemetry import build_telemetry_payload
 
@@ -95,6 +96,7 @@ async def send_registration(
             "os_details": config.get("os_details"),
             "local_ip": get_local_ip(),
             "wan_ip": get_wan_ip(),
+            "peripherals": get_connected_peripherals(),
         }
         register_url = f"{config['backend_url'].rstrip('/')}/api/v1/agent/device-dna"
         if not await post_json(client, register_url, payload, get_auth_headers(config)):


### PR DESCRIPTION
## Description
This PR bridges the gap between simulation and real-device integration. The `real_device_agent.py` script now actively invokes the hardware discovery scanner and packages the discovered peripherals into its telemetry DNA.

## Key Changes
- Imported `get_connected_peripherals()` natively into `real_device_agent.py`.
- Updated the `send_registration` JSON payload struct to include the  array. 
- Formatted with `isort` and `black`.
- Passed all GitHub CI workflows without error.

**Result:** Any physical PC or Endpoint running this Agent script will automatically dump its array of USB scanners, printers, and emulated mock hardware directly into PostgreSQL during the boot/registration phase.