### PR TITLE
fix: add missing devices.peripherals column via additive migration

### DIFF
--- a/backend/src/homepot/database.py
+++ b/backend/src/homepot/database.py
@@ -71,6 +71,7 @@ def _ensure_device_dna_columns(bind: Any) -> None:
             "last_heartbeat_at": (
                 "ALTER TABLE devices ADD COLUMN last_heartbeat_at DATETIME"
             ),
+            "peripherals": "ALTER TABLE devices ADD COLUMN peripherals JSON",
         }
     elif dialect == "postgresql":
         ddl_map = {
@@ -81,6 +82,7 @@ def _ensure_device_dna_columns(bind: Any) -> None:
                 "ALTER TABLE devices ADD COLUMN last_heartbeat_at "
                 "TIMESTAMP WITH TIME ZONE"
             ),
+            "peripherals": "ALTER TABLE devices ADD COLUMN peripherals JSON",
         }
     else:
         ddl_map = {
@@ -90,6 +92,7 @@ def _ensure_device_dna_columns(bind: Any) -> None:
             "last_heartbeat_at": (
                 "ALTER TABLE devices ADD COLUMN last_heartbeat_at TIMESTAMP"
             ),
+            "peripherals": "ALTER TABLE devices ADD COLUMN peripherals JSON",
         }
 
     for column_name, ddl in ddl_map.items():


### PR DESCRIPTION
The PR solves the issues with:

The Device model 'peripherals' JSON column (attached hardware info) that was never added to ensure_device_dna_columns(), the additive ALTER TABLE helper that patches existing databases with newly added Device fields. This caused every query touching the devices table to fail with:

  UndefinedColumnError: column devices.peripherals does not exist

Discovered while validating scripts/run_fleet_simulation.py end-to-end -
every simulated device metrics submission returned 500. Fixed by adding
'peripherals' to the ddl_map for all three dialect branches (sqlite,
postgresql, and generic), matching the existing pattern for os_details,
local_ip, wan_ip, and last_heartbeat_at.

Verified: column now self-heals on next DatabaseService.initialize() (no
manual migration needed), fleet simulation script now completes
successfully (179 metrics pushed, 0 errors), and full backend suite
(478 tests) still passes against PostgreSQL + TimescaleDB."