### PR TITLE
feat: Add assignment and lifecycle history

### DIFF
--- a/backend/src/homepot/migrations/versions/20260720_add_device_assignments_events.py
+++ b/backend/src/homepot/migrations/versions/20260720_add_device_assignments_events.py
@@ -26,8 +26,12 @@ def upgrade() -> None:
         sa.Column("assignment_reason", sa.String(100), nullable=True),
         sa.Column("assigned_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("unassigned_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("is_current", sa.Boolean(), nullable=False, server_default=sa.text("0")),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column(
+            "is_current", sa.Boolean(), nullable=False, server_default=sa.text("0")
+        ),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now()
+        ),
         sa.ForeignKeyConstraint(
             ["device_id"],
             ["devices.id"],

--- a/backend/src/homepot/migrations/versions/20260720_add_device_assignments_events.py
+++ b/backend/src/homepot/migrations/versions/20260720_add_device_assignments_events.py
@@ -1,0 +1,145 @@
+"""Add DeviceAssignment and DeviceLifecycleEvent models.
+
+Revision ID: 20260720_add_device_assignments_events
+Revises: 20260719_add_device_credentials
+Create Date: 2026-07-20
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260720_add_device_assignments_events"
+down_revision = "20260719_add_device_credentials"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create device_assignments and device_lifecycle_events tables."""
+    op.create_table(
+        "device_assignments",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("assignment_id", sa.String(36), nullable=False),
+        sa.Column("device_id", sa.Integer(), nullable=False),
+        sa.Column("site_id", sa.Integer(), nullable=False),
+        sa.Column("tenant_id", sa.Integer(), nullable=True),
+        sa.Column("assignment_reason", sa.String(100), nullable=True),
+        sa.Column("assigned_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("unassigned_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("is_current", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(
+            ["device_id"],
+            ["devices.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["site_id"],
+            ["sites.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["tenant_id"],
+            ["tenants.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_device_assignments_assignment_id"),
+        "device_assignments",
+        ["assignment_id"],
+        unique=True,
+    )
+    op.create_index(
+        op.f("ix_device_assignments_device_id"),
+        "device_assignments",
+        ["device_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "device_lifecycle_events",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("event_id", sa.String(36), nullable=False),
+        sa.Column("device_id", sa.Integer(), nullable=False),
+        sa.Column("epoch_id", sa.Integer(), nullable=True),
+        sa.Column("from_state", sa.String(20), nullable=True),
+        sa.Column("to_state", sa.String(20), nullable=True),
+        sa.Column("triggered_by_user_id", sa.Integer(), nullable=True),
+        sa.Column("triggered_by_device_id", sa.Integer(), nullable=True),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column("idempotency_key", sa.String(100), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now()
+        ),
+        sa.ForeignKeyConstraint(
+            ["device_id"],
+            ["devices.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["epoch_id"],
+            ["lifecycle_epochs.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["triggered_by_user_id"],
+            ["users.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["triggered_by_device_id"],
+            ["devices.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_device_lifecycle_events_device_id"),
+        "device_lifecycle_events",
+        ["device_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_device_lifecycle_events_epoch_id"),
+        "device_lifecycle_events",
+        ["epoch_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_device_lifecycle_events_event_id"),
+        "device_lifecycle_events",
+        ["event_id"],
+        unique=True,
+    )
+    op.create_index(
+        op.f("ix_device_lifecycle_events_idempotency_key"),
+        "device_lifecycle_events",
+        ["idempotency_key"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop device_assignments and device_lifecycle_events tables."""
+    op.drop_index(
+        op.f("ix_device_lifecycle_events_idempotency_key"),
+        table_name="device_lifecycle_events",
+    )
+    op.drop_index(
+        op.f("ix_device_lifecycle_events_event_id"),
+        table_name="device_lifecycle_events",
+    )
+    op.drop_index(
+        op.f("ix_device_lifecycle_events_epoch_id"),
+        table_name="device_lifecycle_events",
+    )
+    op.drop_index(
+        op.f("ix_device_lifecycle_events_device_id"),
+        table_name="device_lifecycle_events",
+    )
+    op.drop_table("device_lifecycle_events")
+
+    op.drop_index(
+        op.f("ix_device_assignments_device_id"),
+        table_name="device_assignments",
+    )
+    op.drop_index(
+        op.f("ix_device_assignments_assignment_id"),
+        table_name="device_assignments",
+    )
+    op.drop_table("device_assignments")

--- a/backend/src/homepot/models.py
+++ b/backend/src/homepot/models.py
@@ -486,6 +486,21 @@ class Device(Base):
         cascade="all, delete-orphan",
     )
 
+    assignments = relationship(
+        "DeviceAssignment",
+        back_populates="device",
+        lazy="select",
+        cascade="all, delete-orphan",
+    )
+
+    lifecycle_events = relationship(
+        "DeviceLifecycleEvent",
+        foreign_keys="DeviceLifecycleEvent.device_id",
+        back_populates="device",
+        lazy="select",
+        cascade="all, delete-orphan",
+    )
+
 
 class DeviceCommand(Base):
     """Command queue for specific devices."""
@@ -631,6 +646,79 @@ class AuditLog(Base):
     # Relationships
     job = relationship("Job", back_populates="logs")
     device = relationship("Device", back_populates="audit_logs")
+
+
+class DeviceAssignment(Base):
+    """Assignment history: records which site a device belonged to.
+
+    Each row represents one assignment period.  Only one row per device
+    may have ``is_current = True`` at any time.  Historical rows are
+    retained so that old telemetry retains its ownership scope.
+    """
+
+    __tablename__ = "device_assignments"
+
+    id = Column(Integer, primary_key=True, index=True)
+    assignment_id = Column(String(36), unique=True, index=True, nullable=False)
+    device_id = Column(Integer, ForeignKey("devices.id"), nullable=False, index=True)
+    site_id = Column(Integer, ForeignKey("sites.id"), nullable=False)
+    tenant_id = Column(Integer, ForeignKey("tenants.id"), nullable=True)
+
+    assignment_reason = Column(
+        String(100), nullable=True
+    )  # e.g. "initial_enrolment", "transfer", "reassignment"
+    assigned_at = Column(DateTime(timezone=True), nullable=False)
+    unassigned_at = Column(DateTime(timezone=True), nullable=True)
+
+    is_current = Column(Boolean, default=False, nullable=False)
+    created_at = Column(DateTime(timezone=True), default=utc_now)
+
+    # Relationships
+    device = relationship("Device", back_populates="assignments")
+    site = relationship("Site")
+    tenant = relationship("Tenant")
+
+
+class DeviceLifecycleEvent(Base):
+    """A single lifecycle-state transition for a device.
+
+    Every transition (pending → active, active → suspended,
+    active → unpaired, etc.) produces one event.  This provides
+    an auditable, ordered history independent of the AuditLog
+    (which is broader in scope).
+    """
+
+    __tablename__ = "device_lifecycle_events"
+
+    id = Column(Integer, primary_key=True, index=True)
+    event_id = Column(String(36), unique=True, index=True, nullable=False)
+    device_id = Column(Integer, ForeignKey("devices.id"), nullable=False, index=True)
+    epoch_id = Column(
+        Integer, ForeignKey("lifecycle_epochs.id"), nullable=True, index=True
+    )
+
+    from_state = Column(String(20), nullable=True)  # previous lifecycle_state
+    to_state = Column(String(20), nullable=True)  # new lifecycle_state
+
+    triggered_by_user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    triggered_by_device_id = Column(Integer, ForeignKey("devices.id"), nullable=True)
+
+    reason = Column(Text, nullable=True)
+    idempotency_key = Column(String(100), nullable=True, index=True)
+    created_at = Column(DateTime(timezone=True), default=utc_now)
+
+    # Relationships
+    device = relationship(
+        "Device",
+        foreign_keys=[device_id],
+        back_populates="lifecycle_events",
+    )
+    triggered_by_device = relationship(
+        "Device",
+        foreign_keys=[triggered_by_device_id],
+    )
+    triggered_by_user = relationship("User")
+    epoch = relationship("LifecycleEpoch")
 
 
 # Database engine and session configuration

--- a/docs/device-lifecycle-and-ownership.md
+++ b/docs/device-lifecycle-and-ownership.md
@@ -360,3 +360,10 @@ The User App should:
 - show “server revocation pending” after a local-only reset;
 - prevent silent success on failed requests.
 
+PR 10: Add assignment and lifecycle history
+Create explicit records such as:
+- DeviceAssignment
+- DeviceLifecycleEpoch
+- DeviceLifecycleEvent
+This provides historical ownership without rewriting old telemetry when a device moves.
+


### PR DESCRIPTION
## Summary

Creates explicit `DeviceAssignment` and `DeviceLifecycleEvent` models to provide historical ownership and lifecycle tracking without rewriting old telemetry when a device moves.

### New models

#### `DeviceAssignment`
Records which site a device was assigned to during each assignment period.
- `assignment_id` (UUID, unique) — stable identifier for each assignment period
- `device_id` (FK → devices.id)
- `site_id` (FK → sites.id)
- `tenant_id` (FK → tenants.id, nullable)
- `assignment_reason` — e.g. "initial_enrolment", "transfer", "reassignment"
- `assigned_at` / `unassigned_at` — temporal bounds
- `is_current` — at most one row per device is current

#### `DeviceLifecycleEvent`
Records every lifecycle-state transition for a device, providing an ordered, auditable history independent of the general AuditLog.
- `event_id` (UUID, unique)
- `device_id` (FK → devices.id)
- `epoch_id` (FK → lifecycle_epochs.id, nullable)
- `from_state` / `to_state` — lifecycle state transition
- `triggered_by_user_id` (FK → users.id, nullable)
- `triggered_by_device_id` (FK → devices.id, nullable)
- `reason` (text, nullable)
- `idempotency_key` (indexed, nullable)
- `created_at`

### Relationships
- `Device.assignments` → `DeviceAssignment` (one-to-many)
- `Device.lifecycle_events` → `DeviceLifecycleEvent` (one-to-many)
- Both use `foreign_keys` to resolve ambiguous FK paths

### Migration
- `20260720_add_device_assignments_events.py` (replaces from `20260719_add_device_credentials`)
- Creates the two tables with all indexes and FKs

### Verification
- Flake8: clean
- `test_device_unpair`: 1/1 passed
- `test_agent_api`: 3/3 passed
- `test_device_commands`: 2/2 passed