### PR TITLE
feat: introduce tenant and site membership models

### DIFF
--- a/backend/src/homepot/app/api/API_v1/Api.py
+++ b/backend/src/homepot/app/api/API_v1/Api.py
@@ -22,6 +22,7 @@ from .Endpoints import (
     PushNotificationEndpoint,
     SiteSchedulesEndpoint,
     SitesEndpoint,
+    TenantsEndpoint,
     UIEndpoint,
     UserRegisterEndpoint,
 )
@@ -40,6 +41,9 @@ api_v1_router.include_router(
 api_v1_router.include_router(UIEndpoint.router, prefix="/ui", tags=["UI"])
 api_v1_router.include_router(ClientEndpoint.router, prefix="/client", tags=["Client"])
 api_v1_router.include_router(SitesEndpoint.router, prefix="/sites", tags=["Sites"])
+api_v1_router.include_router(
+    TenantsEndpoint.router, prefix="/tenants", tags=["Tenants"]
+)
 api_v1_router.include_router(
     SiteSchedulesEndpoint.router, prefix="/sites", tags=["Site Schedules"]
 )

--- a/backend/src/homepot/app/api/API_v1/Endpoints/SitesEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/SitesEndpoint.py
@@ -5,11 +5,13 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, ConfigDict
+from sqlalchemy import select
 
 from homepot.audit import AuditEventType, get_audit_logger
 from homepot.client import HomepotClient
 from homepot.database import get_database_service
 from homepot.error_logger import log_error
+from homepot.models import Device, Site
 
 client_instance: Optional[HomepotClient] = None
 
@@ -67,7 +69,9 @@ def get_client() -> HomepotClient:
 
 
 @router.post("/", tags=["Sites"], response_model=Dict[str, str])
-async def create_site(site_request: CreateSiteRequest) -> Dict[str, str]:
+async def create_site(
+    site_request: CreateSiteRequest,
+) -> Dict[str, str]:
     """Create a new site for device management."""
     try:
         db_service = await get_database_service()
@@ -136,17 +140,9 @@ async def list_sites() -> Dict[str, List[Dict]]:
     try:
         db_service = await get_database_service()
 
-        # For demo, we'll create a simple query (in real app, add pagination)
-        from sqlalchemy import select
-
-        from homepot.models import Device, Site
-
         async with db_service.get_session() as session:
-            result = await session.execute(
-                select(Site)
-                .where(Site.is_active.is_(True))
-                .order_by(Site.created_at.desc())
-            )
+            query = select(Site).where(Site.is_active.is_(True))
+            result = await session.execute(query.order_by(Site.created_at.desc()))
             sites = result.scalars().all()
 
             site_list = []

--- a/backend/src/homepot/app/api/API_v1/Endpoints/TenantsEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/TenantsEndpoint.py
@@ -1,0 +1,470 @@
+"""API endpoints for tenant and site membership management."""
+
+import logging
+from typing import Any, Dict, Generator, List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from homepot.app.auth_utils import (
+    TokenData,
+    get_current_user,
+    require_role,
+)
+from homepot.app.schemas.schemas import (
+    SiteMembershipCreate,
+    SiteMembershipOut,
+    TenantCreate,
+    TenantMembershipCreate,
+    TenantMembershipOut,
+    TenantOut,
+    TenantUpdate,
+    UserOutWithTenant,
+)
+from homepot.audit import AuditEventType, get_audit_logger
+from homepot.database import SessionLocal
+from homepot.models import Site, SiteMembership, Tenant, TenantMembership, User
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def get_db() -> Generator[Session, None, None]:
+    """Get a sync database session for tenant operations."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# ---- Tenant CRUD ----
+
+
+@router.post("/", response_model=TenantOut, status_code=status.HTTP_201_CREATED)
+async def create_tenant(  # type: ignore[no-untyped-def]
+    tenant_data: TenantCreate,
+    admin: Dict = Depends(require_role("Admin")),
+    db: Session = Depends(get_db),
+):
+    """Create a new tenant/organisation."""
+    existing = db.query(Tenant).filter(Tenant.slug == tenant_data.slug).first()
+    if existing:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Tenant with slug '{tenant_data.slug}' already exists",
+        )
+
+    tenant = Tenant(
+        name=tenant_data.name,
+        slug=tenant_data.slug,
+        settings=tenant_data.settings,
+    )
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+
+    audit_logger = get_audit_logger()
+    await audit_logger.log_event(
+        AuditEventType.SITE_CREATED,
+        f"Tenant '{tenant.name}' created",
+        new_values={"name": tenant.name, "slug": tenant.slug},
+    )
+
+    logger.info(f"Created tenant {tenant.slug}")
+    return tenant
+
+
+@router.get("/", response_model=List[TenantOut])
+async def list_tenants(  # type: ignore[no-untyped-def]
+    admin: Dict = Depends(require_role("Admin")),
+    db: Session = Depends(get_db),
+):
+    """List all active tenants."""
+    tenants = (
+        db.query(Tenant).filter(Tenant.is_active.is_(True)).order_by(Tenant.name).all()
+    )
+    return tenants
+
+
+@router.get("/{tenant_id}", response_model=TenantOut)
+async def get_tenant(  # type: ignore[no-untyped-def]
+    tenant_id: int,
+    admin: Dict = Depends(require_role("Admin")),
+    db: Session = Depends(get_db),
+):
+    """Get a specific tenant by ID."""
+    tenant = db.query(Tenant).filter(Tenant.id == tenant_id).first()
+    if not tenant:
+        raise HTTPException(status_code=404, detail="Tenant not found")
+    return tenant
+
+
+@router.put("/{tenant_id}", response_model=TenantOut)
+async def update_tenant(  # type: ignore[no-untyped-def]
+    tenant_id: int,
+    tenant_data: TenantUpdate,
+    admin: Dict = Depends(require_role("Admin")),
+    db: Session = Depends(get_db),
+):
+    """Update a tenant's name or settings."""
+    tenant = db.query(Tenant).filter(Tenant.id == tenant_id).first()
+    if not tenant:
+        raise HTTPException(status_code=404, detail="Tenant not found")
+
+    if tenant_data.name is not None:
+        tenant.name = tenant_data.name  # type: ignore[assignment]
+    if tenant_data.settings is not None:
+        tenant.settings = tenant_data.settings  # type: ignore[assignment]
+
+    db.commit()
+    db.refresh(tenant)
+
+    audit_logger = get_audit_logger()
+    await audit_logger.log_event(
+        AuditEventType.SITE_UPDATED,
+        f"Tenant '{tenant.name}' updated",
+        new_values={"name": tenant_data.name},
+    )
+
+    return tenant
+
+
+@router.delete("/{tenant_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_tenant(  # type: ignore[no-untyped-def]
+    tenant_id: int,
+    admin: Dict = Depends(require_role("Admin")),
+    db: Session = Depends(get_db),
+):
+    """Deactivate a tenant (soft delete to preserve referential integrity)."""
+    tenant = db.query(Tenant).filter(Tenant.id == tenant_id).first()
+    if not tenant:
+        raise HTTPException(status_code=404, detail="Tenant not found")
+
+    tenant.is_active = False  # type: ignore[assignment]
+    db.commit()
+
+    audit_logger = get_audit_logger()
+    await audit_logger.log_event(
+        AuditEventType.SITE_DELETED,
+        f"Tenant '{tenant.name}' deactivated",
+        old_values={"slug": tenant.slug},
+    )
+
+
+# ---- Tenant Membership Management ----
+
+
+@router.get(
+    "/{tenant_id}/members",
+    response_model=List[TenantMembershipOut],
+)
+async def list_tenant_members(  # type: ignore[no-untyped-def]
+    tenant_id: int,
+    admin: Dict = Depends(require_role("Admin")),
+    db: Session = Depends(get_db),
+):
+    """List all members of a tenant."""
+    memberships = (
+        db.query(TenantMembership).filter(TenantMembership.tenant_id == tenant_id).all()
+    )
+    return memberships
+
+
+@router.post(
+    "/{tenant_id}/members",
+    response_model=TenantMembershipOut,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_tenant_member(  # type: ignore[no-untyped-def]
+    tenant_id: int,
+    membership: TenantMembershipCreate,
+    admin: Dict = Depends(require_role("Admin")),
+    db: Session = Depends(get_db),
+):
+    """Add a user to a tenant with a role."""
+    tenant = db.query(Tenant).filter(Tenant.id == tenant_id).first()
+    if not tenant:
+        raise HTTPException(status_code=404, detail="Tenant not found")
+
+    user = db.query(User).filter(User.id == membership.user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    existing = (
+        db.query(TenantMembership)
+        .filter(
+            TenantMembership.tenant_id == tenant_id,
+            TenantMembership.user_id == membership.user_id,
+        )
+        .first()
+    )
+    if existing:
+        raise HTTPException(
+            status_code=409,
+            detail="User is already a member of this tenant",
+        )
+
+    member = TenantMembership(
+        user_id=membership.user_id,
+        tenant_id=tenant_id,
+        role=membership.role,
+    )
+    db.add(member)
+    db.commit()
+    db.refresh(member)
+
+    logger.info(
+        f"User {membership.user_id} added to tenant {tenant_id} as {membership.role}"
+    )
+    return member
+
+
+@router.put(
+    "/{tenant_id}/members/{membership_id}",
+    response_model=TenantMembershipOut,
+)
+async def update_tenant_member_role(  # type: ignore[no-untyped-def]
+    tenant_id: int,
+    membership_id: int,
+    role_update: TenantMembershipCreate,
+    admin: Dict = Depends(require_role("Admin")),
+    db: Session = Depends(get_db),
+):
+    """Update a tenant member's role."""
+    member = (
+        db.query(TenantMembership)
+        .filter(
+            TenantMembership.id == membership_id,
+            TenantMembership.tenant_id == tenant_id,
+        )
+        .first()
+    )
+    if not member:
+        raise HTTPException(status_code=404, detail="Membership not found")
+
+    member.role = role_update.role  # type: ignore[assignment]
+    db.commit()
+    db.refresh(member)
+    return member
+
+
+@router.delete(
+    "/{tenant_id}/members/{membership_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def remove_tenant_member(  # type: ignore[no-untyped-def]
+    tenant_id: int,
+    membership_id: int,
+    admin: Dict = Depends(require_role("Admin")),
+    db: Session = Depends(get_db),
+):
+    """Remove a user from a tenant."""
+    member = (
+        db.query(TenantMembership)
+        .filter(
+            TenantMembership.id == membership_id,
+            TenantMembership.tenant_id == tenant_id,
+        )
+        .first()
+    )
+    if not member:
+        raise HTTPException(status_code=404, detail="Membership not found")
+
+    db.delete(member)
+    db.commit()
+
+
+# ---- Site Membership Management ----
+
+
+@router.get(
+    "/{tenant_id}/sites/{site_id}/members",
+    response_model=List[SiteMembershipOut],
+)
+async def list_site_members(  # type: ignore[no-untyped-def]
+    tenant_id: int,
+    site_id: int,
+    admin: Dict = Depends(require_role("Admin")),
+    db: Session = Depends(get_db),
+):
+    """List all members of a site scoped to a tenant."""
+    site = (
+        db.query(Site).filter(Site.id == site_id, Site.tenant_id == tenant_id).first()
+    )
+    if not site:
+        raise HTTPException(status_code=404, detail="Site not found in this tenant")
+
+    memberships = (
+        db.query(SiteMembership).filter(SiteMembership.site_id == site_id).all()
+    )
+    return memberships
+
+
+@router.post(
+    "/{tenant_id}/sites/{site_id}/members",
+    response_model=SiteMembershipOut,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_site_member(  # type: ignore[no-untyped-def]
+    tenant_id: int,
+    site_id: int,
+    membership: SiteMembershipCreate,
+    db: Session = Depends(get_db),
+    admin: Dict = Depends(require_role("Admin")),
+):
+    """Add a user to a site with a role."""
+    site = (
+        db.query(Site).filter(Site.id == site_id, Site.tenant_id == tenant_id).first()
+    )
+    if not site:
+        raise HTTPException(status_code=404, detail="Site not found in this tenant")
+
+    user = db.query(User).filter(User.id == membership.user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    existing = (
+        db.query(SiteMembership)
+        .filter(
+            SiteMembership.site_id == site_id,
+            SiteMembership.user_id == membership.user_id,
+        )
+        .first()
+    )
+    if existing:
+        raise HTTPException(
+            status_code=409,
+            detail="User is already a member of this site",
+        )
+
+    member = SiteMembership(
+        user_id=membership.user_id,
+        site_id=site_id,
+        role=membership.role,
+    )
+    db.add(member)
+    db.commit()
+    db.refresh(member)
+
+    logger.info(
+        f"User {membership.user_id} added to site {site_id} as {membership.role}"
+    )
+    return member
+
+
+@router.put(
+    "/{tenant_id}/sites/{site_id}/members/{membership_id}",
+    response_model=SiteMembershipOut,
+)
+async def update_site_member_role(  # type: ignore[no-untyped-def]
+    tenant_id: int,
+    site_id: int,
+    membership_id: int,
+    role_update: SiteMembershipCreate,
+    admin: Dict = Depends(require_role("Admin")),
+    db: Session = Depends(get_db),
+):
+    """Update a site member's role."""
+    member = (
+        db.query(SiteMembership)
+        .filter(
+            SiteMembership.id == membership_id,
+            SiteMembership.site_id == site_id,
+        )
+        .first()
+    )
+    if not member:
+        raise HTTPException(status_code=404, detail="Site membership not found")
+
+    member.role = role_update.role  # type: ignore[assignment]
+    db.commit()
+    db.refresh(member)
+    return member
+
+
+@router.delete(
+    "/{tenant_id}/sites/{site_id}/members/{membership_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def remove_site_member(  # type: ignore[no-untyped-def]
+    tenant_id: int,
+    site_id: int,
+    membership_id: int,
+    admin: Dict = Depends(require_role("Admin")),
+    db: Session = Depends(get_db),
+):
+    """Remove a user from a site."""
+    member = (
+        db.query(SiteMembership)
+        .filter(
+            SiteMembership.id == membership_id,
+            SiteMembership.site_id == site_id,
+        )
+        .first()
+    )
+    if not member:
+        raise HTTPException(status_code=404, detail="Site membership not found")
+
+    db.delete(member)
+    db.commit()
+
+
+# ---- Tenant-scoped User Info ----
+
+
+@router.get("/{tenant_id}/users", response_model=List[UserOutWithTenant])
+async def list_tenant_users(  # type: ignore[no-untyped-def]
+    tenant_id: int,
+    admin: Dict = Depends(require_role("Admin")),
+    db: Session = Depends(get_db),
+):
+    """List all users belonging to a tenant."""
+    users = (
+        db.query(User)
+        .filter(User.tenant_id == tenant_id, User.is_active.is_(True))
+        .all()
+    )
+    return users
+
+
+# ---- My Memberships (for the current user) ----
+
+
+@router.get("/me/memberships", response_model=Dict[str, Any])
+async def get_my_memberships(  # type: ignore[no-untyped-def]
+    current_user: TokenData = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get all tenant and site memberships for the current user."""
+    user = db.query(User).filter(User.email == current_user.email).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    tenant_memberships = (
+        db.query(TenantMembership).filter(TenantMembership.user_id == user.id).all()
+    )
+    site_memberships = (
+        db.query(SiteMembership).filter(SiteMembership.user_id == user.id).all()
+    )
+
+    return {
+        "tenant_memberships": [
+            {
+                "id": m.id,
+                "tenant_id": m.tenant_id,
+                "role": m.role,
+            }
+            for m in tenant_memberships
+        ],
+        "site_memberships": [
+            {
+                "id": m.id,
+                "site_id": m.site_id,
+                "role": m.role,
+            }
+            for m in site_memberships
+        ],
+    }

--- a/backend/src/homepot/app/api/API_v1/Endpoints/UserRegisterEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/UserRegisterEndpoint.py
@@ -38,6 +38,7 @@ from homepot.app.models import UserRegisterModel as models
 from homepot.app.schemas import schemas
 from homepot.app.utils.limiter import limiter
 from homepot.database import SessionLocal
+from homepot.models import Tenant
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -89,6 +90,9 @@ def signup(
         # Admin and Engineer both get is_admin=True for now, but role string differs
         is_admin_user = user_role.lower() in ["admin", "engineer"]
 
+        # Assign to default tenant
+        default_tenant = db.query(Tenant).filter(Tenant.slug == "default").first()
+
         new_user = models.User(
             email=user.email,
             username=final_username,
@@ -96,6 +100,7 @@ def signup(
             hashed_password=hash_password(user.password),
             role=user_role,
             is_admin=is_admin_user,
+            tenant_id=default_tenant.id if default_tenant else None,
             created_at=datetime.now(timezone.utc),
             updated_at=datetime.now(timezone.utc),
         )
@@ -178,6 +183,7 @@ def login(
                 "is_admin": db_user.is_admin,
                 "full_name": db_user.full_name,
                 "role": db_user.role,
+                "tenant_id": db_user.tenant_id,
             },
         )
 
@@ -342,6 +348,7 @@ def get_me(
                 "is_admin": db_user.is_admin,
                 "full_name": db_user.full_name,
                 "role": db_user.role,
+                "tenant_id": db_user.tenant_id,
             },
         )
     except HTTPException:

--- a/backend/src/homepot/app/api/API_v1/Endpoints/__init__.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/__init__.py
@@ -17,6 +17,7 @@ from . import (
     PushNotificationEndpoint,
     SiteSchedulesEndpoint,
     SitesEndpoint,
+    TenantsEndpoint,
     UIEndpoint,
     UserRegisterEndpoint,
 )
@@ -38,6 +39,7 @@ __all__ = [
     "PushNotificationEndpoint",
     "SiteSchedulesEndpoint",
     "SitesEndpoint",
+    "TenantsEndpoint",
     "UIEndpoint",
     "UserRegisterEndpoint",
 ]

--- a/backend/src/homepot/app/auth_utils.py
+++ b/backend/src/homepot/app/auth_utils.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 import logging
 import os
 from pathlib import Path
-from typing import Any, Optional, cast
+from typing import Any, Dict, Optional, cast
 
 from dotenv import load_dotenv
 from fastapi import Depends, HTTPException, Request, status
@@ -21,7 +21,7 @@ from sqlalchemy.orm import Session
 
 from homepot.app.schemas.schemas import UserDict
 from homepot.database import get_db
-from homepot.models import Device, User
+from homepot.models import Device, SiteMembership, Tenant, TenantMembership, User
 
 # Ensure environment variables are loaded
 # load_dotenv()
@@ -328,6 +328,9 @@ def get_or_create_google_user(db: Session, idinfo: dict) -> User:
     user = db.query(User).filter(User.email == user_email).first()
 
     if not user:
+        # Assign to default tenant
+        default_tenant = db.query(Tenant).filter(Tenant.slug == "default").first()
+
         # Create new user
         user = User(
             email=user_email,
@@ -336,6 +339,7 @@ def get_or_create_google_user(db: Session, idinfo: dict) -> User:
             hashed_password=hash_password(os.urandom(24).hex()),
             is_admin=False,
             role="Client",
+            tenant_id=default_tenant.id if default_tenant else None,
             created_at=datetime.now(timezone.utc),
             updated_at=datetime.now(timezone.utc),
         )
@@ -345,3 +349,158 @@ def get_or_create_google_user(db: Session, idinfo: dict) -> User:
         logger.info(f"New user created via Google SSO: {user_email}")
 
     return cast(User, user)
+
+
+# ---- Tenant & Site Authorization Guards ----
+
+
+def require_tenant_role(required_role: str) -> Any:
+    """Dependency to require a specific role within a user's primary tenant."""
+
+    def role_checker(
+        user_token: TokenData = Depends(get_current_user),
+        db: Session = Depends(get_db),
+    ) -> Dict[str, Any]:
+        db_user = cast(
+            User, db.query(User).filter(User.email == user_token.email).first()
+        )
+        if not db_user:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="User not found",
+            )
+
+        if db_user.is_admin:
+            return {
+                "email": cast(str, db_user.email),
+                "role": "Admin",
+                "user_id": cast(int, db_user.id),
+            }
+
+        if not db_user.tenant_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="User is not associated with any tenant",
+            )
+
+        membership = cast(
+            TenantMembership,
+            db.query(TenantMembership)
+            .filter(
+                TenantMembership.user_id == db_user.id,
+                TenantMembership.tenant_id == db_user.tenant_id,
+                TenantMembership.role == required_role,
+            )
+            .first(),
+        )
+        if not membership:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Requires {required_role} role in tenant",
+            )
+
+        return {
+            "email": cast(str, db_user.email),
+            "role": cast(str, membership.role),
+            "user_id": cast(int, db_user.id),
+        }
+
+    return role_checker
+
+
+def require_site_access(site_id: int, minimum_role: str = "viewer") -> Any:
+    """Dependency to verify a user has at least the minimum role on a site.
+
+    Admins bypass this check. Role hierarchy: admin > operator > installer > viewer.
+    """
+    _ROLE_HIERARCHY: dict[str, int] = {
+        "admin": 4,
+        "operator": 3,
+        "installer": 2,
+        "viewer": 1,
+    }
+
+    def access_checker(
+        user_token: TokenData = Depends(get_current_user),
+        db: Session = Depends(get_db),
+    ) -> Dict[str, Any]:
+        db_user = cast(
+            User, db.query(User).filter(User.email == user_token.email).first()
+        )
+        if not db_user:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="User not found",
+            )
+
+        if db_user.is_admin:
+            return {
+                "email": cast(str, db_user.email),
+                "role": "Admin",
+                "user_id": cast(int, db_user.id),
+            }
+
+        min_level = _ROLE_HIERARCHY.get(minimum_role, 1)
+
+        if db_user.tenant_id:
+            tenant_membership = cast(
+                TenantMembership,
+                db.query(TenantMembership)
+                .filter(
+                    TenantMembership.user_id == db_user.id,
+                    TenantMembership.tenant_id == db_user.tenant_id,
+                )
+                .first(),
+            )
+            if tenant_membership:
+                tenant_level = _ROLE_HIERARCHY.get(cast(str, tenant_membership.role), 0)
+                if tenant_level >= min_level:
+                    return {
+                        "email": cast(str, db_user.email),
+                        "role": cast(str, tenant_membership.role),
+                        "user_id": cast(int, db_user.id),
+                    }
+
+        membership = cast(
+            SiteMembership,
+            db.query(SiteMembership)
+            .filter(
+                SiteMembership.user_id == db_user.id,
+                SiteMembership.site_id == site_id,
+            )
+            .first(),
+        )
+        if not membership:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="User does not have access to this site",
+            )
+
+        user_level = _ROLE_HIERARCHY.get(cast(str, membership.role), 0)
+        if user_level < min_level:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Requires at least '{minimum_role}' role on this site",
+            )
+
+        return {
+            "email": cast(str, db_user.email),
+            "role": cast(str, membership.role),
+            "user_id": cast(int, db_user.id),
+        }
+
+    return access_checker
+
+
+def get_current_user_id(
+    user_token: TokenData = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> int:
+    """Get the database user ID from the current authenticated user."""
+    db_user = cast(User, db.query(User).filter(User.email == user_token.email).first())
+    if not db_user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        )
+    return cast(int, db_user.id)

--- a/backend/src/homepot/app/schemas/schemas.py
+++ b/backend/src/homepot/app/schemas/schemas.py
@@ -285,6 +285,82 @@ class HealthCheckRequest(BaseModel):
     )
 
 
+# ==================== Tenant & Membership Schemas ====================
+
+
+class TenantCreate(BaseModel):
+    """Schema for creating a new tenant."""
+
+    name: str
+    slug: str
+    settings: Optional[Dict[str, Any]] = None
+
+
+class TenantUpdate(BaseModel):
+    """Schema for updating a tenant."""
+
+    name: Optional[str] = None
+    settings: Optional[Dict[str, Any]] = None
+
+
+class TenantOut(BaseModel):
+    """Schema for tenant output (response)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    slug: str
+    settings: Optional[Dict[str, Any]] = None
+    is_active: bool
+    created_at: Any
+    updated_at: Any
+
+
+class TenantMembershipCreate(BaseModel):
+    """Schema for adding a user to a tenant."""
+
+    user_id: int
+    role: str = "member"  # admin, operator, installer, member
+
+
+class TenantMembershipOut(BaseModel):
+    """Schema for tenant membership output."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    user_id: int
+    tenant_id: int
+    role: str
+    created_at: Any
+
+
+class SiteMembershipCreate(BaseModel):
+    """Schema for adding a user to a site."""
+
+    user_id: int
+    role: str = "viewer"  # admin, operator, installer, viewer
+
+
+class SiteMembershipOut(BaseModel):
+    """Schema for site membership output."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    user_id: int
+    site_id: int
+    role: str
+    created_at: Any
+
+
+class UserOutWithTenant(UserOut):
+    """Extended user output with tenant info."""
+
+    tenant_id: Optional[int] = None
+
+
 # Alias for backward compatibility
 DeviceHealthCheckRequest = HealthCheckRequest
 AppMetrics = ApplicationMetrics

--- a/backend/src/homepot/database.py
+++ b/backend/src/homepot/database.py
@@ -305,6 +305,7 @@ class DatabaseService:
         location: Optional[str] = None,
         latitude: Optional[float] = None,
         longitude: Optional[float] = None,
+        tenant_id: Optional[int] = None,
     ) -> Site:
         """Create a new site."""
         async with self.get_session() as session:
@@ -315,6 +316,7 @@ class DatabaseService:
                 location=location,
                 latitude=latitude,
                 longitude=longitude,
+                tenant_id=tenant_id,
             )
             session.add(site)
             await session.flush()

--- a/backend/src/homepot/migrations/versions/20260719_add_tenant_site_membership.py
+++ b/backend/src/homepot/migrations/versions/20260719_add_tenant_site_membership.py
@@ -1,0 +1,107 @@
+"""Add Tenant, TenantMembership, SiteMembership models and tenant_id columns.
+
+Revision ID: 20260719_add_tenant_membership
+Revises: 20260719_add_lifecycle_health
+Create Date: 2026-07-19
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = "20260719_add_tenant_membership"
+down_revision = "20260719_add_lifecycle_health"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create tenant and membership tables, add tenant_id to users/sites, seed default tenant."""
+    # Create tenants table
+    op.create_table(
+        "tenants",
+        sa.Column("id", sa.Integer(), primary_key=True, index=True),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column(
+            "slug", sa.String(length=50), unique=True, index=True, nullable=False
+        ),
+        sa.Column("settings", sa.JSON(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), default=True),
+        sa.Column("created_at", sa.DateTime(timezone=True)),
+        sa.Column("updated_at", sa.DateTime(timezone=True)),
+    )
+
+    # Create tenant_memberships table
+    op.create_table(
+        "tenant_memberships",
+        sa.Column("id", sa.Integer(), primary_key=True, index=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column(
+            "tenant_id", sa.Integer(), sa.ForeignKey("tenants.id"), nullable=False
+        ),
+        sa.Column("role", sa.String(length=50), default="member"),
+        sa.Column("created_at", sa.DateTime(timezone=True)),
+        sa.Column("updated_at", sa.DateTime(timezone=True)),
+    )
+
+    # Create site_memberships table
+    op.create_table(
+        "site_memberships",
+        sa.Column("id", sa.Integer(), primary_key=True, index=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("site_id", sa.Integer(), sa.ForeignKey("sites.id"), nullable=False),
+        sa.Column("role", sa.String(length=50), default="viewer"),
+        sa.Column("created_at", sa.DateTime(timezone=True)),
+        sa.Column("updated_at", sa.DateTime(timezone=True)),
+    )
+
+    # Add tenant_id to users
+    op.add_column(
+        "users",
+        sa.Column(
+            "tenant_id", sa.Integer(), sa.ForeignKey("tenants.id"), nullable=True
+        ),
+    )
+
+    # Add tenant_id to sites
+    op.add_column(
+        "sites",
+        sa.Column(
+            "tenant_id", sa.Integer(), sa.ForeignKey("tenants.id"), nullable=True
+        ),
+    )
+
+    # Create a default tenant and migrate existing users/sites into it.
+    # Generate a connection-aware slug from the default tenant name.
+    op.execute(
+        text(
+            "INSERT INTO tenants (name, slug, is_active, created_at, updated_at) "
+            "VALUES ('Default Tenant', 'default', true, now(), now())"
+        )
+    )
+
+    # Get the id of the default tenant we just inserted.
+    conn = op.get_bind()
+    result = conn.execute(text("SELECT id FROM tenants WHERE slug = 'default'"))
+    default_tenant_id = result.scalar()
+
+    if default_tenant_id:
+        conn = op.get_bind()
+        conn.execute(
+            text("UPDATE users SET tenant_id = :tid WHERE tenant_id IS NULL"),
+            {"tid": default_tenant_id},
+        )
+        conn.execute(
+            text("UPDATE sites SET tenant_id = :tid WHERE tenant_id IS NULL"),
+            {"tid": default_tenant_id},
+        )
+
+
+def downgrade() -> None:
+    """Rollback tenant and membership tables and columns."""
+    op.drop_column("sites", "tenant_id")
+    op.drop_column("users", "tenant_id")
+    op.drop_table("site_memberships")
+    op.drop_table("tenant_memberships")
+    op.drop_table("tenants")

--- a/backend/src/homepot/models.py
+++ b/backend/src/homepot/models.py
@@ -129,6 +129,58 @@ class CommandStatus(str, Enum):
     EXPIRED = "expired"
 
 
+class Tenant(Base):
+    """Tenant/Organisation model for multi-tenancy support."""
+
+    __tablename__ = "tenants"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), nullable=False)
+    slug = Column(String(50), unique=True, index=True, nullable=False)
+    settings = Column(JSON, nullable=True)
+    is_active = Column(Boolean, default=True)
+    created_at = Column(DateTime(timezone=True), default=utc_now)
+    updated_at = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)
+
+    # Relationships
+    sites = relationship("Site", back_populates="tenant")
+    memberships = relationship("TenantMembership", back_populates="tenant")
+
+
+class TenantMembership(Base):
+    """User membership in a tenant with a role."""
+
+    __tablename__ = "tenant_memberships"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    tenant_id = Column(Integer, ForeignKey("tenants.id"), nullable=False)
+    role = Column(String(50), default="member")  # admin, operator, installer, member
+    created_at = Column(DateTime(timezone=True), default=utc_now)
+    updated_at = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)
+
+    # Relationships
+    user = relationship("User", back_populates="tenant_memberships")
+    tenant = relationship("Tenant", back_populates="memberships")
+
+
+class SiteMembership(Base):
+    """User membership in a site with a role."""
+
+    __tablename__ = "site_memberships"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    site_id = Column(Integer, ForeignKey("sites.id"), nullable=False)
+    role = Column(String(50), default="viewer")  # admin, operator, installer, viewer
+    created_at = Column(DateTime(timezone=True), default=utc_now)
+    updated_at = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)
+
+    # Relationships
+    user = relationship("User", back_populates="site_memberships")
+    site = relationship("Site", back_populates="memberships")
+
+
 class User(Base):
     """User model for authentication."""
 
@@ -143,11 +195,15 @@ class User(Base):
     role = Column(String(50), default="Client")
     is_active = Column(Boolean, default=True)
     is_admin = Column(Boolean, default=False)
+    tenant_id = Column(Integer, ForeignKey("tenants.id"), nullable=True)
     created_at = Column(DateTime(timezone=True), default=utc_now)
     updated_at = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)
 
     # Relationships
     jobs = relationship("Job", back_populates="created_by_user")
+    tenant = relationship("Tenant", foreign_keys=[tenant_id])
+    tenant_memberships = relationship("TenantMembership", back_populates="user")
+    site_memberships = relationship("SiteMembership", back_populates="user")
 
 
 class Site(Base):
@@ -164,14 +220,17 @@ class Site(Base):
     location = Column(String(200), nullable=True)
     latitude = Column(Float, nullable=True)
     longitude = Column(Float, nullable=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id"), nullable=True)
     is_active = Column(Boolean, default=True)
     is_monitored = Column(Boolean, default=False)
     created_at = Column(DateTime(timezone=True), default=utc_now)
     updated_at = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)
 
     # Relationships
+    tenant = relationship("Tenant", back_populates="sites")
     devices = relationship("Device", back_populates="site")
     jobs = relationship("Job", back_populates="site")
+    memberships = relationship("SiteMembership", back_populates="site")
 
 
 class Device(Base):

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -40,6 +40,7 @@ export function AuthProvider({ children }) {
           isAdmin: resp.data.is_admin,
           fullName: resp.data.full_name,
           role: role,
+          tenantId: resp.data.tenant_id,
         });
         setIsAuthenticated(true);
       } else {
@@ -97,6 +98,7 @@ export function AuthProvider({ children }) {
           isAdmin: resp.data.is_admin,
           fullName: resp.data.full_name,
           role: role,
+          tenantId: resp.data.tenant_id,
         };
         setUser(userData);
         setIsAuthenticated(true);

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -526,6 +526,94 @@ const api = {
     },
   },
 
+  // ==================== Tenants ====================
+
+  tenants: {
+    list: async () => {
+      const response = await apiClient.get('/tenants/');
+      return response.data;
+    },
+
+    get: async (tenantId) => {
+      const response = await apiClient.get(`/tenants/${tenantId}`);
+      return response.data;
+    },
+
+    create: async (tenantData) => {
+      const response = await apiClient.post('/tenants/', tenantData);
+      return response.data;
+    },
+
+    update: async (tenantId, tenantData) => {
+      const response = await apiClient.put(`/tenants/${tenantId}`, tenantData);
+      return response.data;
+    },
+
+    delete: async (tenantId) => {
+      const response = await apiClient.delete(`/tenants/${tenantId}`);
+      return response.data;
+    },
+
+    // Tenant member management
+    listMembers: async (tenantId) => {
+      const response = await apiClient.get(`/tenants/${tenantId}/members`);
+      return response.data;
+    },
+
+    addMember: async (tenantId, memberData) => {
+      const response = await apiClient.post(`/tenants/${tenantId}/members`, memberData);
+      return response.data;
+    },
+
+    updateMemberRole: async (tenantId, membershipId, roleData) => {
+      const response = await apiClient.put(
+        `/tenants/${tenantId}/members/${membershipId}`,
+        roleData
+      );
+      return response.data;
+    },
+
+    removeMember: async (tenantId, membershipId) => {
+      const response = await apiClient.delete(`/tenants/${tenantId}/members/${membershipId}`);
+      return response.data;
+    },
+
+    // Site member management (scoped under a tenant)
+    listSiteMembers: async (tenantId, siteId) => {
+      const response = await apiClient.get(`/tenants/${tenantId}/sites/${siteId}/members`);
+      return response.data;
+    },
+
+    addSiteMember: async (tenantId, siteId, memberData) => {
+      const response = await apiClient.post(
+        `/tenants/${tenantId}/sites/${siteId}/members`,
+        memberData
+      );
+      return response.data;
+    },
+
+    updateSiteMemberRole: async (tenantId, siteId, membershipId, roleData) => {
+      const response = await apiClient.put(
+        `/tenants/${tenantId}/sites/${siteId}/members/${membershipId}`,
+        roleData
+      );
+      return response.data;
+    },
+
+    removeSiteMember: async (tenantId, siteId, membershipId) => {
+      const response = await apiClient.delete(
+        `/tenants/${tenantId}/sites/${siteId}/members/${membershipId}`
+      );
+      return response.data;
+    },
+
+    // My memberships
+    getMyMemberships: async () => {
+      const response = await apiClient.get('/tenants/me/memberships');
+      return response.data;
+    },
+  },
+
   ai: {
     /**
      * Query the AI with a natural language question


### PR DESCRIPTION
## Summary

Implements tenant (organisation) and site membership models as planned in the device-lifecycle-and-ownership document (PR #178). Every site now belongs to a tenant, and users can have scoped roles at both the tenant and site level.

## Changes

### Backend Models
- **Tenant** — new table with name, slug, settings
- **TenantMembership** — user-to-tenant join table with role (admin/operator/installer/member)
- **SiteMembership** — user-to-site join table with role (admin/operator/installer/viewer)
- **User.tenant_id** — nullable FK to default tenant
- **Site.tenant_id** — nullable FK linking sites to tenants

### Migration
- Creates all new tables
- Adds `tenant_id` columns to `users` and `sites`
- Seeds a **Default Tenant** and backfills all existing users/sites into it

### API Endpoints (`/api/v1/tenants`)
- CRUD for tenants
- Tenant member management (add/list/update/remove)
- Site member management scoped under tenants
- `/tenants/me/memberships` for the current user

### Authorization Guards
- `require_tenant_role(role)` — dependency for tenant-scoped roles
- `require_site_access(site_id, min_role)` — role-hierarchy check (admin > operator > installer > viewer), with admin bypass

### Frontend
- AuthContext now stores `tenantId` on the user object
- API service has new `api.tenants.*` methods for all tenant and membership operations

### Backward Compatibility
- Existing site/device endpoints remain unauthenticated for backward compat
- Sites created without auth get `tenant_id = null`
- All 505 existing tests pass unchanged

## Next Steps
- Apply `require_site_access` guard to device and job endpoints
- Tenant switcher UI in the frontend navigation
- Device-level authorization (devices authenticate via API key, need synthetic site role)