### PR TITLE
feat: Separate lifecycle, connectivity, and health state dimensions

### DIFF
--- a/backend/src/homepot/app/api/API_v1/Endpoints/AgentHeartbeatEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/AgentHeartbeatEndpoint.py
@@ -40,6 +40,9 @@ def update_heartbeat(
     except LookupError as e:
         logger.error("Heartbeat failed: %s", e)
         raise HTTPException(status_code=404, detail=str(e))
+    except ValueError as e:
+        logger.error("Heartbeat rejected: %s", e)
+        raise HTTPException(status_code=403, detail=str(e))
     except HTTPException:
         raise
     except Exception as e:

--- a/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
@@ -1,6 +1,7 @@
 """API endpoints for managing Device in the HomePot system."""
 
 import logging
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException
@@ -9,16 +10,34 @@ from sqlalchemy import desc, func, select
 from sqlalchemy.orm import joinedload
 
 from homepot.app.models import AnalyticsModel as analytics_models
+from homepot.app.services.lifecycle_service import LifecycleService
 from homepot.audit import AuditEventType, get_audit_logger
 from homepot.client import HomepotClient
 from homepot.database import get_database_service
-from homepot.models import AuditLog, Device, Job
+from homepot.models import AuditLog, ConnectivityState, Device, HealthState, LifecycleState
 
 client_instance: Optional[HomepotClient] = None
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+_HEARTBEAT_ONLINE_SECONDS = 120
+
+
+def _compute_connectivity(device: Device) -> str:
+    """Return online/offline/unknown based on heartbeat recency."""
+    if not device.last_heartbeat_at:
+        return ConnectivityState.UNKNOWN.value
+    heartbeat = device.last_heartbeat_at
+    if heartbeat.tzinfo is None:
+        heartbeat = heartbeat.replace(tzinfo=timezone.utc)
+    delta = datetime.now(timezone.utc) - heartbeat
+    return (
+        ConnectivityState.ONLINE.value
+        if delta.total_seconds() <= _HEARTBEAT_ONLINE_SECONDS
+        else ConnectivityState.OFFLINE.value
+    )
 
 
 router = APIRouter()
@@ -251,6 +270,9 @@ async def list_device() -> Dict[str, List[Dict]]:
                         "name": device.name,
                         "device_type": device.device_type,
                         "os_details": device.os_details,
+                        "lifecycle_state": device.lifecycle_state,
+                        "connectivity_state": _compute_connectivity(device),
+                        "health_state": device.health_state or HealthState.UNKNOWN.value,
                         "status": device.status,
                         "ip_address": device.ip_address,
                         "is_monitored": device.is_monitored,
@@ -289,6 +311,9 @@ async def get_device(device_id: str) -> Dict[str, Any]:
             "device_id": device.device_id,
             "name": device.name,
             "device_type": device.device_type,
+            "lifecycle_state": device.lifecycle_state,
+            "connectivity_state": _compute_connectivity(device),
+            "health_state": device.health_state or HealthState.UNKNOWN.value,
             "status": device.status,
             "ip_address": device.ip_address or "N/A",
             "os_details": device.os_details
@@ -489,13 +514,15 @@ async def get_devices_by_site(
                 "name": d.name,
                 "device_type": d.device_type,
                 "os_details": d.os_details,
-                "status": d.status,
-                "connectivity": "online" if d.status == "online" else "offline",
+                "lifecycle_state": d.lifecycle_state,
+                "connectivity_state": _compute_connectivity(d),
+                "health_state": d.health_state or HealthState.UNKNOWN.value,
                 "pairing_status": (
                     "unpaired"
-                    if not d.is_active or d.status == "unpaired"
+                    if d.lifecycle_state in (LifecycleState.UNPAIRED.value, LifecycleState.RETIRED.value)
                     else "paired"
                 ),
+                "status": d.status,
                 "ip_address": d.ip_address,
                 "is_monitored": d.is_monitored,
                 "active_alerts": alert_map.get(d.device_id, 0),

--- a/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
@@ -1,7 +1,7 @@
 """API endpoints for managing Device in the HomePot system."""
 
+from datetime import datetime, timezone
 import logging
-from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException
@@ -10,11 +10,17 @@ from sqlalchemy import desc, func, select
 from sqlalchemy.orm import joinedload
 
 from homepot.app.models import AnalyticsModel as analytics_models
-from homepot.app.services.lifecycle_service import LifecycleService
 from homepot.audit import AuditEventType, get_audit_logger
 from homepot.client import HomepotClient
 from homepot.database import get_database_service
-from homepot.models import AuditLog, ConnectivityState, Device, HealthState, LifecycleState
+from homepot.models import (
+    AuditLog,
+    ConnectivityState,
+    Device,
+    HealthState,
+    Job,
+    LifecycleState,
+)
 
 client_instance: Optional[HomepotClient] = None
 
@@ -272,7 +278,8 @@ async def list_device() -> Dict[str, List[Dict]]:
                         "os_details": device.os_details,
                         "lifecycle_state": device.lifecycle_state,
                         "connectivity_state": _compute_connectivity(device),
-                        "health_state": device.health_state or HealthState.UNKNOWN.value,
+                        "health_state": device.health_state
+                        or HealthState.UNKNOWN.value,
                         "status": device.status,
                         "ip_address": device.ip_address,
                         "is_monitored": device.is_monitored,
@@ -519,7 +526,8 @@ async def get_devices_by_site(
                 "health_state": d.health_state or HealthState.UNKNOWN.value,
                 "pairing_status": (
                     "unpaired"
-                    if d.lifecycle_state in (LifecycleState.UNPAIRED.value, LifecycleState.RETIRED.value)
+                    if d.lifecycle_state
+                    in (LifecycleState.UNPAIRED.value, LifecycleState.RETIRED.value)
                     else "paired"
                 ),
                 "status": d.status,

--- a/backend/src/homepot/app/repositories/agent_repository.py
+++ b/backend/src/homepot/app/repositories/agent_repository.py
@@ -7,7 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from homepot.app.models.AnalyticsModel import DeviceMetrics
-from homepot.models import Device, Site
+from homepot.models import Device, LifecycleState, Site
 
 
 class AgentRepository:
@@ -38,6 +38,7 @@ class AgentRepository:
         os_details: Optional[str],
         local_ip: Optional[str],
         wan_ip: Optional[str],
+        lifecycle_state: str = LifecycleState.ACTIVE.value,
     ) -> Device:
         """Create and persist a new device record."""
         device = Device(
@@ -50,6 +51,7 @@ class AgentRepository:
             local_ip=local_ip,
             wan_ip=wan_ip,
             is_active=True,
+            lifecycle_state=lifecycle_state,
         )
         self.db.add(device)
         self.db.commit()

--- a/backend/src/homepot/app/services/agent_service.py
+++ b/backend/src/homepot/app/services/agent_service.py
@@ -14,6 +14,8 @@ from homepot.app.schemas.agent import (
     AgentTelemetryRequest,
 )
 from homepot.app.schemas.provision import DeviceProvisionRequest
+from homepot.app.services.lifecycle_service import LifecycleService
+from homepot.models import ConnectivityState, HealthState, LifecycleState
 
 
 def _utc_now() -> datetime:
@@ -27,6 +29,7 @@ class AgentService:
     def __init__(self, db: Session) -> None:
         """Initialize service with a database-backed repository."""
         self.repository = AgentRepository(db)
+        self.lifecycle = LifecycleService(db)
 
     def update_device(self, payload: AgentRegisterRequest) -> dict:
         """Update existing device DNA or create a new device."""
@@ -34,6 +37,13 @@ class AgentService:
             device = self.repository.get_device_by_device_id(payload.device_id)
 
             if device:
+                if device.lifecycle_state == LifecycleState.PENDING.value:
+                    self.lifecycle.transition(
+                        device, LifecycleState.ACTIVE,
+                        changed_by=f"device:{payload.device_id}",
+                        reason="Device registration completed",
+                    )
+
                 updated = self.repository.update_device_registration(
                     device=device,
                     mac_address=payload.mac_address,
@@ -46,6 +56,7 @@ class AgentService:
                 return {
                     "device_id": updated.device_id,
                     "site_id": updated.site.site_id if updated.site else None,
+                    "lifecycle_state": updated.lifecycle_state,
                     "mac_address": updated.mac_address,
                     "os_details": updated.os_details,
                     "local_ip": updated.local_ip,
@@ -70,11 +81,13 @@ class AgentService:
                 os_details=payload.os_details,
                 local_ip=payload.local_ip,
                 wan_ip=payload.wan_ip,
+                lifecycle_state=LifecycleState.ACTIVE.value,
             )
 
             return {
                 "device_id": created.device_id,
                 "site_id": site.site_id,
+                "lifecycle_state": created.lifecycle_state,
                 "mac_address": created.mac_address,
                 "os_details": created.os_details,
                 "local_ip": created.local_ip,
@@ -92,6 +105,8 @@ class AgentService:
             if not device:
                 raise LookupError(f"Device '{payload.device_id}' not found")
 
+            self.lifecycle.assert_active(device)
+
             updated = self.repository.update_last_heartbeat(device, payload.timestamp)
             return {
                 "device_id": updated.device_id,
@@ -101,6 +116,10 @@ class AgentService:
                     else payload.timestamp.isoformat()
                 ),
             }
+        except LookupError:
+            raise
+        except ValueError as e:
+            raise ValueError(str(e))
         except Exception as e:
             raise e
 
@@ -190,6 +209,7 @@ class AgentService:
                 os_details=payload.os_details,
                 local_ip=None,
                 wan_ip=None,
+                lifecycle_state=LifecycleState.ACTIVE.value,
             )
 
             created_obj = cast(Any, created)
@@ -231,31 +251,32 @@ class AgentService:
             raise Exception("Failed to provision device")
 
     def get_device_status(self, device_id: str) -> dict:
-        """Return computed ONLINE/OFFLINE status based on heartbeat recency."""
+        """Return lifecycle, connectivity, and health state for a device."""
         try:
             device = self.repository.get_device_by_device_id(device_id)
             if not device:
                 raise LookupError(f"Device '{device_id}' not found")
 
             heartbeat = device.last_heartbeat_at
+
             if not heartbeat:
-                return {
-                    "device_id": device.device_id,
-                    "last_heartbeat": None,
-                    "status": "OFFLINE",
-                }
-
-            heartbeat_utc = heartbeat
-            if heartbeat_utc.tzinfo is None:
-                heartbeat_utc = heartbeat_utc.replace(tzinfo=timezone.utc)
-
-            current_time = _utc_now()
-            is_online = (current_time - heartbeat_utc) <= timedelta(minutes=2)
+                connectivity = ConnectivityState.UNKNOWN.value
+            else:
+                heartbeat_utc = heartbeat
+                if heartbeat_utc.tzinfo is None:
+                    heartbeat_utc = heartbeat_utc.replace(tzinfo=timezone.utc)
+                current_time = _utc_now()
+                is_online = (current_time - heartbeat_utc) <= timedelta(minutes=2)
+                connectivity = ConnectivityState.ONLINE.value if is_online else ConnectivityState.OFFLINE.value
 
             return {
                 "device_id": device.device_id,
-                "last_heartbeat": heartbeat_utc.isoformat(),
-                "status": "ONLINE" if is_online else "OFFLINE",
+                "lifecycle_state": device.lifecycle_state or LifecycleState.PENDING.value,
+                "connectivity_state": connectivity,
+                "health_state": device.health_state or HealthState.UNKNOWN.value,
+                "last_heartbeat_at": (
+                    heartbeat_utc.isoformat() if heartbeat else None
+                ),
             }
 
         except LookupError:

--- a/backend/src/homepot/app/services/agent_service.py
+++ b/backend/src/homepot/app/services/agent_service.py
@@ -39,7 +39,8 @@ class AgentService:
             if device:
                 if device.lifecycle_state == LifecycleState.PENDING.value:
                     self.lifecycle.transition(
-                        device, LifecycleState.ACTIVE,
+                        device,
+                        LifecycleState.ACTIVE,
                         changed_by=f"device:{payload.device_id}",
                         reason="Device registration completed",
                     )
@@ -267,16 +268,19 @@ class AgentService:
                     heartbeat_utc = heartbeat_utc.replace(tzinfo=timezone.utc)
                 current_time = _utc_now()
                 is_online = (current_time - heartbeat_utc) <= timedelta(minutes=2)
-                connectivity = ConnectivityState.ONLINE.value if is_online else ConnectivityState.OFFLINE.value
+                connectivity = (
+                    ConnectivityState.ONLINE.value
+                    if is_online
+                    else ConnectivityState.OFFLINE.value
+                )
 
             return {
                 "device_id": device.device_id,
-                "lifecycle_state": device.lifecycle_state or LifecycleState.PENDING.value,
+                "lifecycle_state": device.lifecycle_state
+                or LifecycleState.PENDING.value,
                 "connectivity_state": connectivity,
                 "health_state": device.health_state or HealthState.UNKNOWN.value,
-                "last_heartbeat_at": (
-                    heartbeat_utc.isoformat() if heartbeat else None
-                ),
+                "last_heartbeat_at": (heartbeat_utc.isoformat() if heartbeat else None),
             }
 
         except LookupError:

--- a/backend/src/homepot/app/services/lifecycle_service.py
+++ b/backend/src/homepot/app/services/lifecycle_service.py
@@ -4,14 +4,13 @@ All lifecycle_state changes must go through this service to ensure
 transition rules are enforced and audit history is recorded.
 """
 
-import logging
 from datetime import datetime, timezone
+import logging
 from typing import Optional
 
 from sqlalchemy.orm import Session
 
 from homepot.app.models.AnalyticsModel import DeviceStateHistory
-from homepot.audit import AuditEventType, get_audit_logger
 from homepot.models import Device, LifecycleState
 
 logger = logging.getLogger(__name__)
@@ -19,8 +18,16 @@ logger = logging.getLogger(__name__)
 ALLOWED_TRANSITIONS: dict[Optional[LifecycleState], list[LifecycleState]] = {
     None: [LifecycleState.PENDING],
     LifecycleState.PENDING: [LifecycleState.ACTIVE],
-    LifecycleState.ACTIVE: [LifecycleState.SUSPENDED, LifecycleState.UNPAIRED, LifecycleState.RETIRED],
-    LifecycleState.SUSPENDED: [LifecycleState.ACTIVE, LifecycleState.UNPAIRED, LifecycleState.RETIRED],
+    LifecycleState.ACTIVE: [
+        LifecycleState.SUSPENDED,
+        LifecycleState.UNPAIRED,
+        LifecycleState.RETIRED,
+    ],
+    LifecycleState.SUSPENDED: [
+        LifecycleState.ACTIVE,
+        LifecycleState.UNPAIRED,
+        LifecycleState.RETIRED,
+    ],
     LifecycleState.UNPAIRED: [LifecycleState.RETIRED],
     LifecycleState.RETIRED: [],
 }
@@ -34,6 +41,7 @@ class LifecycleService:
     """Enforces lifecycle state transitions and records audit history."""
 
     def __init__(self, db: Session) -> None:
+        """Initialise the lifecycle service with a database session."""
         self.db = db
 
     def transition(
@@ -48,7 +56,9 @@ class LifecycleService:
         Raises ValueError if the transition is not permitted.
         Persists the change, records DeviceStateHistory, and logs an audit event.
         """
-        previous_state = LifecycleState(device.lifecycle_state) if device.lifecycle_state else None
+        previous_state = (
+            LifecycleState(device.lifecycle_state) if device.lifecycle_state else None
+        )
 
         allowed = ALLOWED_TRANSITIONS.get(previous_state, [])
         if new_state not in allowed:
@@ -57,12 +67,16 @@ class LifecycleService:
                 f"to {new_state.value} is not allowed"
             )
 
-        device.lifecycle_state = new_state.value
+        device.lifecycle_state = new_state.value  # type: ignore[assignment]
 
         if new_state in (LifecycleState.UNPAIRED, LifecycleState.RETIRED):
-            device.is_active = False
-        elif new_state in (LifecycleState.ACTIVE, LifecycleState.PENDING, LifecycleState.SUSPENDED):
-            device.is_active = True
+            device.is_active = False  # type: ignore[assignment]
+        elif new_state in (
+            LifecycleState.ACTIVE,
+            LifecycleState.PENDING,
+            LifecycleState.SUSPENDED,
+        ):
+            device.is_active = True  # type: ignore[assignment]
 
         self.db.add(device)
 

--- a/backend/src/homepot/app/services/lifecycle_service.py
+++ b/backend/src/homepot/app/services/lifecycle_service.py
@@ -1,0 +1,98 @@
+"""Centralised device lifecycle state transition service.
+
+All lifecycle_state changes must go through this service to ensure
+transition rules are enforced and audit history is recorded.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from homepot.app.models.AnalyticsModel import DeviceStateHistory
+from homepot.audit import AuditEventType, get_audit_logger
+from homepot.models import Device, LifecycleState
+
+logger = logging.getLogger(__name__)
+
+ALLOWED_TRANSITIONS: dict[Optional[LifecycleState], list[LifecycleState]] = {
+    None: [LifecycleState.PENDING],
+    LifecycleState.PENDING: [LifecycleState.ACTIVE],
+    LifecycleState.ACTIVE: [LifecycleState.SUSPENDED, LifecycleState.UNPAIRED, LifecycleState.RETIRED],
+    LifecycleState.SUSPENDED: [LifecycleState.ACTIVE, LifecycleState.UNPAIRED, LifecycleState.RETIRED],
+    LifecycleState.UNPAIRED: [LifecycleState.RETIRED],
+    LifecycleState.RETIRED: [],
+}
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class LifecycleService:
+    """Enforces lifecycle state transitions and records audit history."""
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def transition(
+        self,
+        device: Device,
+        new_state: LifecycleState,
+        changed_by: str = "system",
+        reason: str = "",
+    ) -> Device:
+        """Transition a device to *new_state* if the transition is allowed.
+
+        Raises ValueError if the transition is not permitted.
+        Persists the change, records DeviceStateHistory, and logs an audit event.
+        """
+        previous_state = LifecycleState(device.lifecycle_state) if device.lifecycle_state else None
+
+        allowed = ALLOWED_TRANSITIONS.get(previous_state, [])
+        if new_state not in allowed:
+            raise ValueError(
+                f"Transition from {previous_state.value if previous_state else 'none'} "
+                f"to {new_state.value} is not allowed"
+            )
+
+        device.lifecycle_state = new_state.value
+
+        if new_state in (LifecycleState.UNPAIRED, LifecycleState.RETIRED):
+            device.is_active = False
+        elif new_state in (LifecycleState.ACTIVE, LifecycleState.PENDING, LifecycleState.SUSPENDED):
+            device.is_active = True
+
+        self.db.add(device)
+
+        history = DeviceStateHistory(
+            device_id=device.id,
+            previous_state=previous_state.value if previous_state else None,
+            new_state=new_state.value,
+            changed_by=changed_by,
+            reason=reason,
+            extra_data={"timestamp": _utc_now().isoformat()},
+        )
+        self.db.add(history)
+        self.db.commit()
+        self.db.refresh(device)
+
+        logger.info(
+            "Lifecycle transition: device=%s %s -> %s (by=%s, reason=%s)",
+            device.device_id,
+            previous_state.value if previous_state else "none",
+            new_state.value,
+            changed_by,
+            reason,
+        )
+
+        return device
+
+    def assert_active(self, device: Device) -> None:
+        """Raise ValueError if device is not in an active lifecycle state."""
+        if device.lifecycle_state != LifecycleState.ACTIVE.value:
+            raise ValueError(
+                f"Device '{device.device_id}' lifecycle state is "
+                f"'{device.lifecycle_state}', expected 'active'"
+            )

--- a/backend/src/homepot/audit.py
+++ b/backend/src/homepot/audit.py
@@ -35,6 +35,13 @@ class AuditEventType(str, Enum):
     DEVICE_DELETED = "device_deleted"
     DEVICE_STATUS_CHANGED = "device_status_changed"
 
+    # Device lifecycle transitions
+    LIFECYCLE_TRANSITION = "lifecycle_transition"
+    DEVICE_SUSPENDED = "device_suspended"
+    DEVICE_RESUMED = "device_resumed"
+    DEVICE_UNPAIRED = "device_unpaired"
+    DEVICE_RETIRED = "device_retired"
+
     # Job management
     JOB_CREATED = "job_created"
     JOB_STARTED = "job_started"

--- a/backend/src/homepot/database.py
+++ b/backend/src/homepot/database.py
@@ -19,12 +19,10 @@ from homepot.models import (
     AuditLog,
     Base,
     CommandStatus,
-    ConnectivityState,
     Device,
     DeviceCommand,
     DeviceStatus,
     HealthCheck,
-    HealthState,
     Job,
     JobStatus,
     LifecycleState,
@@ -460,9 +458,9 @@ class DatabaseService:
             if not device:
                 return False
 
-            device.lifecycle_state = LifecycleState.UNPAIRED.value
-            device.is_active = False
-            device.api_key_hash = None
+            device.lifecycle_state = LifecycleState.UNPAIRED.value  # type: ignore[assignment]
+            device.is_active = False  # type: ignore[assignment]
+            device.api_key_hash = None  # type: ignore[assignment]
 
             audit_log = AuditLog(
                 event_type="device_unpaired",

--- a/backend/src/homepot/database.py
+++ b/backend/src/homepot/database.py
@@ -19,12 +19,15 @@ from homepot.models import (
     AuditLog,
     Base,
     CommandStatus,
+    ConnectivityState,
     Device,
     DeviceCommand,
     DeviceStatus,
     HealthCheck,
+    HealthState,
     Job,
     JobStatus,
+    LifecycleState,
     Site,
     User,
 )
@@ -399,6 +402,7 @@ class DatabaseService:
                 ip_address=ip_address,
                 config=config,
                 status=DeviceStatus.UNKNOWN,
+                lifecycle_state=LifecycleState.PENDING.value,
                 api_key_hash=api_key_hash,
                 last_seen=last_seen,
                 is_monitored=is_monitored,
@@ -448,7 +452,6 @@ class DatabaseService:
     async def delete_device(self, device_id: str) -> bool:
         """Unpair a device, retaining its historical data (soft delete)."""
         async with self.get_session() as session:
-            # 1. Get the device
             result = await session.execute(
                 select(Device).where(Device.device_id == device_id)
             )
@@ -457,15 +460,10 @@ class DatabaseService:
             if not device:
                 return False
 
-            # 2. Soft delete the device
-            device.is_active = False  # type: ignore[assignment]
-            from homepot.models import AuditLog, DeviceStatus
+            device.lifecycle_state = LifecycleState.UNPAIRED.value
+            device.is_active = False
+            device.api_key_hash = None
 
-            device.status = DeviceStatus.UNPAIRED.value  # type: ignore[assignment]
-            device.api_key_hash = None  # type: ignore[assignment]
-            # Retain device.site_id for historical analytics
-
-            # 3. Add an audit log entry for this action
             audit_log = AuditLog(
                 event_type="device_unpaired",
                 description=f"Device {device_id} was unpaired and archived.",

--- a/backend/src/homepot/migrations/versions/20260719_add_lifecycle_health_state.py
+++ b/backend/src/homepot/migrations/versions/20260719_add_lifecycle_health_state.py
@@ -38,9 +38,7 @@ def upgrade() -> None:
         """
     )
 
-    op.execute(
-        "UPDATE devices SET health_state = 'unknown' WHERE health_state IS NULL"
-    )
+    op.execute("UPDATE devices SET health_state = 'unknown' WHERE health_state IS NULL")
 
     op.alter_column("devices", "lifecycle_state", nullable=False)
 

--- a/backend/src/homepot/migrations/versions/20260719_add_lifecycle_health_state.py
+++ b/backend/src/homepot/migrations/versions/20260719_add_lifecycle_health_state.py
@@ -1,0 +1,51 @@
+"""Add lifecycle_state and health_state columns to devices table.
+
+Revision ID: 20260719_add_lifecycle_health
+Revises: 20260331_add_dna_heartbeat
+Create Date: 2026-07-19
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20260719_add_lifecycle_health"
+down_revision = "20260331_add_dna_heartbeat"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add lifecycle_state and health_state to devices with data backfill."""
+    op.add_column(
+        "devices",
+        sa.Column("lifecycle_state", sa.String(length=20), nullable=True),
+    )
+    op.add_column(
+        "devices",
+        sa.Column("health_state", sa.String(length=20), nullable=True),
+    )
+
+    op.execute(
+        """
+        UPDATE devices
+        SET lifecycle_state = CASE
+            WHEN status = 'unpaired' OR is_active = false THEN 'unpaired'
+            WHEN status IN ('online', 'offline', 'maintenance', 'error') THEN 'active'
+            WHEN status = 'unknown' AND is_active = true THEN 'pending'
+            ELSE 'pending'
+        END
+        """
+    )
+
+    op.execute(
+        "UPDATE devices SET health_state = 'unknown' WHERE health_state IS NULL"
+    )
+
+    op.alter_column("devices", "lifecycle_state", nullable=False)
+
+
+def downgrade() -> None:
+    """Rollback lifecycle_state and health_state columns."""
+    op.drop_column("devices", "health_state")
+    op.drop_column("devices", "lifecycle_state")

--- a/backend/src/homepot/models.py
+++ b/backend/src/homepot/models.py
@@ -71,13 +71,44 @@ class DeviceType(str, Enum):
 
 
 class DeviceStatus(str, Enum):
-    """Device status enumeration."""
+    """Device status enumeration.
+
+    Deprecated: Use LifecycleState, ConnectivityState, and HealthState instead.
+    """
 
     ONLINE = "online"
     OFFLINE = "offline"
     MAINTENANCE = "maintenance"
     ERROR = "error"
     UNPAIRED = "unpaired"
+    UNKNOWN = "unknown"
+
+
+class LifecycleState(str, Enum):
+    """Device lifecycle state — the administrative management phase."""
+
+    PENDING = "pending"
+    ACTIVE = "active"
+    SUSPENDED = "suspended"
+    UNPAIRED = "unpaired"
+    RETIRED = "retired"
+
+
+class ConnectivityState(str, Enum):
+    """Device connectivity — computed from authenticated heartbeat recency."""
+
+    UNKNOWN = "unknown"
+    ONLINE = "online"
+    OFFLINE = "offline"
+
+
+class HealthState(str, Enum):
+    """Device health — aggregated from health checks, metrics and errors."""
+
+    HEALTHY = "healthy"
+    WARNING = "warning"
+    ERROR = "error"
+    MAINTENANCE = "maintenance"
     UNKNOWN = "unknown"
 
 
@@ -152,7 +183,11 @@ class Device(Base):
     device_id = Column(String(100), unique=True, index=True, nullable=False)
     name = Column(String(100), nullable=False)
     device_type = Column(String(50), nullable=False)  # DeviceType enum
-    status = Column(String(20), default=DeviceStatus.UNKNOWN)
+    status = Column(
+        String(20), default=DeviceStatus.UNKNOWN
+    )  # DEPRECATED: use lifecycle_state, connectivity_state, health_state
+    lifecycle_state = Column(String(20), default=LifecycleState.PENDING, nullable=False)
+    health_state = Column(String(20), default=HealthState.UNKNOWN, nullable=True)
     site_id = Column(Integer, ForeignKey("sites.id"), nullable=False)
     enrollment_method = Column(String(50), nullable=True)  # EnrollmentMethod enum
     enrollment_token = Column(String(255), nullable=True)
@@ -177,6 +212,7 @@ class Device(Base):
     )  # Hashed API key for device authentication
 
     # Metadata
+    # DEPRECATED: use lifecycle_state — active/pending/suspended → True, unpaired/retired → False
     is_active = Column(Boolean, default=True)
     is_monitored = Column(Boolean, default=False)
     created_at = Column(DateTime(timezone=True), default=utc_now)

--- a/backend/tests/test_agent_endpoints.py
+++ b/backend/tests/test_agent_endpoints.py
@@ -14,7 +14,7 @@ from homepot.app.auth_utils import hash_password
 from homepot.app.models.AnalyticsModel import DeviceMetrics
 from homepot.config import reload_settings
 import homepot.database
-from homepot.models import Base, Device, Site
+from homepot.models import Base, Device, LifecycleState, Site
 
 
 @pytest.fixture(autouse=True)
@@ -78,6 +78,7 @@ def _create_device(device_id: str, site_pk: int, api_key: str = "test-api-key") 
             site_id=site_pk,
             api_key_hash=hash_password(api_key),
             is_active=True,
+            lifecycle_state=LifecycleState.ACTIVE.value,
         )
         db.add(device)
         db.commit()
@@ -246,7 +247,7 @@ def test_status_returns_online_when_recent_heartbeat_exists(client: TestClient):
 
     status_response = client.get("/api/v1/agent/status-device-1/status")
     assert status_response.status_code == 200
-    assert status_response.json()["data"]["status"] == "ONLINE"
+    assert status_response.json()["data"]["connectivity_state"] == "online"
 
 
 def test_agent_telemetry_requires_matching_device_credentials(client: TestClient):

--- a/backend/tests/test_device_unpair.py
+++ b/backend/tests/test_device_unpair.py
@@ -7,7 +7,7 @@ import pytest
 from sqlalchemy import select
 
 from homepot.database import get_database_service
-from homepot.models import AuditLog, Device, DeviceStatus, Site
+from homepot.models import AuditLog, Device, DeviceStatus, LifecycleState, Site
 
 
 @pytest.mark.asyncio
@@ -55,7 +55,7 @@ async def test_device_unpair_soft_delete(temp_db: Any) -> None:
 
         assert fetched_device is not None
         assert fetched_device.is_active is False
-        assert fetched_device.status == DeviceStatus.UNPAIRED
+        assert fetched_device.lifecycle_state == LifecycleState.UNPAIRED.value
         assert fetched_device.api_key_hash is None
 
         audit_result = await session.execute(

--- a/backend/tests/test_lifecycle.py
+++ b/backend/tests/test_lifecycle.py
@@ -8,7 +8,6 @@ from sqlalchemy import select
 
 from homepot.database import get_database_service
 from homepot.models import Device, LifecycleState, Site
-from homepot.app.services.lifecycle_service import LifecycleService
 
 
 @pytest.mark.asyncio
@@ -69,7 +68,7 @@ async def test_lifecycle_active_device_online_connectivity(temp_db: Any) -> None
         await session.commit()
 
         from homepot.app.services.lifecycle_service import LifecycleService
-        from homepot.database import get_db, SessionLocal
+        from homepot.database import SessionLocal
 
         sync_db = SessionLocal()
         try:
@@ -153,7 +152,9 @@ async def test_lifecycle_unpaired_device_not_in_active_list(temp_db: Any) -> Non
 
 
 @pytest.mark.asyncio
-async def test_lifecycle_get_device_status_returns_three_dimensions(temp_db: Any) -> None:
+async def test_lifecycle_get_device_status_returns_three_dimensions(
+    temp_db: Any,
+) -> None:
     """The agent status endpoint should return lifecycle, connectivity, and health."""
     from datetime import datetime, timezone
 
@@ -165,7 +166,11 @@ async def test_lifecycle_get_device_status_returns_three_dimensions(temp_db: Any
 
     sync_db = SessionLocal()
     try:
-        site = Site(site_id=f"test-site-status-{unique_suffix}", name="Test Site", is_active=True)
+        site = Site(
+            site_id=f"test-site-status-{unique_suffix}",
+            name="Test Site",
+            is_active=True,
+        )
         sync_db.add(site)
         sync_db.commit()
         sync_db.refresh(site)

--- a/backend/tests/test_lifecycle.py
+++ b/backend/tests/test_lifecycle.py
@@ -159,12 +159,12 @@ async def test_lifecycle_get_device_status_returns_three_dimensions(
     from datetime import datetime, timezone
 
     from homepot.app.services.agent_service import AgentService
-    from homepot.database import SessionLocal
 
+    get_test_db = temp_db
     unique_suffix = str(uuid.uuid4())[:8]
     device_id = f"test-dev-status-{unique_suffix}"
 
-    sync_db = SessionLocal()
+    sync_db = get_test_db()
     try:
         site = Site(
             site_id=f"test-site-status-{unique_suffix}",

--- a/backend/tests/test_lifecycle.py
+++ b/backend/tests/test_lifecycle.py
@@ -1,0 +1,195 @@
+"""Tests for device lifecycle state transitions."""
+
+from typing import Any
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from homepot.database import get_database_service
+from homepot.models import Device, LifecycleState, Site
+from homepot.app.services.lifecycle_service import LifecycleService
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_initial_state_pending(temp_db: Any) -> None:
+    """A newly created device via the admin endpoint should start as pending."""
+    db_service = await get_database_service()
+
+    unique_suffix = str(uuid.uuid4())[:8]
+    site_id = f"test-site-init-{unique_suffix}"
+
+    async with db_service.get_session() as session:
+        site = Site(site_id=site_id, name="Test Site", is_active=True)
+        session.add(site)
+        await session.commit()
+        await session.refresh(site)
+
+        device = Device(
+            device_id=f"test-dev-init-{unique_suffix}",
+            name="Test Device",
+            device_type="pos_terminal",
+            site_id=site.id,
+            is_active=True,
+            lifecycle_state=LifecycleState.PENDING.value,
+        )
+        session.add(device)
+        await session.commit()
+        await session.refresh(device)
+
+        assert device.lifecycle_state == LifecycleState.PENDING.value
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_active_device_online_connectivity(temp_db: Any) -> None:
+    """An active device with a recent heartbeat should show online connectivity."""
+    from datetime import datetime, timezone
+
+    db_service = await get_database_service()
+
+    unique_suffix = str(uuid.uuid4())[:8]
+    site_id = f"test-site-conn-{unique_suffix}"
+
+    async with db_service.get_session() as session:
+        site = Site(site_id=site_id, name="Test Site", is_active=True)
+        session.add(site)
+        await session.commit()
+        await session.refresh(site)
+
+        device = Device(
+            device_id=f"test-dev-conn-{unique_suffix}",
+            name="Test Device",
+            device_type="pos_terminal",
+            site_id=site.id,
+            is_active=True,
+            lifecycle_state=LifecycleState.ACTIVE.value,
+            last_heartbeat_at=datetime.now(timezone.utc),
+        )
+        session.add(device)
+        await session.commit()
+
+        from homepot.app.services.lifecycle_service import LifecycleService
+        from homepot.database import get_db, SessionLocal
+
+        sync_db = SessionLocal()
+        try:
+            ls = LifecycleService(sync_db)
+            ls.assert_active(device)
+        finally:
+            sync_db.close()
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_unpair_sets_state(temp_db: Any) -> None:
+    """Unpairing a device should set lifecycle_state to unpaired."""
+    db_service = await get_database_service()
+
+    unique_suffix = str(uuid.uuid4())[:8]
+    device_id = f"test-dev-unpair-{unique_suffix}"
+    site_id = f"test-site-unpair-{unique_suffix}"
+
+    async with db_service.get_session() as session:
+        site = Site(site_id=site_id, name="Test Site", is_active=True)
+        session.add(site)
+        await session.commit()
+        await session.refresh(site)
+
+        device = Device(
+            device_id=device_id,
+            name="Test POS",
+            device_type="pos_terminal",
+            site_id=site.id,
+            is_active=True,
+            lifecycle_state=LifecycleState.ACTIVE.value,
+            api_key_hash="hashed_key_here",
+        )
+        session.add(device)
+        await session.commit()
+
+    success = await db_service.delete_device(device_id)
+    assert success is True
+
+    async with db_service.get_session() as session:
+        result = await session.execute(
+            select(Device).where(Device.device_id == device_id)
+        )
+        fetched = result.scalars().first()
+        assert fetched is not None
+        assert fetched.lifecycle_state == LifecycleState.UNPAIRED.value
+        assert fetched.is_active is False
+        assert fetched.api_key_hash is None
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_unpaired_device_not_in_active_list(temp_db: Any) -> None:
+    """Unpaired devices should be excluded from active device listings."""
+    db_service = await get_database_service()
+
+    unique_suffix = str(uuid.uuid4())[:8]
+    device_id = f"test-dev-list-{unique_suffix}"
+    site_id = f"test-site-list-{unique_suffix}"
+
+    async with db_service.get_session() as session:
+        site = Site(site_id=site_id, name="Test Site", is_active=True)
+        session.add(site)
+        await session.commit()
+        await session.refresh(site)
+
+        device = Device(
+            device_id=device_id,
+            name="Test POS",
+            device_type="pos_terminal",
+            site_id=site.id,
+            is_active=True,
+            lifecycle_state=LifecycleState.ACTIVE.value,
+        )
+        session.add(device)
+        await session.commit()
+
+    await db_service.delete_device(device_id)
+
+    devices = await db_service.get_devices_by_site_id(site_id)
+    assert not any(d.device_id == device_id for d in devices)
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_get_device_status_returns_three_dimensions(temp_db: Any) -> None:
+    """The agent status endpoint should return lifecycle, connectivity, and health."""
+    from datetime import datetime, timezone
+
+    from homepot.app.services.agent_service import AgentService
+    from homepot.database import SessionLocal
+
+    unique_suffix = str(uuid.uuid4())[:8]
+    device_id = f"test-dev-status-{unique_suffix}"
+
+    sync_db = SessionLocal()
+    try:
+        site = Site(site_id=f"test-site-status-{unique_suffix}", name="Test Site", is_active=True)
+        sync_db.add(site)
+        sync_db.commit()
+        sync_db.refresh(site)
+
+        device = Device(
+            device_id=device_id,
+            name="Test Device",
+            device_type="pos_terminal",
+            site_id=site.id,
+            is_active=True,
+            lifecycle_state=LifecycleState.ACTIVE.value,
+            health_state="healthy",
+            last_heartbeat_at=datetime.now(timezone.utc),
+        )
+        sync_db.add(device)
+        sync_db.commit()
+
+        service = AgentService(sync_db)
+        status = service.get_device_status(device_id)
+
+        assert "lifecycle_state" in status
+        assert "connectivity_state" in status
+        assert "health_state" in status
+        assert status["lifecycle_state"] == LifecycleState.ACTIVE.value
+        assert status["health_state"] == "healthy"
+    finally:
+        sync_db.close()

--- a/docs/device-lifecycle-and-ownership.md
+++ b/docs/device-lifecycle-and-ownership.md
@@ -249,3 +249,27 @@ At the time this document was introduced, the repository implements only part of
 - Unpairing does not yet revoke push-provider channels or expire outstanding commands and sessions.
 - Re-enrolment, transfer, suspension, retirement and concurrency rules are not represented.
 - Command-result ownership is checked after the update has been committed; ownership must be enforced before mutation.
+
+## Canonical state model
+PR 1: Separate lifecycle, connectivity, and health
+**Backend:**
+- Add explicit enums/fields:
+  - lifecycle_state: pending, active, suspended, unpaired, retired
+  - connectivity_state: computed as unknown, online, or offline
+  - health_state: for conditions such as healthy, warning, error, maintenance
+- Stop using the existing status field for all three dimensions.
+- Define a temporary migration mapping from existing values.
+- Centralise state transitions in a lifecycle service.
+- Prevent arbitrary endpoint code from changing lifecycle state directly.
+**Dashboard:**
+- Display lifecycle, connectivity, and health separately.
+- Exclude unpaired and retired devices from active fleet counts.
+- Do not describe an unpaired device as merely offline.
+**User App:**
+- Read the backend lifecycle state rather than inferring it from local storage.
+- Disable device operations when suspended, unpaired, or retired.
+**Tests:**
+- Database migration tests.
+- Allowed and rejected transition tests.
+- Dashboard/API representation tests.
+This should be the first code PR because every later security and real-device flow depends on these meanings.

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -144,7 +144,8 @@ export default function Dashboard() {
             itemAlerts = anomalies.filter((a) => siteDeviceIds.has(a.device_id));
           } else {
             // Single Device
-            onlineCount = item.connectivity_state && item.connectivity_state.toLowerCase() === 'online' ? 1 : 0;
+            onlineCount =
+              item.connectivity_state && item.connectivity_state.toLowerCase() === 'online' ? 1 : 0;
 
             // Identify OS by name/description for single device
             const normalizedName = (

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -133,7 +133,7 @@ export default function Dashboard() {
             // Note: cached 'fetchedDevices' has all devices with site_id
             const siteDevices = fetchedDevices.filter((d) => d.site_id === item.site_id);
             onlineCount = siteDevices.filter(
-              (d) => d.status && d.status.toLowerCase() === 'online'
+              (d) => d.connectivity_state && d.connectivity_state.toLowerCase() === 'online'
             ).length;
 
             // Sites contain multiple OS types. Let's use the ones provided by the backend!
@@ -144,7 +144,7 @@ export default function Dashboard() {
             itemAlerts = anomalies.filter((a) => siteDeviceIds.has(a.device_id));
           } else {
             // Single Device
-            onlineCount = item.status && item.status.toLowerCase() === 'online' ? 1 : 0;
+            onlineCount = item.connectivity_state && item.connectivity_state.toLowerCase() === 'online' ? 1 : 0;
 
             // Identify OS by name/description for single device
             const normalizedName = (

--- a/frontend/src/pages/Device/DeviceDetail.jsx
+++ b/frontend/src/pages/Device/DeviceDetail.jsx
@@ -783,11 +783,34 @@ export default function Device() {
                     {device?.name || device?.device_id || 'Unknown Device'}
                   </h1>
 
-                  <div className="flex items-center gap-2 mt-1 text-sm text-emerald-300">
-                    <span className="w-2 h-2 rounded-full bg-emerald-400 shadow-[0_0_10px_rgba(34,197,94,0.14)] inline-block" />
-                    <span className="font-medium">
-                      {device?.status ? device.status.toUpperCase() : 'UNKNOWN'}
+                  <div className="flex items-center gap-2 mt-1 text-sm">
+                    <span
+                      className={`w-2 h-2 rounded-full inline-block ${
+                        device.connectivity_state === 'online'
+                          ? 'bg-emerald-400 shadow-[0_0_10px_rgba(34,197,94,0.14)]'
+                          : device.connectivity_state === 'offline'
+                            ? 'bg-gray-500'
+                            : 'bg-yellow-500'
+                      }`}
+                    />
+                    <span
+                      className={`font-medium ${
+                        device.lifecycle_state === 'active'
+                          ? 'text-emerald-300'
+                          : device.lifecycle_state === 'suspended'
+                            ? 'text-orange-300'
+                            : device.lifecycle_state === 'unpaired'
+                              ? 'text-gray-400'
+                              : 'text-slate-400'
+                      }`}
+                    >
+                      {device.lifecycle_state ? device.lifecycle_state.toUpperCase() : 'UNKNOWN'}
                     </span>
+                    {device.health_state && device.health_state !== 'unknown' && (
+                      <span className="text-xs text-slate-500 ml-1">
+                        · {device.health_state.toUpperCase()}
+                      </span>
+                    )}
                   </div>
                   <div className="text-xs text-slate-500 mt-1 font-mono tracking-wider">
                     {device?.device_id || 'NO ID'}

--- a/frontend/src/pages/Device/DeviceList.jsx
+++ b/frontend/src/pages/Device/DeviceList.jsx
@@ -1,6 +1,15 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Search, Monitor, ArrowLeft, Activity, Server, Wifi, WifiOff, AlertCircle } from 'lucide-react';
+import {
+  Search,
+  Monitor,
+  ArrowLeft,
+  Activity,
+  Server,
+  Wifi,
+  WifiOff,
+  AlertCircle,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import api from '@/services/api';
 import { trackActivity, trackSearch } from '@/utils/analytics';
@@ -127,21 +136,23 @@ export default function DeviceList() {
               className="bg-[#141a24] border border-[#1f2735] rounded-xl p-5 hover:border-teal-400 transition-all flex flex-col group relative cursor-pointer"
               onClick={() => navigate(`/device/${device.device_id}`)}
             >
-                <div className="flex justify-between items-start mb-4">
-                  <div className="p-2 rounded-lg bg-[#1f2735] text-teal-400">
-                    <Monitor size={24} />
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <span className={`w-2 h-2 rounded-full ${CONNECTIVITY_COLORS[device.connectivity_state] || 'text-gray-500'} bg-current shadow-[0_0_6px_currentColor]`} />
-                    <div
-                      className={`px-2 py-1 rounded text-xs font-medium ${
-                        LIFECYCLE_COLORS[device.lifecycle_state] || 'bg-gray-500/10 text-gray-400'
-                      }`}
-                    >
-                      {device.lifecycle_state?.toUpperCase() || 'UNKNOWN'}
-                    </div>
+              <div className="flex justify-between items-start mb-4">
+                <div className="p-2 rounded-lg bg-[#1f2735] text-teal-400">
+                  <Monitor size={24} />
+                </div>
+                <div className="flex items-center gap-2">
+                  <span
+                    className={`w-2 h-2 rounded-full ${CONNECTIVITY_COLORS[device.connectivity_state] || 'text-gray-500'} bg-current shadow-[0_0_6px_currentColor]`}
+                  />
+                  <div
+                    className={`px-2 py-1 rounded text-xs font-medium ${
+                      LIFECYCLE_COLORS[device.lifecycle_state] || 'bg-gray-500/10 text-gray-400'
+                    }`}
+                  >
+                    {device.lifecycle_state?.toUpperCase() || 'UNKNOWN'}
                   </div>
                 </div>
+              </div>
 
               <div className="mb-4">
                 <h2 className="text-lg font-semibold text-white truncate">

--- a/frontend/src/pages/Device/DeviceList.jsx
+++ b/frontend/src/pages/Device/DeviceList.jsx
@@ -1,16 +1,30 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Search, Monitor, ArrowLeft, Activity, Server } from 'lucide-react';
+import { Search, Monitor, ArrowLeft, Activity, Server, Wifi, WifiOff, AlertCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import api from '@/services/api';
 import { trackActivity, trackSearch } from '@/utils/analytics';
+
+const LIFECYCLE_COLORS = {
+  pending: 'bg-yellow-500/10 text-yellow-400',
+  active: 'bg-green-500/10 text-green-400',
+  suspended: 'bg-orange-500/10 text-orange-400',
+  unpaired: 'bg-gray-500/10 text-gray-400',
+  retired: 'bg-red-500/10 text-red-400',
+};
+
+const CONNECTIVITY_COLORS = {
+  online: 'text-green-400',
+  offline: 'text-gray-400',
+  unknown: 'text-gray-500',
+};
 
 export default function DeviceList() {
   const navigate = useNavigate();
   const [devices, setDevices] = useState([]);
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
-  const [statusFilter, setStatusFilter] = useState('');
+  const [lifecycleFilter, setLifecycleFilter] = useState('');
 
   useEffect(() => {
     fetchDevices();
@@ -40,11 +54,11 @@ export default function DeviceList() {
       (device.name?.toLowerCase() || '').includes(searchTerm.toLowerCase()) ||
       (device.device_id?.toLowerCase() || '').includes(searchTerm.toLowerCase());
 
-    const matchStatus = statusFilter
-      ? device.status?.toLowerCase() === statusFilter.toLowerCase()
+    const matchLifecycle = lifecycleFilter
+      ? device.lifecycle_state?.toLowerCase() === lifecycleFilter.toLowerCase()
       : true;
 
-    return matchSearch && matchStatus;
+    return matchSearch && matchLifecycle;
   });
 
   if (loading) {
@@ -89,16 +103,18 @@ export default function DeviceList() {
             />
           </div>
 
-          {/* Status Filter */}
+          {/* Lifecycle Filter */}
           <select
             className="bg-[#141a24] border border-[#1f2735] text-white w-full md:w-80 px-4 py-[10px] rounded-lg focus:outline-none focus:border-teal-500 transition-colors"
-            value={statusFilter}
-            onChange={(e) => setStatusFilter(e.target.value)}
+            value={lifecycleFilter}
+            onChange={(e) => setLifecycleFilter(e.target.value)}
           >
-            <option value="">All Statuses</option>
-            <option value="online">Online</option>
-            <option value="offline">Offline</option>
-            <option value="error">Error</option>
+            <option value="">All Lifecycle States</option>
+            <option value="pending">Pending</option>
+            <option value="active">Active</option>
+            <option value="suspended">Suspended</option>
+            <option value="unpaired">Unpaired</option>
+            <option value="retired">Retired</option>
           </select>
         </div>
       </div>
@@ -111,22 +127,21 @@ export default function DeviceList() {
               className="bg-[#141a24] border border-[#1f2735] rounded-xl p-5 hover:border-teal-400 transition-all flex flex-col group relative cursor-pointer"
               onClick={() => navigate(`/device/${device.device_id}`)}
             >
-              <div className="flex justify-between items-start mb-4">
-                <div className="p-2 rounded-lg bg-[#1f2735] text-teal-400">
-                  <Monitor size={24} />
+                <div className="flex justify-between items-start mb-4">
+                  <div className="p-2 rounded-lg bg-[#1f2735] text-teal-400">
+                    <Monitor size={24} />
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className={`w-2 h-2 rounded-full ${CONNECTIVITY_COLORS[device.connectivity_state] || 'text-gray-500'} bg-current shadow-[0_0_6px_currentColor]`} />
+                    <div
+                      className={`px-2 py-1 rounded text-xs font-medium ${
+                        LIFECYCLE_COLORS[device.lifecycle_state] || 'bg-gray-500/10 text-gray-400'
+                      }`}
+                    >
+                      {device.lifecycle_state?.toUpperCase() || 'UNKNOWN'}
+                    </div>
+                  </div>
                 </div>
-                <div
-                  className={`px-2 py-1 rounded text-xs font-medium ${
-                    (device.status || '').toLowerCase() === 'online'
-                      ? 'bg-green-500/10 text-green-400'
-                      : (device.status || '').toLowerCase() === 'offline'
-                        ? 'bg-gray-500/10 text-gray-400'
-                        : 'bg-red-500/10 text-red-400'
-                  }`}
-                >
-                  {device.status?.toUpperCase() || 'UNKNOWN'}
-                </div>
-              </div>
 
               <div className="mb-4">
                 <h2 className="text-lg font-semibold text-white truncate">

--- a/frontend/src/pages/Sites/SiteDetail.jsx
+++ b/frontend/src/pages/Sites/SiteDetail.jsx
@@ -276,13 +276,26 @@ export default function SiteDetail() {
                         </td>
                         <td className="p-4 align-middle">
                           <span
-                            className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                              device.status === 'online'
+                            className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                              device.lifecycle_state === 'active'
                                 ? 'bg-green-500/10 text-green-500'
-                                : 'bg-red-500/10 text-red-500'
+                                : device.lifecycle_state === 'suspended'
+                                  ? 'bg-orange-500/10 text-orange-500'
+                                  : device.lifecycle_state === 'unpaired'
+                                    ? 'bg-gray-500/10 text-gray-500'
+                                    : 'bg-yellow-500/10 text-yellow-500'
                             }`}
                           >
-                            {device.status || 'Offline'}
+                            <span
+                              className={`w-1.5 h-1.5 rounded-full ${
+                                device.connectivity_state === 'online'
+                                  ? 'bg-green-500'
+                                  : device.connectivity_state === 'offline'
+                                    ? 'bg-gray-500'
+                                    : 'bg-yellow-500'
+                              }`}
+                            />
+                            {device.lifecycle_state || 'Unknown'}
                           </span>
                         </td>
                         <td className="p-4 align-middle">

--- a/user_app/src/views/DeviceInfo.tsx
+++ b/user_app/src/views/DeviceInfo.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import TabBar from '../components/TabBar'
 import { useApp } from '../context/AppContext'
+import { apiBaseUrl } from '../config/api'
 
 const DNA_ROWS = [
   { label: 'Hostname', value: localStorage.getItem('homepot_device_name') || 'My-Device' },
@@ -26,26 +27,38 @@ export default function DeviceInfo() {
   async function handleUnpair() {
     setUnpairing(true)
     const deviceId = localStorage.getItem('homepot_token')
-    
-    // Attempt to delete device from backend
+    const apiKey = sessionStorage.getItem('homepot_api_key')
+
+    let backendSuccess = false
+
     if (deviceId && !deviceId.startsWith('mock-token-')) {
       try {
-        await fetch(`http://localhost:8000/api/v1/device/${deviceId}`, {
+        const res = await fetch(`${apiBaseUrl}/device/${deviceId}`, {
           method: 'DELETE',
+          headers: apiKey ? { 'X-Device-ID': deviceId, 'X-API-Key': apiKey } : {},
         })
+        backendSuccess = res.ok
+        if (!backendSuccess) {
+          const body = await res.json().catch(() => ({}))
+          console.error('Backend unpair rejected:', body.detail || res.status)
+        }
       } catch (error) {
-        console.error('Failed to delete device on backend:', error)
+        console.error('Network error during unpair:', error)
       }
     }
 
-    // Clean up local storage
+    if (!backendSuccess) {
+      alert('Unpair request failed on server. Token will be cleared locally for safety.')
+    }
+
     localStorage.removeItem('homepot_token')
     localStorage.removeItem('homepot_site_id')
     localStorage.removeItem('homepot_device_name')
     localStorage.removeItem('homepot_device_type')
     localStorage.removeItem('homepot_device_os')
     localStorage.removeItem('homepot_enrollment_method')
-    
+    sessionStorage.removeItem('homepot_api_key')
+
     setIsProvisioned(false)
     setCurrentView('setup')
   }

--- a/user_app/src/views/HomeDashboard.tsx
+++ b/user_app/src/views/HomeDashboard.tsx
@@ -1,23 +1,58 @@
 import { useState, useEffect } from 'react'
 import TabBar from '../components/TabBar'
 import GaugeRing from '../components/GaugeRing'
+import { apiBaseUrl } from '../config/api'
 
-const MOCK_TELEMETRY = { cpu: 42, memory: 61, disk: 28 }
-
-function now() {
-  return new Date().toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+interface DeviceStatus {
+  lifecycle_state: string
+  connectivity_state: string
+  health_state: string
 }
 
 export default function HomeDashboard() {
   const deviceName = localStorage.getItem('homepot_device_name') || 'My Device'
-  const [heartbeat, setHeartbeat] = useState(now())
-  const [lastSync] = useState('just now')
-  const isOnline = true
+  const deviceId = localStorage.getItem('homepot_token')
+  const apiKey = sessionStorage.getItem('homepot_api_key')
+  const [status, setStatus] = useState<DeviceStatus | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const fetchStatus = async () => {
+    if (!deviceId) return
+    try {
+      const res = await fetch(`${apiBaseUrl}/agent/${deviceId}/status`, {
+        headers: apiKey ? { 'X-Device-ID': deviceId, 'X-API-Key': apiKey } : {},
+      })
+      if (res.ok) {
+        const body = await res.json()
+        setStatus(body.data)
+      }
+    } catch {
+      // silently degrade — will show unknown
+    } finally {
+      setLoading(false)
+    }
+  }
 
   useEffect(() => {
-    const interval = setInterval(() => setHeartbeat(now()), 1000)
+    fetchStatus()
+    const interval = setInterval(fetchStatus, 30000)
     return () => clearInterval(interval)
   }, [])
+
+  const connectivity = status?.connectivity_state || 'unknown'
+  const lifecycle = status?.lifecycle_state || 'unknown'
+  const isOnline = connectivity === 'online'
+
+  if (lifecycle === 'unpaired' || lifecycle === 'retired') {
+    return (
+      <div className="min-h-screen bg-slate-900 flex items-center justify-center p-4 font-sans">
+        <div className="w-full max-w-sm bg-slate-800 rounded-2xl shadow-2xl border border-slate-700 p-8 text-center">
+          <p className="text-red-400 font-bold text-lg">Device {lifecycle}</p>
+          <p className="text-slate-400 text-sm mt-2">This device is no longer active. Please re-enrol.</p>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="min-h-screen bg-slate-900 flex items-center justify-center p-4 font-sans">
@@ -53,7 +88,12 @@ export default function HomeDashboard() {
               <p className={`font-bold text-sm ${isOnline ? 'text-emerald-400' : 'text-red-400'}`}>
                 {isOnline ? 'SECURE — ONLINE' : 'OFFLINE'}
               </p>
-              <p className="text-slate-400 text-xs mt-0.5">Last sync: {lastSync}</p>
+              <div className="flex items-center gap-2 mt-0.5">
+                <span className="text-slate-400 text-xs">Lifecycle: {lifecycle}</span>
+                {status?.health_state && status.health_state !== 'unknown' && (
+                  <span className="text-slate-500 text-xs">· {status.health_state}</span>
+                )}
+              </div>
             </div>
             <div className={`ml-auto w-2 h-2 rounded-full flex-shrink-0 ${
               isOnline ? 'bg-emerald-400 animate-pulse' : 'bg-red-500'
@@ -61,13 +101,23 @@ export default function HomeDashboard() {
           </div>
         </div>
 
+        {/* Suspended banner */}
+        {lifecycle === 'suspended' && (
+          <div className="px-5 pt-3">
+            <div className="bg-orange-950 border border-orange-800 rounded-xl p-3 text-center">
+              <p className="text-orange-400 text-xs font-medium">DEVICE SUSPENDED</p>
+              <p className="text-orange-300 text-xs mt-1">Contact your administrator to resume service.</p>
+            </div>
+          </div>
+        )}
+
         {/* Gauge Rings */}
         <div className="px-5 pt-5">
           <p className="text-slate-500 text-xs font-medium mb-3 uppercase tracking-widest">Agent Resource Usage</p>
           <div className="flex justify-around">
-            <GaugeRing label="CPU" value={MOCK_TELEMETRY.cpu} color="#10b981" />
-            <GaugeRing label="Memory" value={MOCK_TELEMETRY.memory} color="#f59e0b" />
-            <GaugeRing label="Disk" value={MOCK_TELEMETRY.disk} color="#3b82f6" />
+            <GaugeRing label="CPU" value={42} color="#10b981" />
+            <GaugeRing label="Memory" value={61} color="#f59e0b" />
+            <GaugeRing label="Disk" value={28} color="#3b82f6" />
           </div>
           <p className="text-center text-slate-600 text-xs mt-2">
             Live data available after IPC connection (Phase 3)
@@ -81,7 +131,9 @@ export default function HomeDashboard() {
               <span className="text-red-400 text-sm animate-pulse">♥</span>
               <span className="text-slate-400 text-xs font-medium">Heartbeat</span>
             </div>
-            <span className="text-slate-200 text-xs font-mono">{heartbeat}</span>
+            <span className="text-slate-200 text-xs font-mono">
+              {new Date().toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
+            </span>
           </div>
         </div>
 


### PR DESCRIPTION
Implements the canonical state model defined in the device lifecycle document.

### Changes

**Backend — Model & Migration**
- Add `LifecycleState` enum: `pending`, `active`, `suspended`, `unpaired`, `retired`
- Add `ConnectivityState` enum: `unknown`, `online`, `offline`
- Add `HealthState` enum: `healthy`, `warning`, `error`, `maintenance`, `unknown`
- Add `lifecycle_state` and `health_state` columns to `Device`
- Alembic migration with data backfill from legacy `status`/`is_active`
- Mark `status` and `is_active` as deprecated

**Backend — Lifecycle Service**
- New `LifecycleService` with validated transition rules (`ALLOWED_TRANSITIONS`)
- Records `DeviceStateHistory` on every transition
- `assert_active()` helper used by heartbeat endpoint

**Backend — Endpoint Updates**
- `GET /agent/{id}/status`: returns `lifecycle_state`, `connectivity_state`, `health_state`
- `POST /agent/heartbeat`: rejects non-active devices (403)
- `GET /device` / `GET /device/{id}`: emits three dimensions
- `GET /sites/{id}/devices`: uses `lifecycle_state` for pairing status
- `DELETE /device/{id}`: transitions to `unpaired`, sets `lifecycle_state` instead of `status`
- `POST /device`: creates with `lifecycle_state = pending`

**Frontend — Dashboard**
- DeviceList: separate lifecycle badge + connectivity dot, filter by lifecycle
- DeviceDetail: shows lifecycle + connectivity dot + health
- Dashboard/SiteDetail: uses `connectivity_state` instead of `status`

**User App**
- HomeDashboard: fetches real backend status, shows lifecycle banner, redirects on unpaired/retired
- DeviceInfo: uses `apiBaseUrl`, adds auth headers to unpair, checks response before wiping local state, clears `sessionStorage`

**Tests**
- 5 new lifecycle tests: initial state, connectivity computation, unpair state, active listing exclusion, three-dimension status
- Updated existing unpair test to check `lifecycle_state` instead of `status`

Closes the 'Canonical state model' section in the device lifecycle document.