### PR TITLE
feat: implement pre-provisioned claiming with lifecycle epochs

### DIFF
--- a/backend/src/homepot/app/api/API_v1/Endpoints/EnrolmentIntentsEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/EnrolmentIntentsEndpoint.py
@@ -70,11 +70,10 @@ def create_enrolment_intent(
         )
         if not current_db_user:
             raise HTTPException(status_code=403, detail="User not found")
-        db_user: User = current_db_user  # type: ignore[assignment]
+        db_user: User = current_db_user
         site = _get_site_by_site_id(db, site_id)
         verify_site_access_for_user(db_user, site_id, db, minimum_role="operator")
 
-        # Check idempotency
         if payload.idempotency_key:
             existing = (
                 db.query(EnrolmentIntent)
@@ -93,7 +92,6 @@ def create_enrolment_intent(
             hours=payload.expires_in_hours
         )
 
-        # Generate a one-time claim token
         claim_token = secrets.token_urlsafe(32)
         claim_token_hash = pwd_context.hash(claim_token)
 
@@ -149,7 +147,7 @@ def list_enrolment_intents(
         )
         if not current_db_user:
             raise HTTPException(status_code=403, detail="User not found")
-        db_user: User = current_db_user  # type: ignore[assignment]
+        db_user: User = current_db_user
         site = _get_site_by_site_id(db, site_id)
         verify_site_access_for_user(db_user, site_id, db, minimum_role="viewer")
 
@@ -210,7 +208,7 @@ def get_enrolment_intent(
         )
         if not current_db_user:
             raise HTTPException(status_code=403, detail="User not found")
-        db_user: User = current_db_user  # type: ignore[assignment]
+        db_user: User = current_db_user
         _get_site_by_site_id(db, site_id)
         verify_site_access_for_user(db_user, site_id, db, minimum_role="viewer")
 
@@ -254,7 +252,7 @@ def update_enrolment_intent_status(
     db: Session = Depends(get_db),
     current_user: UserDict = Depends(require_user()),
 ) -> Dict[str, Any]:
-    """Approve or reject a pending enrolment intent.
+    """Approve, reject, or revoke a pending enrolment intent.
 
     Requires operator-level access on the target site.
     """
@@ -264,7 +262,7 @@ def update_enrolment_intent_status(
         )
         if not current_db_user:
             raise HTTPException(status_code=403, detail="User not found")
-        db_user: User = current_db_user  # type: ignore[assignment]
+        db_user: User = current_db_user
         _get_site_by_site_id(db, site_id)
         verify_site_access_for_user(db_user, site_id, db, minimum_role="operator")
 
@@ -314,70 +312,85 @@ def claim_enrolment_intent(
     """Claim an enrolment intent using its one-time claim token.
 
     This endpoint is used by the device/app side (no user auth required).
-    On success, a device is created in PENDING lifecycle state and
-    device credentials are returned.
+    On success, a device is created in PENDING lifecycle state with a
+    lifecycle epoch record, and device credentials are returned.
+
+    Uses an atomic database operation (row-level locking) to prevent
+    duplicate and concurrent claims.
     """
+    import asyncio
+
     try:
-        intent = _get_intent_by_id_sync(db, intent_id)
-        if not intent:
-            raise HTTPException(status_code=404, detail="Enrolment intent not found")
 
-        # Validate intent is in a claimable state
-        if intent.status != EnrolmentIntentStatus.APPROVED:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Intent must be approved before claiming (current: {intent.status})",
-            )
-
-        if intent.expires_at and intent.expires_at < datetime.now(timezone.utc):
-            raise HTTPException(status_code=400, detail="Enrolment intent has expired")
-
-        # Verify claim token
-        if not intent.claim_token_hash or not pwd_context.verify(
-            payload.claim_token, intent.claim_token_hash  # type: ignore[arg-type]
-        ):
-            raise HTTPException(status_code=401, detail="Invalid claim token")
-
-        # Create the device
-        new_device_id = f"{payload.device_type}-{secrets.token_hex(4)}"
-        api_key = secrets.token_urlsafe(32)
-        api_key_hash = pwd_context.hash(api_key)
-
-        async def _create_device() -> Any:
+        async def _claim() -> Dict[str, Any]:
             svc = await get_database_service()
-            device = await svc.create_device(
-                device_id=new_device_id,
-                name=payload.device_name or new_device_id,
-                device_type=payload.device_type,
-                site_id=intent.site_id,  # type: ignore[arg-type]
-                api_key_hash=api_key_hash,
-                enrollment_method=intent.enrolment_method,  # type: ignore[arg-type]
-            )
-            return device
-
-        # Mark intent as consumed
-        async def _consume_intent() -> None:
-            svc = await get_database_service()
-            await svc.update_enrolment_intent_status(
+            return await svc.claim_enrolment_intent_atomic(
                 intent_id=intent_id,
-                status=EnrolmentIntentStatus.CONSUMED,
-                consumed_at=datetime.now(timezone.utc),
+                claim_token=payload.claim_token,
+                device_name=payload.device_name,
+                device_type=payload.device_type,
+                os_details=payload.os_details,
+                expected_device_identity=payload.expected_device_identity,
             )
 
-        import asyncio
-
-        asyncio.run(_create_device())
-        asyncio.run(_consume_intent())
-
+        result = asyncio.run(_claim())
         return {
             "status": "success",
             "message": "Device claimed successfully",
-            "device_id": new_device_id,
-            "api_key": api_key,
-            "site_id": intent.site_id,  # type: ignore[arg-type]
+            "device_id": result["device_id"],
+            "api_key": result["api_key"],
+            "site_id": result["site_id"],
+            "epoch_id": result["epoch_id"],
         }
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error("Failed to claim enrolment intent: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/sites/{site_id}/enrolment-intents/{intent_id}/regenerate-token",
+    tags=["Enrolment Intents"],
+    response_model=Dict[str, Any],
+)
+def regenerate_claim_token(
+    site_id: str,
+    intent_id: str,
+    db: Session = Depends(get_db),
+    current_user: UserDict = Depends(require_user()),
+) -> Dict[str, Any]:
+    """Regenerate the claim token for an existing enrolment intent.
+
+    Requires operator-level access on the target site.
+    Only possible while the intent is still in PENDING or APPROVED status.
+    """
+    try:
+        current_db_user = (
+            db.query(User).filter(User.email == current_user["email"]).first()
+        )
+        if not current_db_user:
+            raise HTTPException(status_code=403, detail="User not found")
+        db_user: User = current_db_user
+        _get_site_by_site_id(db, site_id)
+        verify_site_access_for_user(db_user, site_id, db, minimum_role="operator")
+
+        import asyncio
+
+        async def _regenerate() -> Dict[str, str]:
+            svc = await get_database_service()
+            return await svc.regenerate_claim_token(intent_id=intent_id)
+
+        result = asyncio.run(_regenerate())
+        return {
+            "status": "success",
+            "message": "Claim token regenerated",
+            "claim_token": result["claim_token"],
+        }
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except HTTPException:
         raise
     except Exception as e:
-        logger.error("Failed to claim enrolment intent: %s", e, exc_info=True)
+        logger.error("Failed to regenerate claim token: %s", e, exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/src/homepot/app/schemas/enrolment.py
+++ b/backend/src/homepot/app/schemas/enrolment.py
@@ -42,8 +42,8 @@ class EnrolmentIntentApprove(BaseModel):
 
     status: str = Field(
         ...,
-        pattern="^(approved|rejected)$",
-        description="New status: approved or rejected",
+        pattern="^(approved|rejected|revoked)$",
+        description="New status: approved, rejected, or revoked",
     )
 
 
@@ -56,6 +56,9 @@ class EnrolmentIntentClaim(BaseModel):
     os_details: Optional[str] = Field(
         None, description="Operating system info reported by the device"
     )
+    expected_device_identity: Optional[str] = Field(
+        None, description="Stable device evidence (e.g. serial number, hardware ID)"
+    )
 
     model_config = ConfigDict(
         json_schema_extra={
@@ -64,6 +67,7 @@ class EnrolmentIntentClaim(BaseModel):
                 "device_name": "Kitchen POS A",
                 "device_type": "pos_terminal",
                 "os_details": "Android 13",
+                "expected_device_identity": "SN-12345",
             }
         }
     )
@@ -103,3 +107,4 @@ class EnrolmentIntentClaimResponse(BaseModel):
     device_id: str
     api_key: str
     site_id: str
+    epoch_id: str

--- a/backend/src/homepot/database.py
+++ b/backend/src/homepot/database.py
@@ -9,6 +9,7 @@ import datetime
 import logging
 from pathlib import Path
 from typing import Any, AsyncGenerator, Dict, Generator, List, Optional
+import uuid
 
 from sqlalchemy import Result, create_engine, inspect, select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -27,6 +28,7 @@ from homepot.models import (
     HealthCheck,
     Job,
     JobStatus,
+    LifecycleEpoch,
     LifecycleState,
     Site,
     User,
@@ -393,6 +395,7 @@ class DatabaseService:
         is_monitored: bool = False,
         enrollment_method: Optional[str] = "pre-provisioned",
         enrollment_token: Optional[str] = None,
+        os_details: Optional[str] = None,
     ) -> Device:
         """Create a new device."""
         async with self.get_session() as session:
@@ -410,6 +413,7 @@ class DatabaseService:
                 is_monitored=is_monitored,
                 enrollment_method=enrollment_method,
                 enrollment_token=enrollment_token,
+                os_details=os_details,
             )
             session.add(device)
             await session.flush()
@@ -882,6 +886,157 @@ class DatabaseService:
                 query = query.where(EnrolmentIntent.status == status)
             result = await session.execute(query)
             return len(list(result.scalars().all()))
+
+    async def claim_enrolment_intent_atomic(
+        self,
+        intent_id: str,
+        claim_token: str,
+        device_name: Optional[str],
+        device_type: str,
+        os_details: Optional[str],
+        expected_device_identity: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Atomically claim an enrolment intent and create the device.
+
+        Uses ``select_for_update`` to lock the intent row, preventing
+        duplicate or concurrent claims.  Validates token hash, expiry,
+        scope (expected_device_identity) and unused state.  On success
+        creates the device, records a lifecycle epoch, and marks the
+        intent as consumed — all in a single transaction.
+        """
+        import secrets as _secrets
+
+        from passlib.context import CryptContext as _CryptContext
+
+        _pwd = _CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+        async with self.get_session() as session:
+            # Lock the intent row for the duration of this transaction
+            result = await session.execute(
+                select(EnrolmentIntent)
+                .where(EnrolmentIntent.intent_id == intent_id)
+                .with_for_update()
+            )
+            intent = result.scalar_one_or_none()
+            if not intent:
+                raise ValueError("Enrolment intent not found")
+
+            # Validate unused state
+            if intent.status != EnrolmentIntentStatus.APPROVED:
+                raise ValueError(
+                    f"Intent must be approved before claiming (current: {intent.status})"
+                )
+
+            # Validate expiry
+            if intent.expires_at and intent.expires_at < datetime.datetime.now(
+                datetime.timezone.utc
+            ):
+                raise ValueError("Enrolment intent has expired")
+
+            # Validate token hash
+            if not intent.claim_token_hash or not _pwd.verify(
+                claim_token, intent.claim_token_hash  # type: ignore[arg-type]
+            ):
+                raise ValueError("Invalid claim token")
+
+            # Validate expected device identity if set
+            if (
+                intent.expected_device_identity
+                and expected_device_identity != intent.expected_device_identity
+            ):
+                raise ValueError(
+                    f"Expected device identity '{intent.expected_device_identity}' "
+                    f"does not match provided '{expected_device_identity}'"
+                )
+
+            # Create the device
+            new_device_id = f"{device_type}-{_secrets.token_hex(4)}"
+            api_key = _secrets.token_urlsafe(32)
+            api_key_hash = _pwd.hash(api_key)
+
+            device = Device(
+                device_id=new_device_id,
+                name=device_name or new_device_id,
+                device_type=device_type,
+                site_id=intent.site_id,
+                api_key_hash=api_key_hash,
+                os_details=os_details,
+                enrollment_method=intent.enrolment_method,
+                lifecycle_state=LifecycleState.PENDING.value,
+            )
+            session.add(device)
+            await session.flush()
+
+            # Create lifecycle epoch
+            epoch_id = str(uuid.uuid4())
+            epoch = LifecycleEpoch(
+                epoch_id=epoch_id,
+                device_id=device.id,
+                site_id=intent.site_id,
+                tenant_id=intent.tenant_id,
+                claimed_at=datetime.datetime.now(datetime.timezone.utc),
+                claim_token_hash=intent.claim_token_hash,
+                enrolment_method=intent.enrolment_method,
+            )
+            session.add(epoch)
+            await session.flush()
+
+            # Link device to its current lifecycle epoch
+            device.lifecycle_epoch_id = epoch.id  # type: ignore[assignment]
+
+            # Mark intent as consumed
+            intent.status = EnrolmentIntentStatus.CONSUMED.value  # type: ignore[assignment]
+            intent.consumed_at = datetime.datetime.now(datetime.timezone.utc)  # type: ignore[assignment]
+
+            await session.flush()
+            await session.refresh(device)
+            await session.refresh(epoch)
+
+        return {
+            "device_id": new_device_id,
+            "api_key": api_key,
+            "site_id": intent.site_id,
+            "epoch_id": epoch_id,
+        }
+
+    async def regenerate_claim_token(
+        self,
+        intent_id: str,
+    ) -> Dict[str, str]:
+        """Regenerate a claim token for an existing pending enrolment intent.
+
+        Returns the new token and its expiry.  Only works on intents
+        that are still in PENDING or APPROVED status.
+        """
+        import secrets as _secrets
+
+        from passlib.context import CryptContext as _CryptContext
+
+        _pwd = _CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+        async with self.get_session() as session:
+            result = await session.execute(
+                select(EnrolmentIntent)
+                .where(EnrolmentIntent.intent_id == intent_id)
+                .with_for_update()
+            )
+            intent = result.scalar_one_or_none()
+            if not intent:
+                raise ValueError("Enrolment intent not found")
+
+            if intent.status not in (
+                EnrolmentIntentStatus.PENDING,
+                EnrolmentIntentStatus.APPROVED,
+            ):
+                raise ValueError(
+                    f"Cannot regenerate token for intent in status '{intent.status}'"
+                )
+
+            new_token = _secrets.token_urlsafe(32)
+            intent.claim_token_hash = _pwd.hash(new_token)  # type: ignore[assignment]
+            await session.flush()
+
+            return {"claim_token": new_token}
 
 
 # Global database service instance

--- a/backend/src/homepot/migrations/versions/20260719_add_lifecycle_epochs.py
+++ b/backend/src/homepot/migrations/versions/20260719_add_lifecycle_epochs.py
@@ -1,0 +1,57 @@
+"""Add LifecycleEpoch model and lifecycle_epoch_id to Device.
+
+Revision ID: 20260719_add_lifecycle_epochs
+Revises: 20260719_add_enrolment_intents
+Create Date: 2026-07-19
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260719_add_lifecycle_epochs"
+down_revision = "20260719_add_enrolment_intents"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create the lifecycle_epochs table and add lifecycle_epoch_id to devices."""
+    op.create_table(
+        "lifecycle_epochs",
+        sa.Column("id", sa.Integer(), primary_key=True, index=True),
+        sa.Column(
+            "epoch_id", sa.String(length=36), unique=True, index=True, nullable=False
+        ),
+        sa.Column(
+            "device_id",
+            sa.Integer(),
+            sa.ForeignKey("devices.id"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("site_id", sa.Integer(), sa.ForeignKey("sites.id"), nullable=False),
+        sa.Column(
+            "tenant_id", sa.Integer(), sa.ForeignKey("tenants.id"), nullable=True
+        ),
+        sa.Column("claimed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("ended_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("claim_token_hash", sa.String(length=255), nullable=True),
+        sa.Column("enrolment_method", sa.String(length=50), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True)),
+        sa.Column("updated_at", sa.DateTime(timezone=True)),
+    )
+    op.add_column(
+        "devices",
+        sa.Column(
+            "lifecycle_epoch_id",
+            sa.Integer(),
+            sa.ForeignKey("lifecycle_epochs.id"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop the lifecycle_epochs table and lifecycle_epoch_id from devices."""
+    op.drop_column("devices", "lifecycle_epoch_id")
+    op.drop_table("lifecycle_epochs")

--- a/backend/src/homepot/models.py
+++ b/backend/src/homepot/models.py
@@ -127,6 +127,7 @@ class EnrolmentIntentStatus(str, Enum):
     REJECTED = "rejected"
     CONSUMED = "consumed"
     EXPIRED = "expired"
+    REVOKED = "revoked"
 
 
 class CommandStatus(str, Enum):
@@ -280,6 +281,37 @@ class EnrolmentIntent(Base):
     creator = relationship("User", foreign_keys=[creator_id])
 
 
+class LifecycleEpoch(Base):
+    """A lifecycle epoch tracks a period in a device's operational life.
+
+    An epoch begins when a device is claimed (pre-provisioned flow) and
+    ends when the device is unpaired or retired.  Each claim creates a
+    new epoch; subsequent state transitions (active, suspended, etc.)
+    update the current epoch without ending it.
+    """
+
+    __tablename__ = "lifecycle_epochs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    epoch_id = Column(String(36), unique=True, index=True, nullable=False)
+    device_id = Column(Integer, ForeignKey("devices.id"), nullable=False, index=True)
+    site_id = Column(Integer, ForeignKey("sites.id"), nullable=False)
+    tenant_id = Column(Integer, ForeignKey("tenants.id"), nullable=True)
+    claimed_at = Column(DateTime(timezone=True), nullable=False)
+    ended_at = Column(DateTime(timezone=True), nullable=True)
+    claim_token_hash = Column(String(255), nullable=True)
+    enrolment_method = Column(String(50), nullable=False)
+    created_at = Column(DateTime(timezone=True), default=utc_now)
+    updated_at = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)
+
+    # Relationships
+    device = relationship(
+        "Device",
+        foreign_keys=[device_id],
+        back_populates="lifecycle_epochs",
+    )
+
+
 class Device(Base):
     """Device model representing end-points and OT devices."""
 
@@ -297,6 +329,11 @@ class Device(Base):
     site_id = Column(Integer, ForeignKey("sites.id"), nullable=False)
     enrollment_method = Column(String(50), nullable=True)  # EnrollmentMethod enum
     enrollment_token = Column(String(255), nullable=True)
+
+    # Current lifecycle epoch (set at claim time)
+    lifecycle_epoch_id = Column(
+        Integer, ForeignKey("lifecycle_epochs.id"), nullable=True
+    )
 
     # Device specifications
     ip_address = Column(String(45), nullable=True)  # IPv4/IPv6
@@ -406,6 +443,14 @@ class Device(Base):
 
     state_history = relationship(
         "DeviceStateHistory",
+        back_populates="device",
+        lazy="select",
+        cascade="all, delete-orphan",
+    )
+
+    lifecycle_epochs = relationship(
+        "LifecycleEpoch",
+        foreign_keys="LifecycleEpoch.device_id",
         back_populates="device",
         lazy="select",
         cascade="all, delete-orphan",

--- a/docs/device-lifecycle-and-ownership.md
+++ b/docs/device-lifecycle-and-ownership.md
@@ -297,5 +297,22 @@ Knowing a Site ID must not be sufficient to enrol or administer a device.
 - Device credentials only operate on that same device.
 - Unauthenticated provisioning and unpairing are rejected.
 
+PR 5: Implement pre-provisioned claiming
+**Dashboard:**
+- Administrator creates a pending device/enrolment intent.
+- Display claim status and expiry.
+- Allow token revocation and regeneration.
+**User App:**
+- Accept the claim token.
+- Present stable device evidence.
+- Securely receive and store credentials.
+Backend:
+- Validate token hash, scope, expiry, and unused state.
+- Consume the token atomically.
+- Create the lifecycle epoch.
+- Issue the API key only once.
+- Reject duplicate and concurrent claims.
+
+
 
 

--- a/frontend/src/pages/EnrolmentIntents/EnrolmentIntentsList.jsx
+++ b/frontend/src/pages/EnrolmentIntents/EnrolmentIntentsList.jsx
@@ -1,0 +1,320 @@
+import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import api from '../../services/api';
+
+export default function EnrolmentIntentsList() {
+  const { id: siteId } = useParams();
+  const navigate = useNavigate();
+
+  const [intents, setIntents] = useState([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [statusFilter, setStatusFilter] = useState('');
+  const [showCreate, setShowCreate] = useState(false);
+  const [createForm, setCreateForm] = useState({
+    expected_device_identity: '',
+    expires_in_hours: 48,
+    idempotency_key: '',
+  });
+  const [createResult, setCreateResult] = useState(null);
+  const [regenerating, setRegenerating] = useState(null);
+
+  const fetchIntents = async () => {
+    try {
+      setLoading(true);
+      const data = await api.enrolmentIntents.list(
+        siteId,
+        statusFilter || null,
+        100,
+        0
+      );
+      setIntents(data.intents || []);
+      setTotal(data.total || 0);
+    } catch (err) {
+      console.error('Failed to load enrolment intents:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchIntents();
+  }, [siteId, statusFilter]);
+
+  const statusColors = {
+    pending: 'bg-yellow-100 text-yellow-800',
+    approved: 'bg-green-100 text-green-800',
+    rejected: 'bg-red-100 text-red-800',
+    consumed: 'bg-blue-100 text-blue-800',
+    expired: 'bg-gray-100 text-gray-800',
+    revoked: 'bg-purple-100 text-purple-800',
+  };
+
+  const handleCreate = async (e) => {
+    e.preventDefault();
+    try {
+      const payload = {
+        enrolment_method: 'pre-provisioned',
+        expires_in_hours: createForm.expires_in_hours,
+      };
+      if (createForm.expected_device_identity) {
+        payload.expected_device_identity = createForm.expected_device_identity;
+      }
+      if (createForm.idempotency_key) {
+        payload.idempotency_key = createForm.idempotency_key;
+      }
+      const result = await api.enrolmentIntents.create(siteId, payload);
+      setCreateResult(result);
+      setShowCreate(false);
+      setCreateForm({ expected_device_identity: '', expires_in_hours: 48, idempotency_key: '' });
+      fetchIntents();
+    } catch (err) {
+      console.error('Failed to create enrolment intent:', err);
+      alert('Failed to create enrolment intent');
+    }
+  };
+
+  const handleRevoke = async (intentId) => {
+    if (!window.confirm('Revoke this enrolment intent? The current token will no longer work.')) return;
+    try {
+      await api.enrolmentIntents.updateStatus(siteId, intentId, { status: 'revoked' });
+      fetchIntents();
+    } catch (err) {
+      console.error('Failed to revoke intent:', err);
+    }
+  };
+
+  const handleRegenerate = async (intentId) => {
+    try {
+      setRegenerating(intentId);
+      const result = await api.enrolmentIntents.regenerateToken(siteId, intentId);
+      alert(`New claim token: ${result.claim_token}\n\nSave this token securely — it will not be shown again.`);
+      fetchIntents();
+    } catch (err) {
+      console.error('Failed to regenerate token:', err);
+      alert('Failed to regenerate token');
+    } finally {
+      setRegenerating(null);
+    }
+  };
+
+  const handleApprove = async (intentId) => {
+    try {
+      await api.enrolmentIntents.updateStatus(siteId, intentId, { status: 'approved' });
+      fetchIntents();
+    } catch (err) {
+      console.error('Failed to approve intent:', err);
+    }
+  };
+
+  const handleReject = async (intentId) => {
+    try {
+      await api.enrolmentIntents.updateStatus(siteId, intentId, { status: 'rejected' });
+      fetchIntents();
+    } catch (err) {
+      console.error('Failed to reject intent:', err);
+    }
+  };
+
+  return (
+    <div className="p-6">
+      <div className="flex justify-between items-center mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">Enrolment Intents</h1>
+          <p className="text-gray-600 text-sm">
+            Manage pre-provisioned device enrolment intents for this site
+          </p>
+        </div>
+        <div className="flex gap-3">
+          <button
+            onClick={() => navigate(`/sites/${siteId}`)}
+            className="px-4 py-2 border border-gray-300 rounded-lg text-sm hover:bg-gray-50"
+          >
+            Back to Site
+          </button>
+          <button
+            onClick={() => { setShowCreate(!showCreate); setCreateResult(null); }}
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm hover:bg-blue-700"
+          >
+            {showCreate ? 'Cancel' : 'Create Intent'}
+          </button>
+        </div>
+      </div>
+
+      {showCreate && (
+        <div className="mb-6 p-4 border border-gray-200 rounded-lg bg-gray-50">
+          <h3 className="font-semibold mb-3">Create New Enrolment Intent</h3>
+          <form onSubmit={handleCreate} className="space-y-3">
+            <div>
+              <label className="block text-sm font-medium text-gray-700">
+                Expected Device Identity (optional)
+              </label>
+              <input
+                type="text"
+                value={createForm.expected_device_identity}
+                onChange={(e) => setCreateForm({ ...createForm, expected_device_identity: e.target.value })}
+                placeholder="e.g. serial number or hardware ID"
+                className="mt-1 block w-full border border-gray-300 rounded-md p-2 text-sm"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700">
+                Expires In (hours)
+              </label>
+              <input
+                type="number"
+                value={createForm.expires_in_hours}
+                onChange={(e) => setCreateForm({ ...createForm, expires_in_hours: parseInt(e.target.value) || 48 })}
+                min={1}
+                max={8760}
+                className="mt-1 block w-full border border-gray-300 rounded-md p-2 text-sm"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700">
+                Idempotency Key (optional)
+              </label>
+              <input
+                type="text"
+                value={createForm.idempotency_key}
+                onChange={(e) => setCreateForm({ ...createForm, idempotency_key: e.target.value })}
+                placeholder="e.g. req-abc-123"
+                className="mt-1 block w-full border border-gray-300 rounded-md p-2 text-sm"
+              />
+            </div>
+            <button
+              type="submit"
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm hover:bg-blue-700"
+            >
+              Create Intent
+            </button>
+          </form>
+        </div>
+      )}
+
+      {createResult && (
+        <div className="mb-6 p-4 border border-yellow-300 rounded-lg bg-yellow-50">
+          <h3 className="font-semibold text-yellow-800 mb-2">Intent Created!</h3>
+          <p className="text-sm text-yellow-700 mb-1">
+            <strong>Claim Token:</strong>{' '}
+            <span className="font-mono bg-yellow-100 px-2 py-1 rounded">
+              {createResult.claim_token}
+            </span>
+          </p>
+          <p className="text-xs text-yellow-600">
+            Save this token securely. It will not be shown again.
+          </p>
+        </div>
+      )}
+
+      <div className="mb-4">
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+          className="border border-gray-300 rounded-md p-2 text-sm"
+        >
+          <option value="">All Statuses</option>
+          <option value="pending">Pending</option>
+          <option value="approved">Approved</option>
+          <option value="rejected">Rejected</option>
+          <option value="consumed">Consumed</option>
+          <option value="expired">Expired</option>
+          <option value="revoked">Revoked</option>
+        </select>
+        <span className="ml-3 text-sm text-gray-500">{total} total</span>
+      </div>
+
+      {loading ? (
+        <div className="text-center py-10 text-gray-500">Loading...</div>
+      ) : intents.length === 0 ? (
+        <div className="text-center py-10 text-gray-500">
+          No enrolment intents found. Create one to get started.
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full bg-white border border-gray-200 rounded-lg">
+            <thead>
+              <tr className="bg-gray-50 border-b">
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Intent ID</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Expires</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Device Identity</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Created</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {intents.map((intent) => (
+                <tr key={intent.id} className="border-b hover:bg-gray-50">
+                  <td className="px-4 py-3 text-sm font-mono">{intent.intent_id}</td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={`px-2 py-1 rounded-full text-xs font-medium ${
+                        statusColors[intent.status] || 'bg-gray-100 text-gray-800'
+                      }`}
+                    >
+                      {intent.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-sm">
+                    {intent.expires_at ? (
+                      <span className={new Date(intent.expires_at) < new Date() ? 'text-red-600' : ''}>
+                        {new Date(intent.expires_at).toLocaleString()}
+                      </span>
+                    ) : '-'}
+                  </td>
+                  <td className="px-4 py-3 text-sm">
+                    {intent.expected_device_identity || '-'}
+                  </td>
+                  <td className="px-4 py-3 text-sm">
+                    {intent.created_at ? new Date(intent.created_at).toLocaleString() : '-'}
+                  </td>
+                  <td className="px-4 py-3 text-sm">
+                    <div className="flex gap-2">
+                      {intent.status === 'pending' && (
+                        <>
+                          <button
+                            onClick={() => handleApprove(intent.intent_id)}
+                            className="px-3 py-1 bg-green-600 text-white rounded text-xs hover:bg-green-700"
+                          >
+                            Approve
+                          </button>
+                          <button
+                            onClick={() => handleReject(intent.intent_id)}
+                            className="px-3 py-1 bg-red-600 text-white rounded text-xs hover:bg-red-700"
+                          >
+                            Reject
+                          </button>
+                        </>
+                      )}
+                      {(intent.status === 'pending' || intent.status === 'approved') && (
+                        <>
+                          <button
+                            onClick={() => handleRegenerate(intent.intent_id)}
+                            disabled={regenerating === intent.intent_id}
+                            className="px-3 py-1 bg-yellow-600 text-white rounded text-xs hover:bg-yellow-700 disabled:opacity-50"
+                          >
+                            {regenerating === intent.intent_id ? '...' : 'Regen Token'}
+                          </button>
+                          <button
+                            onClick={() => handleRevoke(intent.intent_id)}
+                            className="px-3 py-1 bg-purple-600 text-white rounded text-xs hover:bg-purple-700"
+                          >
+                            Revoke
+                          </button>
+                        </>
+                      )}
+                      {intent.status === 'consumed' && (
+                        <span className="text-xs text-gray-400 italic">Consumed</span>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/EnrolmentIntents/EnrolmentIntentsList.jsx
+++ b/frontend/src/pages/EnrolmentIntents/EnrolmentIntentsList.jsx
@@ -22,12 +22,7 @@ export default function EnrolmentIntentsList() {
   const fetchIntents = async () => {
     try {
       setLoading(true);
-      const data = await api.enrolmentIntents.list(
-        siteId,
-        statusFilter || null,
-        100,
-        0
-      );
+      const data = await api.enrolmentIntents.list(siteId, statusFilter || null, 100, 0);
       setIntents(data.intents || []);
       setTotal(data.total || 0);
     } catch (err) {
@@ -75,7 +70,8 @@ export default function EnrolmentIntentsList() {
   };
 
   const handleRevoke = async (intentId) => {
-    if (!window.confirm('Revoke this enrolment intent? The current token will no longer work.')) return;
+    if (!window.confirm('Revoke this enrolment intent? The current token will no longer work.'))
+      return;
     try {
       await api.enrolmentIntents.updateStatus(siteId, intentId, { status: 'revoked' });
       fetchIntents();
@@ -88,7 +84,9 @@ export default function EnrolmentIntentsList() {
     try {
       setRegenerating(intentId);
       const result = await api.enrolmentIntents.regenerateToken(siteId, intentId);
-      alert(`New claim token: ${result.claim_token}\n\nSave this token securely — it will not be shown again.`);
+      alert(
+        `New claim token: ${result.claim_token}\n\nSave this token securely — it will not be shown again.`
+      );
       fetchIntents();
     } catch (err) {
       console.error('Failed to regenerate token:', err);
@@ -133,7 +131,10 @@ export default function EnrolmentIntentsList() {
             Back to Site
           </button>
           <button
-            onClick={() => { setShowCreate(!showCreate); setCreateResult(null); }}
+            onClick={() => {
+              setShowCreate(!showCreate);
+              setCreateResult(null);
+            }}
             className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm hover:bg-blue-700"
           >
             {showCreate ? 'Cancel' : 'Create Intent'}
@@ -152,19 +153,21 @@ export default function EnrolmentIntentsList() {
               <input
                 type="text"
                 value={createForm.expected_device_identity}
-                onChange={(e) => setCreateForm({ ...createForm, expected_device_identity: e.target.value })}
+                onChange={(e) =>
+                  setCreateForm({ ...createForm, expected_device_identity: e.target.value })
+                }
                 placeholder="e.g. serial number or hardware ID"
                 className="mt-1 block w-full border border-gray-300 rounded-md p-2 text-sm"
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700">
-                Expires In (hours)
-              </label>
+              <label className="block text-sm font-medium text-gray-700">Expires In (hours)</label>
               <input
                 type="number"
                 value={createForm.expires_in_hours}
-                onChange={(e) => setCreateForm({ ...createForm, expires_in_hours: parseInt(e.target.value) || 48 })}
+                onChange={(e) =>
+                  setCreateForm({ ...createForm, expires_in_hours: parseInt(e.target.value) || 48 })
+                }
                 min={1}
                 max={8760}
                 className="mt-1 block w-full border border-gray-300 rounded-md p-2 text-sm"
@@ -235,12 +238,24 @@ export default function EnrolmentIntentsList() {
           <table className="min-w-full bg-white border border-gray-200 rounded-lg">
             <thead>
               <tr className="bg-gray-50 border-b">
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Intent ID</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Expires</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Device Identity</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Created</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  Intent ID
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  Status
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  Expires
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  Device Identity
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  Created
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  Actions
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -258,14 +273,16 @@ export default function EnrolmentIntentsList() {
                   </td>
                   <td className="px-4 py-3 text-sm">
                     {intent.expires_at ? (
-                      <span className={new Date(intent.expires_at) < new Date() ? 'text-red-600' : ''}>
+                      <span
+                        className={new Date(intent.expires_at) < new Date() ? 'text-red-600' : ''}
+                      >
                         {new Date(intent.expires_at).toLocaleString()}
                       </span>
-                    ) : '-'}
+                    ) : (
+                      '-'
+                    )}
                   </td>
-                  <td className="px-4 py-3 text-sm">
-                    {intent.expected_device_identity || '-'}
-                  </td>
+                  <td className="px-4 py-3 text-sm">{intent.expected_device_identity || '-'}</td>
                   <td className="px-4 py-3 text-sm">
                     {intent.created_at ? new Date(intent.created_at).toLocaleString() : '-'}
                   </td>

--- a/frontend/src/pages/Sites/SiteDetail.jsx
+++ b/frontend/src/pages/Sites/SiteDetail.jsx
@@ -178,6 +178,12 @@ export default function SiteDetail() {
                 {site.is_monitored ? 'Monitored' : 'Add to Dashboard'}
               </Button>
               <Button
+                onClick={() => navigate(`/sites/${site.site_id || site.id}/enrolment-intents`)}
+                className="bg-transparent border text-blue-400 border-blue-400 hover:bg-blue-400/10"
+              >
+                Enrolment Intents
+              </Button>
+              <Button
                 onClick={() => navigate('/dashboard')}
                 className="bg-transparent border text-gray-400 border-gray-400 hover:bg-gray-400/10"
               >

--- a/frontend/src/routes/index.jsx
+++ b/frontend/src/routes/index.jsx
@@ -29,6 +29,7 @@ const UserActivity = lazy(() => import('../pages/UserActivity'));
 
 const Agents = lazy(() => import('../pages/Agents'));
 const DataCollection = lazy(() => import('../pages/DataCollection'));
+const EnrolmentIntentsList = lazy(() => import('../pages/EnrolmentIntents/EnrolmentIntentsList'));
 
 export default function RoutesIndex() {
   return (
@@ -61,6 +62,7 @@ export default function RoutesIndex() {
           <Route path="sites/new" element={<SiteForm />} />
           <Route path="sites/:id/edit" element={<SiteForm />} />
           <Route path="sites/:id" element={<SiteDetail />} />
+          <Route path="sites/:id/enrolment-intents" element={<EnrolmentIntentsList />} />
           <Route path="sites" element={<SitesList />} />
           <Route path="device/:id" element={<Devices />} />
           <Route path="device/:id/settings" element={<DeviceSettings />} />

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -614,6 +614,49 @@ const api = {
     },
   },
 
+  // ==================== Enrolment Intents ====================
+  enrolmentIntents: {
+    create: async (siteId, payload) => {
+      const response = await apiClient.post(
+        `/sites/${siteId}/enrolment-intents`,
+        payload
+      );
+      return response.data;
+    },
+
+    list: async (siteId, status = null, limit = 50, offset = 0) => {
+      const params = { limit, offset };
+      if (status) params.status = status;
+      const response = await apiClient.get(
+        `/sites/${siteId}/enrolment-intents`,
+        { params }
+      );
+      return response.data;
+    },
+
+    get: async (siteId, intentId) => {
+      const response = await apiClient.get(
+        `/sites/${siteId}/enrolment-intents/${intentId}`
+      );
+      return response.data;
+    },
+
+    updateStatus: async (siteId, intentId, payload) => {
+      const response = await apiClient.put(
+        `/sites/${siteId}/enrolment-intents/${intentId}`,
+        payload
+      );
+      return response.data;
+    },
+
+    regenerateToken: async (siteId, intentId) => {
+      const response = await apiClient.post(
+        `/sites/${siteId}/enrolment-intents/${intentId}/regenerate-token`
+      );
+      return response.data;
+    },
+  },
+
   ai: {
     /**
      * Query the AI with a natural language question

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -617,27 +617,19 @@ const api = {
   // ==================== Enrolment Intents ====================
   enrolmentIntents: {
     create: async (siteId, payload) => {
-      const response = await apiClient.post(
-        `/sites/${siteId}/enrolment-intents`,
-        payload
-      );
+      const response = await apiClient.post(`/sites/${siteId}/enrolment-intents`, payload);
       return response.data;
     },
 
     list: async (siteId, status = null, limit = 50, offset = 0) => {
       const params = { limit, offset };
       if (status) params.status = status;
-      const response = await apiClient.get(
-        `/sites/${siteId}/enrolment-intents`,
-        { params }
-      );
+      const response = await apiClient.get(`/sites/${siteId}/enrolment-intents`, { params });
       return response.data;
     },
 
     get: async (siteId, intentId) => {
-      const response = await apiClient.get(
-        `/sites/${siteId}/enrolment-intents/${intentId}`
-      );
+      const response = await apiClient.get(`/sites/${siteId}/enrolment-intents/${intentId}`);
       return response.data;
     },
 

--- a/user_app/src/App.tsx
+++ b/user_app/src/App.tsx
@@ -3,10 +3,12 @@ import SetupWizard from './views/SetupWizard'
 import HomeDashboard from './views/HomeDashboard'
 import Permissions from './views/Permissions'
 import DeviceInfo from './views/DeviceInfo'
+import ClaimDevice from './views/ClaimDevice'
 
 function AppContent() {
   const { currentView } = useApp()
 
+  if (currentView === 'claim') return <ClaimDevice />
   if (currentView === 'setup') return <SetupWizard />
   if (currentView === 'home') return <HomeDashboard />
   if (currentView === 'permissions') return <Permissions />

--- a/user_app/src/context/AppContext.tsx
+++ b/user_app/src/context/AppContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useState } from 'react'
 import type { ReactNode } from 'react'
 
-type View = 'setup' | 'home' | 'permissions' | 'settings'
+type View = 'setup' | 'home' | 'permissions' | 'settings' | 'claim'
 
 interface DeviceInfo {
   deviceId: string

--- a/user_app/src/views/ClaimDevice.tsx
+++ b/user_app/src/views/ClaimDevice.tsx
@@ -1,0 +1,219 @@
+import React, { useState } from 'react';
+import { useApp } from '../context/AppContext';
+import { apiBaseUrl } from '../config/api';
+
+export default function ClaimDevice() {
+  const { setCurrentView, setDeviceInfo, setIsProvisioned } = useApp();
+  const [step, setStep] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [form, setForm] = useState({
+    intentId: '',
+    claimToken: '',
+    deviceName: '',
+    deviceType: 'pos_terminal',
+    deviceOs: '',
+  });
+
+  const deviceTypes = [
+    'pos_terminal',
+    'virtual_terminal',
+    'kiosk',
+    'tablet',
+    'mobile_scanner',
+    'printer',
+    'scanner',
+    'signage',
+  ];
+
+  const osOptions = [
+    'Android',
+    'iOS',
+    'Windows',
+    'Linux',
+    'macOS',
+    'Other',
+  ];
+
+  const handleChange = (field, value) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+
+    try {
+      const deviceOs = form.deviceOs || navigator.platform || 'Unknown';
+      const deviceName = form.deviceName || `Device-${Math.random().toString(36).slice(2, 8)}`;
+
+      const response = await fetch(
+        `${apiBaseUrl}/enrolment-intents/${form.intentId}/claim`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            claim_token: form.claimToken,
+            device_name: deviceName,
+            device_type: form.deviceType,
+            os_details: deviceOs,
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({}));
+        throw new Error(errData.detail || `Claim failed (${response.status})`);
+      }
+
+      const result = await response.json();
+
+      localStorage.setItem('homepot_token', result.device_id);
+      localStorage.setItem('homepot_device_id', result.device_id);
+      localStorage.setItem('homepot_device_name', deviceName);
+      localStorage.setItem('homepot_device_type', form.deviceType);
+      localStorage.setItem('homepot_device_os', deviceOs);
+      localStorage.setItem('homepot_enrollment_method', 'pre-provisioned');
+      sessionStorage.setItem('homepot_api_key', result.api_key);
+
+      setDeviceInfo({
+        deviceId: result.device_id,
+        siteId: result.site_id,
+        deviceName,
+        token: result.api_key,
+      });
+      setIsProvisioned(true);
+      setCurrentView('home');
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleBackToSetup = () => {
+    setCurrentView('setup');
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-900 to-gray-800 text-white flex flex-col">
+      <div className="flex-1 p-6 flex flex-col justify-center max-w-md mx-auto w-full">
+        <div className="text-center mb-8">
+          <div className="text-5xl mb-3">🔗</div>
+          <h1 className="text-2xl font-bold">Claim Device</h1>
+          <p className="text-gray-400 mt-2">
+            Enter the claim token provided by your administrator
+          </p>
+        </div>
+
+        {error && (
+          <div className="mb-4 p-3 bg-red-900/50 border border-red-700 rounded-lg text-sm text-red-200">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">
+              Intent ID *
+            </label>
+            <input
+              type="text"
+              value={form.intentId}
+              onChange={(e) => handleChange('intentId', e.target.value)}
+              placeholder="Intent ID from administrator"
+              required
+              disabled={loading}
+              className="w-full px-4 py-3 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">
+              Claim Token *
+            </label>
+            <input
+              type="text"
+              value={form.claimToken}
+              onChange={(e) => handleChange('claimToken', e.target.value)}
+              placeholder="Claim token from administrator"
+              required
+              disabled={loading}
+              className="w-full px-4 py-3 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">
+              Device Name
+            </label>
+            <input
+              type="text"
+              value={form.deviceName}
+              onChange={(e) => handleChange('deviceName', e.target.value)}
+              placeholder="e.g. Kitchen POS A"
+              disabled={loading}
+              className="w-full px-4 py-3 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">
+              Device Type *
+            </label>
+            <select
+              value={form.deviceType}
+              onChange={(e) => handleChange('deviceType', e.target.value)}
+              required
+              disabled={loading}
+              className="w-full px-4 py-3 bg-gray-700 border border-gray-600 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {deviceTypes.map((dt) => (
+                <option key={dt} value={dt}>
+                  {dt.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">
+              Operating System
+            </label>
+            <select
+              value={form.deviceOs}
+              onChange={(e) => handleChange('deviceOs', e.target.value)}
+              disabled={loading}
+              className="w-full px-4 py-3 bg-gray-700 border border-gray-600 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">Auto-detect</option>
+              {osOptions.map((os) => (
+                <option key={os} value={os}>
+                  {os}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading || !form.intentId || !form.claimToken}
+            className="w-full py-3 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 disabled:cursor-not-allowed rounded-lg font-semibold transition-colors"
+          >
+            {loading ? 'Claiming...' : 'Claim Device'}
+          </button>
+        </form>
+
+        <div className="mt-6 text-center">
+          <button
+            onClick={handleBackToSetup}
+            disabled={loading}
+            className="text-gray-400 hover:text-white text-sm underline disabled:opacity-50"
+          >
+            Back to setup options
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/user_app/src/views/SetupWizard.tsx
+++ b/user_app/src/views/SetupWizard.tsx
@@ -289,6 +289,7 @@ function Step3({ siteId, deviceName, deviceType, deviceOs, onBack, onComplete }:
 
 export default function SetupWizard() {
   const { setCurrentView, setIsProvisioned } = useApp()
+  const [showClaimOption, setShowClaimOption] = useState(false)
   const [step, setStep] = useState(0)
   const [siteId, setSiteId] = useState('')
   const [deviceName, setDeviceName] = useState('')
@@ -323,6 +324,16 @@ export default function SetupWizard() {
         <StepIndicator current={step} />
 
         <div className="border-t border-slate-700 pt-4">
+          <div className="mb-4">
+            <button
+              onClick={() => setCurrentView('claim')}
+              className="w-full py-2 bg-blue-600 hover:bg-blue-700 rounded-lg text-sm font-medium transition-colors"
+            >
+              Have a claim token? Click here to claim
+            </button>
+            <p className="text-center text-slate-500 text-xs mt-2">or set up a new device below</p>
+            <div className="mt-3 mb-2 border-t border-slate-700" />
+          </div>
           {step === 0 && (
             <Step1
               siteId={siteId}


### PR DESCRIPTION
## Summary

Implements the pre-provisioned device claiming flow — admins create enrolment intents with scoped claim tokens, and device users securely claim them with stable device evidence.

## Backend Changes

- **LifecycleEpoch model** — tracks each claim epoch with claimed_at, ended_at, enrolment_method, claim_token_hash
- **Device.lifecycle_epoch_id** — FK linking to the current lifecycle epoch
- **Atomic claim** — `claim_enrolment_intent_atomic()` uses `select_for_update()` row-level locking to prevent duplicate and concurrent claims
- **Token validation** — validates hash, expiry, unused/approved state, and expected_device_identity (stable device evidence)
- **Token regeneration** — new `POST .../regenerate-token` endpoint for admins
- **REVOKED status** — added to `EnrolmentIntentStatus` for token revocation
- **os_details** — passed through to device creation on claim

## Dashboard (Admin)

- **EnrolmentIntentsList page** — full table view at `/sites/:id/enrolment-intents` with:
  - Create new intent form (expected_device_identity, expiry, idempotency key)
  - Status badges with colour coding
  - Approve / Reject / Revoke / Regenerate Token actions
  - Status filter dropdown
- **API client** — all enrolment intent operations in `api.enrolmentIntents.*`
- **SiteDetail link** — button to navigate to enrolment intents

## User App

- **ClaimDevice view** — accepts intent ID + claim token, presents device evidence (type, OS)
- **Secure credential storage** — api_key in sessionStorage, device info in localStorage
- **SetupWizard integration** — \"Have a claim token?\" button navigates to claim flow
- **'claim' view type** — added to AppContext

## Migration

- `20260719_add_lifecycle_epochs` — creates `lifecycle_epochs` table and adds `lifecycle_epoch_id` to `devices`
