### PR TITLE
feat: Agent packaging and identity

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "pyyaml>=6.0.1",
     "python-dotenv>=1.0.0",
     "psutil>=5.9.0",
+    "platformdirs>=4.0.0",
     # AI Dependencies
     "chromadb>=0.4.0",
     "ollama>=0.1.0",
@@ -95,6 +96,11 @@ test = [
     "faker>=20.1.0",
     "greenlet>=2.0.0",
 ]
+agent = [
+    "httpx>=0.25.0",
+    "psutil>=5.9.0",
+    "platformdirs>=4.0.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/brunel-opensim/homepot-client"
@@ -104,6 +110,7 @@ Documentation = "https://github.com/brunel-opensim/homepot-client/tree/main/docs
 
 [project.scripts]
 homepot-client = "homepot.cli:main"
+homepot-agent = "homepot.agent.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/backend/src/homepot/agent/__init__.py
+++ b/backend/src/homepot/agent/__init__.py
@@ -1,5 +1,29 @@
 """Homepot agent package initialization."""
 
 from homepot.agent.agent_api import router
+from homepot.agent.credential_storage import (
+    CredentialStorage,
+    LinuxFileStorage,
+    SimulationStorage,
+    create_credential_storage,
+)
+from homepot.agent.identity import (
+    get_device_id,
+    get_or_create_device_id,
+    identity_dir,
+    identity_path,
+    reset_device_id,
+)
 
-__all__ = ["router"]
+__all__ = [
+    "router",
+    "CredentialStorage",
+    "LinuxFileStorage",
+    "SimulationStorage",
+    "create_credential_storage",
+    "get_device_id",
+    "get_or_create_device_id",
+    "identity_dir",
+    "identity_path",
+    "reset_device_id",
+]

--- a/backend/src/homepot/agent/cli.py
+++ b/backend/src/homepot/agent/cli.py
@@ -1,0 +1,247 @@
+"""Command-line interface for the HOMEPOT Agent.
+
+Provides commands for running the agent, managing device identity,
+inspecting status, and viewing configuration.
+"""
+
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import typer
+
+from homepot.agent.credential_storage import (
+    LinuxFileStorage,
+    SimulationStorage,
+    create_credential_storage,
+)
+from homepot.agent.identity import (
+    get_device_id,
+    get_or_create_device_id,
+    identity_dir,
+    identity_path,
+    reset_device_id,
+)
+from homepot.agent.real_device_agent import load_agent_config, run_agent
+
+app = typer.Typer(
+    name="homepot-agent",
+    help="HOMEPOT Device Agent - managed endpoint runtime",
+    add_completion=False,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@app.callback()
+def _main(
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose logging"),
+    config: Optional[Path] = typer.Option(
+        None,
+        "--config",
+        "-c",
+        help="Path to agent configuration JSON file",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+    ),
+) -> None:
+    """Configure global agent options."""
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
+    if config:
+        os.environ["HOMEPOT_AGENT_CONFIG"] = str(config.resolve())
+
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+
+
+@app.command()
+def run(
+    config: Optional[Path] = typer.Option(
+        None,
+        "--config",
+        "-c",
+        help="Path to agent configuration JSON file",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+    ),
+) -> None:
+    """Run the agent runtime (registration, heartbeat, telemetry).
+
+    This is the main entry point used by the systemd service.
+    """
+    if config:
+        os.environ["HOMEPOT_AGENT_CONFIG"] = str(config.resolve())
+    ensure_identity()
+    asyncio.run(run_agent())
+
+
+def ensure_identity() -> str:
+    """Ensure a persistent device identity exists and log it."""
+    device_id = get_or_create_device_id()
+    logger.info("Device identity: %s", device_id)
+    logger.info("Identity file: %s", identity_path())
+    return device_id
+
+
+# ---------------------------------------------------------------------------
+# identity
+# ---------------------------------------------------------------------------
+
+
+@app.command()
+def identity() -> None:
+    """Show the current device identity or generate one."""
+    device_id = get_or_create_device_id()
+    path = identity_path()
+    dir_path = identity_dir()
+
+    typer.echo(f"Device ID:   {device_id}")
+    typer.echo(f"Identity:    {path}")
+    typer.echo(f"Storage:     {dir_path}")
+    typer.echo(f"Provisioned: {is_provisioned_str()}")
+
+    cred = create_credential_storage()
+    if cred.is_provisioned():
+        typer.echo(f"API Key:     {mask_key(cred.get_api_key() or '')}")
+
+
+@app.command()
+def reset_identity() -> None:
+    """Remove the stored device identity (does not affect machine-id)."""
+    current = get_device_id()
+    if current:
+        typer.echo(f"Removing identity: {current}")
+        reset_device_id()
+        typer.echo("Identity removed.  Run 'homepot-agent identity' to generate a new one.")
+    else:
+        typer.echo("No identity to remove.")
+
+
+# ---------------------------------------------------------------------------
+# status
+# ---------------------------------------------------------------------------
+
+
+@app.command()
+def status() -> None:
+    """Show the current agent status."""
+    cred = create_credential_storage()
+    is_prov = cred.is_provisioned()
+    device_id = get_device_id() or "(not set)"
+
+    typer.echo(f"Device ID:    {device_id}")
+    typer.echo(f"Provisioned:  {yes_no(is_prov)}")
+    if is_prov:
+        typer.echo(f"Device Name:  {cred.get_metadata('device_name') or '(not set)'}")
+        typer.echo(f"Site ID:      {cred.get_metadata('site_id') or '(not set)'}")
+
+    identity_path_val = identity_path()
+    typer.echo(f"Identity:     {identity_path_val}")
+    typer.echo(f"  Exists:     {yes_no(identity_path_val.exists())}")
+
+
+# ---------------------------------------------------------------------------
+# config
+# ---------------------------------------------------------------------------
+
+
+@app.command()
+def show_config(
+    config: Optional[Path] = typer.Option(
+        None,
+        "--config",
+        "-c",
+        help="Path to agent configuration JSON file",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+    ),
+) -> None:
+    """Show the effective agent configuration."""
+    if config:
+        os.environ["HOMEPOT_AGENT_CONFIG"] = str(config.resolve())
+    try:
+        cfg = load_agent_config()
+        typer.echo(json.dumps(cfg, indent=2))
+    except (FileNotFoundError, ValueError) as exc:
+        typer.echo(f"Error loading config: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+
+# ---------------------------------------------------------------------------
+# credentials
+# ---------------------------------------------------------------------------
+
+
+@app.command()
+def credentials() -> None:
+    """Show credential storage status and metadata."""
+    cred = create_credential_storage()
+    if not cred.is_provisioned():
+        typer.echo("No credentials stored.")
+        raise typer.Exit(code=0)
+
+    device_id = cred.get_device_id()
+    api_key = cred.get_api_key()
+
+    typer.echo(f"Device ID:    {device_id}")
+    typer.echo(f"API Key:      {mask_key(api_key or '')}")
+    typer.echo(f"Storage:      {type(cred).__name__}")
+
+    if isinstance(cred, LinuxFileStorage):
+        typer.echo(f"File:         {cred._file_path}")
+
+    for meta_key in ("device_name", "site_id", "device_type", "enrollment_method"):
+        val = cred.get_metadata(meta_key)
+        if val:
+            typer.echo(f"{meta_key}: {val}")
+
+
+@app.command()
+def clear_credentials() -> None:
+    """Remove all stored credentials (local unpair)."""
+    cred = create_credential_storage()
+    if cred.is_provisioned():
+        cred.clear()
+        typer.echo("Credentials cleared.")
+    else:
+        typer.echo("No credentials to clear.")
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def is_provisioned_str() -> str:
+    cred = create_credential_storage()
+    return yes_no(cred.is_provisioned())
+
+
+def yes_no(val: bool) -> str:
+    return "yes" if val else "no"
+
+
+def mask_key(key: str) -> str:
+    if len(key) <= 8:
+        return "****"
+    return key[:4] + "*" * (len(key) - 8) + key[-4:]
+
+
+def main() -> None:
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/src/homepot/agent/cli.py
+++ b/backend/src/homepot/agent/cli.py
@@ -9,13 +9,12 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Optional
 
 import typer
 
 from homepot.agent.credential_storage import (
     LinuxFileStorage,
-    SimulationStorage,
     create_credential_storage,
 )
 from homepot.agent.identity import (
@@ -38,7 +37,9 @@ logger = logging.getLogger(__name__)
 
 @app.callback()
 def _main(
-    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose logging"),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Enable verbose logging"
+    ),
     config: Optional[Path] = typer.Option(
         None,
         "--config",
@@ -122,7 +123,9 @@ def reset_identity() -> None:
     if current:
         typer.echo(f"Removing identity: {current}")
         reset_device_id()
-        typer.echo("Identity removed.  Run 'homepot-agent identity' to generate a new one.")
+        typer.echo(
+            "Identity removed.  Run 'homepot-agent identity' to generate a new one."
+        )
     else:
         typer.echo("No identity to remove.")
 
@@ -225,21 +228,25 @@ def clear_credentials() -> None:
 
 
 def is_provisioned_str() -> str:
+    """Return 'yes' or 'no' indicating whether credentials exist."""
     cred = create_credential_storage()
     return yes_no(cred.is_provisioned())
 
 
 def yes_no(val: bool) -> str:
+    """Return 'yes' for True, 'no' for False."""
     return "yes" if val else "no"
 
 
 def mask_key(key: str) -> str:
+    """Mask all but the first and last 4 characters of an API key."""
     if len(key) <= 8:
         return "****"
     return key[:4] + "*" * (len(key) - 8) + key[-4:]
 
 
 def main() -> None:
+    """Entry point for the homepot-agent console script."""
     app()
 
 

--- a/backend/src/homepot/agent/credential_storage.py
+++ b/backend/src/homepot/agent/credential_storage.py
@@ -14,12 +14,12 @@ Implementations:
 - ``AndroidKeystore`` — placeholder for Android Keystore
 """
 
+from abc import ABC, abstractmethod
 import json
 import logging
 import os
-import sys
-from abc import ABC, abstractmethod
 from pathlib import Path
+import sys
 from typing import Dict, Optional
 
 logger = logging.getLogger(__name__)
@@ -34,6 +34,7 @@ DeviceCredentials = Dict[str, str]
 # ---------------------------------------------------------------------------
 # Abstract interface
 # ---------------------------------------------------------------------------
+
 
 class CredentialStorage(ABC):
     """Abstract interface for persisting device credentials."""
@@ -60,41 +61,50 @@ class CredentialStorage(ABC):
 
     @abstractmethod
     def is_provisioned(self) -> bool:
-        """``True`` if credentials are present (device is provisioned)."""
+        """Return True if credentials are present."""
 
 
 # ---------------------------------------------------------------------------
 # Simulation storage (in-memory)
 # ---------------------------------------------------------------------------
 
+
 class SimulationStorage(CredentialStorage):
     """In-memory credential storage for testing and development."""
 
     def __init__(self) -> None:
+        """Initialize an empty in-memory credential store."""
         self._data: Dict[str, str] = {}
 
     def save(self, creds: DeviceCredentials) -> None:
+        """Save credentials to the in-memory store."""
         self._data.update(creds)
 
     def get_api_key(self) -> Optional[str]:
+        """Return the stored API key or None."""
         return self._data.get("api_key")
 
     def get_device_id(self) -> Optional[str]:
+        """Return the stored device ID or None."""
         return self._data.get("device_id")
 
     def get_metadata(self, key: str) -> Optional[str]:
+        """Return a metadata field by key or None."""
         return self._data.get(key)
 
     def clear(self) -> None:
+        """Remove all stored credentials."""
         self._data.clear()
 
     def is_provisioned(self) -> bool:
+        """Return True if device_id is present in the store."""
         return "device_id" in self._data
 
 
 # ---------------------------------------------------------------------------
 # Linux file storage (file on disk with strict permissions)
 # ---------------------------------------------------------------------------
+
 
 class LinuxFileStorage(CredentialStorage):
     """Stores credentials in a JSON file with ``0o600`` permissions.
@@ -103,9 +113,11 @@ class LinuxFileStorage(CredentialStorage):
     """
 
     def __init__(self, file_path: Optional[Path] = None) -> None:
+        """Initialize Linux file storage at the given path."""
         self._file_path = file_path or Path.home() / ".homepot" / "credentials"
 
     def _read(self) -> Dict[str, str]:
+        """Read credentials from the JSON file. Returns empty dict on error."""
         if not self._file_path.exists():
             return {}
         try:
@@ -116,6 +128,7 @@ class LinuxFileStorage(CredentialStorage):
             return {}
 
     def _write(self, data: Dict[str, str]) -> None:
+        """Write credentials to the JSON file with 0o600 permissions."""
         self._file_path.parent.mkdir(parents=True, exist_ok=True)
         self._file_path.write_text(
             json.dumps(data, indent=2),
@@ -124,30 +137,37 @@ class LinuxFileStorage(CredentialStorage):
         self._file_path.chmod(0o600)
 
     def save(self, creds: DeviceCredentials) -> None:
+        """Save credentials to the JSON file."""
         data = self._read()
         data.update(creds)
         self._write(data)
 
     def get_api_key(self) -> Optional[str]:
+        """Return the stored API key or None."""
         return self._read().get("api_key")
 
     def get_device_id(self) -> Optional[str]:
+        """Return the stored device ID or None."""
         return self._read().get("device_id")
 
     def get_metadata(self, key: str) -> Optional[str]:
+        """Return a metadata field by key or None."""
         return self._read().get(key)
 
     def clear(self) -> None:
+        """Remove the credentials file."""
         if self._file_path.exists():
             self._file_path.unlink()
 
     def is_provisioned(self) -> bool:
+        """Return True if the file contains a device_id."""
         return self._file_path.exists() and "device_id" in self._read()
 
 
 # ---------------------------------------------------------------------------
 # Platform-aware factory
 # ---------------------------------------------------------------------------
+
 
 def create_credential_storage(
     storage_path: Optional[Path] = None,

--- a/backend/src/homepot/agent/credential_storage.py
+++ b/backend/src/homepot/agent/credential_storage.py
@@ -1,0 +1,166 @@
+"""Credential-storage abstraction for device credentials.
+
+Mirrors the TypeScript CredentialStorage interface from
+user_app/src/services/credentialStorage.ts.
+
+The plaintext API key is returned **only** at issuance or rotation.
+This abstraction ensures the same higher-level workflow works across
+development simulations and production platforms.
+
+Implementations:
+- ``SimulationStorage`` — in-memory dict / temp file (for dev/testing)
+- ``LinuxFileStorage`` — file on disk with strict permissions (0o600)
+- ``WindowsCredManager`` — placeholder for Windows Credential Manager / DPAPI
+- ``AndroidKeystore`` — placeholder for Android Keystore
+"""
+
+import json
+import logging
+import os
+import sys
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+DeviceCredentials = Dict[str, str]
+
+
+# ---------------------------------------------------------------------------
+# Abstract interface
+# ---------------------------------------------------------------------------
+
+class CredentialStorage(ABC):
+    """Abstract interface for persisting device credentials."""
+
+    @abstractmethod
+    def save(self, creds: DeviceCredentials) -> None:
+        """Persist credentials after a successful provision or claim."""
+
+    @abstractmethod
+    def get_api_key(self) -> Optional[str]:
+        """Retrieve the stored API key.  Returns ``None`` if not provisioned."""
+
+    @abstractmethod
+    def get_device_id(self) -> Optional[str]:
+        """Retrieve the stored device ID.  Returns ``None`` if not provisioned."""
+
+    @abstractmethod
+    def get_metadata(self, key: str) -> Optional[str]:
+        """Retrieve a metadata field by key."""
+
+    @abstractmethod
+    def clear(self) -> None:
+        """Remove all stored credentials (unpair / factory-reset)."""
+
+    @abstractmethod
+    def is_provisioned(self) -> bool:
+        """``True`` if credentials are present (device is provisioned)."""
+
+
+# ---------------------------------------------------------------------------
+# Simulation storage (in-memory)
+# ---------------------------------------------------------------------------
+
+class SimulationStorage(CredentialStorage):
+    """In-memory credential storage for testing and development."""
+
+    def __init__(self) -> None:
+        self._data: Dict[str, str] = {}
+
+    def save(self, creds: DeviceCredentials) -> None:
+        self._data.update(creds)
+
+    def get_api_key(self) -> Optional[str]:
+        return self._data.get("api_key")
+
+    def get_device_id(self) -> Optional[str]:
+        return self._data.get("device_id")
+
+    def get_metadata(self, key: str) -> Optional[str]:
+        return self._data.get(key)
+
+    def clear(self) -> None:
+        self._data.clear()
+
+    def is_provisioned(self) -> bool:
+        return "device_id" in self._data
+
+
+# ---------------------------------------------------------------------------
+# Linux file storage (file on disk with strict permissions)
+# ---------------------------------------------------------------------------
+
+class LinuxFileStorage(CredentialStorage):
+    """Stores credentials in a JSON file with ``0o600`` permissions.
+
+    Default location: ``~/.homepot/credentials``
+    """
+
+    def __init__(self, file_path: Optional[Path] = None) -> None:
+        self._file_path = file_path or Path.home() / ".homepot" / "credentials"
+
+    def _read(self) -> Dict[str, str]:
+        if not self._file_path.exists():
+            return {}
+        try:
+            raw = self._file_path.read_text("utf-8")
+            return dict(json.loads(raw))
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Failed to read credentials file: %s", exc)
+            return {}
+
+    def _write(self, data: Dict[str, str]) -> None:
+        self._file_path.parent.mkdir(parents=True, exist_ok=True)
+        self._file_path.write_text(
+            json.dumps(data, indent=2),
+            encoding="utf-8",
+        )
+        self._file_path.chmod(0o600)
+
+    def save(self, creds: DeviceCredentials) -> None:
+        data = self._read()
+        data.update(creds)
+        self._write(data)
+
+    def get_api_key(self) -> Optional[str]:
+        return self._read().get("api_key")
+
+    def get_device_id(self) -> Optional[str]:
+        return self._read().get("device_id")
+
+    def get_metadata(self, key: str) -> Optional[str]:
+        return self._read().get(key)
+
+    def clear(self) -> None:
+        if self._file_path.exists():
+            self._file_path.unlink()
+
+    def is_provisioned(self) -> bool:
+        return self._file_path.exists() and "device_id" in self._read()
+
+
+# ---------------------------------------------------------------------------
+# Platform-aware factory
+# ---------------------------------------------------------------------------
+
+def create_credential_storage(
+    storage_path: Optional[Path] = None,
+) -> CredentialStorage:
+    """Return the appropriate ``CredentialStorage`` for the current platform.
+
+    - **Linux** → ``LinuxFileStorage``
+    - **Other** → ``SimulationStorage`` (dev/test fallback)
+    """
+    if os.name == "posix" and sys.platform != "darwin":
+        return LinuxFileStorage(file_path=storage_path)
+    logger.info(
+        "No platform-specific credential storage for %s; using SimulationStorage",
+        sys.platform,
+    )
+    return SimulationStorage()

--- a/backend/src/homepot/agent/identity.py
+++ b/backend/src/homepot/agent/identity.py
@@ -12,10 +12,9 @@ and re-enrolment.  The identity is stored in:
 
 import hashlib
 import logging
-import os
-import uuid
 from pathlib import Path
 from typing import Optional
+import uuid
 
 from platformdirs import user_data_dir
 
@@ -64,7 +63,9 @@ def _machine_id_identity() -> Optional[str]:
         raw = machine_id_path.read_text("utf-8").strip()
         if not raw:
             return None
-        salted = hashlib.sha256(f"homepot-device-identity:{raw}".encode()).hexdigest()[:32]
+        salted = hashlib.sha256(f"homepot-device-identity:{raw}".encode()).hexdigest()[
+            :32
+        ]
         return f"device-{salted}"
     except (OSError, PermissionError) as exc:
         logger.warning("Cannot read machine-id: %s", exc)
@@ -100,9 +101,7 @@ def get_or_create_device_id() -> str:
         if machine_id:
             logger.info("Derived device identity from machine-id: %s", machine_id)
             return machine_id
-        logger.warning(
-            "Cannot persist identity file; using ephemeral UUID: %s", new_id
-        )
+        logger.warning("Cannot persist identity file; using ephemeral UUID: %s", new_id)
         return new_id
 
 

--- a/backend/src/homepot/agent/identity.py
+++ b/backend/src/homepot/agent/identity.py
@@ -12,8 +12,8 @@ and re-enrolment.  The identity is stored in:
 
 import hashlib
 import logging
-import tempfile
 from pathlib import Path
+import tempfile
 from typing import Optional
 import uuid
 

--- a/backend/src/homepot/agent/identity.py
+++ b/backend/src/homepot/agent/identity.py
@@ -12,6 +12,7 @@ and re-enrolment.  The identity is stored in:
 
 import hashlib
 import logging
+import tempfile
 from pathlib import Path
 from typing import Optional
 import uuid
@@ -22,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 _IDENTITY_FILENAME = "identity"
 _VAR_LIB_PATH = Path("/var/lib/homepot")
-_FALLBACK_DIR = Path(user_data_dir("homepot", ensure_exists=True))
+_FALLBACK_DIR = Path(user_data_dir("homepot"))
 
 
 def _get_identity_dir() -> Path:
@@ -37,7 +38,14 @@ def _get_identity_dir() -> Path:
         test_file.unlink()
         return _VAR_LIB_PATH
     except (OSError, PermissionError):
+        pass
+    try:
+        _FALLBACK_DIR.mkdir(parents=True, exist_ok=True)
         return _FALLBACK_DIR
+    except (OSError, PermissionError):
+        tmp_dir = Path(tempfile.gettempdir()) / "homepot"
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+        return tmp_dir
 
 
 def _identity_file_path() -> Path:

--- a/backend/src/homepot/agent/identity.py
+++ b/backend/src/homepot/agent/identity.py
@@ -1,0 +1,143 @@
+"""Persistent stable device identity for the HOMEPOT agent.
+
+Generates and manages a stable device identity that survives restarts
+and re-enrolment.  The identity is stored in:
+
+1. ``/var/lib/homepot/identity`` — preferred FHS-compliant path when
+   writable (used by the installed daemon).
+2. ``XDG_DATA_HOME/homepot/identity`` — fallback for unprivileged/dev runs.
+3. ``/etc/machine-id`` (hashed with a salt) — fallback when neither is
+   writable, providing a deterministic identity tied to the hardware.
+"""
+
+import hashlib
+import logging
+import os
+import uuid
+from pathlib import Path
+from typing import Optional
+
+from platformdirs import user_data_dir
+
+logger = logging.getLogger(__name__)
+
+_IDENTITY_FILENAME = "identity"
+_VAR_LIB_PATH = Path("/var/lib/homepot")
+_FALLBACK_DIR = Path(user_data_dir("homepot", ensure_exists=True))
+
+
+def _get_identity_dir() -> Path:
+    """Return the best writable directory for the identity file.
+
+    Prefers ``/var/lib/homepot``; falls back to XDG data dir.
+    """
+    try:
+        _VAR_LIB_PATH.mkdir(parents=True, exist_ok=True)
+        test_file = _VAR_LIB_PATH / ".write_test"
+        test_file.touch()
+        test_file.unlink()
+        return _VAR_LIB_PATH
+    except (OSError, PermissionError):
+        return _FALLBACK_DIR
+
+
+def _identity_file_path() -> Path:
+    return _get_identity_dir() / _IDENTITY_FILENAME
+
+
+def _generate_uuid_identity() -> str:
+    """Generate a new random UUID-based device identity."""
+    return f"device-{uuid.uuid4().hex}"
+
+
+def _machine_id_identity() -> Optional[str]:
+    """Derive a deterministic identity from ``/etc/machine-id``.
+
+    Returns ``None`` if the file is unavailable.
+    """
+    machine_id_path = Path("/etc/machine-id")
+    if not machine_id_path.exists():
+        machine_id_path = Path("/var/lib/dbus/machine-id")
+    if not machine_id_path.exists():
+        return None
+    try:
+        raw = machine_id_path.read_text("utf-8").strip()
+        if not raw:
+            return None
+        salted = hashlib.sha256(f"homepot-device-identity:{raw}".encode()).hexdigest()[:32]
+        return f"device-{salted}"
+    except (OSError, PermissionError) as exc:
+        logger.warning("Cannot read machine-id: %s", exc)
+        return None
+
+
+def get_or_create_device_id() -> str:
+    """Return the persistent device identity, creating one if needed.
+
+    Resolution order:
+    1. Read existing identity file.
+    2. If absent, generate a UUID and persist it.
+    3. If the identity directory is unwritable, derive from ``/etc/machine-id``.
+    """
+    identity_path = _identity_file_path()
+    if identity_path.exists():
+        try:
+            raw = identity_path.read_text("utf-8").strip()
+            if raw:
+                return raw
+        except OSError as exc:
+            logger.warning("Failed to read identity file %s: %s", identity_path, exc)
+
+    new_id = _generate_uuid_identity()
+    try:
+        identity_path.parent.mkdir(parents=True, exist_ok=True)
+        identity_path.write_text(new_id + "\n", encoding="utf-8")
+        identity_path.chmod(0o644)
+        logger.info("Generated new device identity: %s", new_id)
+        return new_id
+    except (OSError, PermissionError):
+        machine_id = _machine_id_identity()
+        if machine_id:
+            logger.info("Derived device identity from machine-id: %s", machine_id)
+            return machine_id
+        logger.warning(
+            "Cannot persist identity file; using ephemeral UUID: %s", new_id
+        )
+        return new_id
+
+
+def get_device_id() -> Optional[str]:
+    """Read the existing device identity without creating a new one.
+
+    Returns ``None`` if no identity has been established.
+    """
+    identity_path = _identity_file_path()
+    if identity_path.exists():
+        try:
+            raw = identity_path.read_text("utf-8").strip()
+            if raw:
+                return raw
+        except OSError:
+            pass
+    return _machine_id_identity()
+
+
+def reset_device_id() -> None:
+    """Remove the persisted identity file so a new one is generated next time.
+
+    Does **not** affect ``/etc/machine-id``.
+    """
+    identity_path = _identity_file_path()
+    if identity_path.exists():
+        identity_path.unlink()
+        logger.info("Device identity file removed: %s", identity_path)
+
+
+def identity_path() -> Path:
+    """Return the path to the identity file."""
+    return _identity_file_path()
+
+
+def identity_dir() -> Path:
+    """Return the directory containing the identity file."""
+    return _get_identity_dir()

--- a/backend/src/homepot/agent/real_device_agent.py
+++ b/backend/src/homepot/agent/real_device_agent.py
@@ -3,16 +3,13 @@
 import asyncio
 import json
 import logging
-import os
 from pathlib import Path
 import threading
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, cast
 
 import httpx
 from uvicorn import Config, Server
 
-from homepot.agent.credential_storage import create_credential_storage
-from homepot.agent.identity import get_or_create_device_id
 from homepot.agent.utils.device_dna import get_local_ip, get_mac_address, get_wan_ip
 from homepot.agent.utils.heartbeat import build_heartbeat_payload
 from homepot.agent.utils.local_ipc import (
@@ -25,58 +22,20 @@ from homepot.agent.utils.retry_queue import RetryQueue
 from homepot.agent.utils.telemetry import build_telemetry_payload
 
 logger = logging.getLogger(__name__)
-
-_DEFAULT_CONFIG_PATH = Path(__file__).parent / "agent-config.json"
-
-
-def _config_path() -> Path:
-    override = os.environ.get("HOMEPOT_AGENT_CONFIG")
-    if override:
-        return Path(override)
-    return _DEFAULT_CONFIG_PATH
+logging.basicConfig(level=logging.INFO)
 
 
 def load_agent_config() -> Dict[str, Any]:
-    """Load and validate the agent configuration.
+    """Load and validate the agent configuration JSON file."""
+    config_path = Path(__file__).parent / "agent-config.json"
+    with config_path.open("r", encoding="utf-8") as f:
+        data = cast(Dict[str, Any], json.load(f))
 
-    Resolution order:
-    1. ``HOMEPOT_AGENT_CONFIG`` environment variable.
-    2. ``agent-config.json`` shipped with the package.
-    """
-    config_path = _config_path()
-    try:
-        with config_path.open("r", encoding="utf-8") as f:
-            data = cast(Dict[str, Any], json.load(f))
-    except FileNotFoundError:
-        logger.warning("Config not found at %s; using defaults", config_path)
-        data = {}
-
-    # Fill in device identity from the identity module if not set
-    if not data.get("device_id"):
-        data["device_id"] = get_or_create_device_id()
-        logger.info("Using generated device identity: %s", data["device_id"])
-
-    # Fill in credentials from credential storage if not set
-    cred_storage = create_credential_storage()
-    if not data.get("api_key") and cred_storage.is_provisioned():
-        api_key = cred_storage.get_api_key()
-        if api_key:
-            data["api_key"] = api_key
-            logger.info("Using API key from credential storage")
-        site_id = cred_storage.get_metadata("site_id")
-        if site_id and not data.get("site_id"):
-            data["site_id"] = site_id
-
-    required = ["backend_url", "device_id"]
+    required = ["backend_url", "device_id", "api_key", "site_id"]
     missing = [field for field in required if not data.get(field)]
     if missing:
-        raise ValueError(
-            f"Missing required config fields: {', '.join(missing)}. "
-            "Set via config file or environment."
-        )
+        raise ValueError(f"Missing required config fields: {', '.join(missing)}")
 
-    data.setdefault("api_key", "")
-    data.setdefault("site_id", "")
     data.setdefault("heartbeat_interval_seconds", 30)
     data.setdefault("telemetry_interval_seconds", 30)
     data.setdefault("retry_flush_interval_seconds", 60)
@@ -117,6 +76,17 @@ async def send_registration(
 ) -> None:
     """Send initial device registration payload with static device DNA."""
     try:
+        # Payload sent to POST /api/v1/agent/device-dna
+        # {
+        #   "device_id": "android-pos-001",
+        #   "site_id": "site-1234",
+        #   "device_name": "Front POS",
+        #   "device_type": "pos_terminal",
+        #   "mac_address": "00:11:22:33:44:55",
+        #   "os_details": "Android 13",
+        #   "local_ip": "192.168.1.20",
+        #   "wan_ip": "203.0.113.10"
+        # }
         payload = {
             "device_id": config["device_id"],
             "site_id": config["site_id"],
@@ -146,6 +116,13 @@ async def heartbeat_loop(
     interval = int(config["heartbeat_interval_seconds"])
     while True:
         try:
+            # Payload sent to POST /api/v1/agent/heartbeat
+            # {
+            #   "device_id": "android-pos-001",
+            #   "site_id": "site-1234",
+            #   "status": "ONLINE",
+            #   "timestamp": "2026-04-13T12:00:00Z"
+            # }
             payload = build_heartbeat_payload(
                 config["device_id"],
                 site_id=config["site_id"],
@@ -155,7 +132,7 @@ async def heartbeat_loop(
             if ok:
                 if ipc_server is not None:
                     update_local_agent_state(
-                        ipc_server.config.app,
+                        ipc_server.config.app,  # type: ignore[arg-type]
                         status="ONLINE",
                         last_heartbeat=payload["timestamp"],
                     )
@@ -163,7 +140,7 @@ async def heartbeat_loop(
                 retry_queue.enqueue({"url": url, "payload": payload})
                 if ipc_server is not None:
                     update_local_agent_state(
-                        ipc_server.config.app,
+                        ipc_server.config.app,  # type: ignore[arg-type]
                         status="OFFLINE",
                     )
         except Exception as e:
@@ -182,12 +159,21 @@ async def telemetry_loop(
     interval = int(config["telemetry_interval_seconds"])
     while True:
         try:
+            # Payload sent to POST /api/v1/agent/telemetry
+            # {
+            #   "device_id": "android-pos-001",
+            #   "site_id": "site-1234",
+            #   "cpu_usage": 20.1,
+            #   "memory_usage": 55.4,
+            #   "disk_usage": 44.8,
+            #   "timestamp": "2026-04-13T12:00:30Z"
+            # }
             payload = build_telemetry_payload(config["device_id"])
             payload["site_id"] = config["site_id"]
             ok = await post_json(client, url, payload, get_auth_headers(config))
             if ok and ipc_server is not None:
                 update_local_agent_state(
-                    ipc_server.config.app,
+                    ipc_server.config.app,  # type: ignore[arg-type]
                     last_telemetry=payload,
                 )
             if not ok:

--- a/backend/src/homepot/agent/real_device_agent.py
+++ b/backend/src/homepot/agent/real_device_agent.py
@@ -3,13 +3,16 @@
 import asyncio
 import json
 import logging
+import os
 from pathlib import Path
 import threading
-from typing import Any, Dict, cast
+from typing import Any, Dict, Optional, cast
 
 import httpx
 from uvicorn import Config, Server
 
+from homepot.agent.credential_storage import create_credential_storage
+from homepot.agent.identity import get_or_create_device_id
 from homepot.agent.utils.device_dna import get_local_ip, get_mac_address, get_wan_ip
 from homepot.agent.utils.heartbeat import build_heartbeat_payload
 from homepot.agent.utils.local_ipc import (
@@ -22,20 +25,58 @@ from homepot.agent.utils.retry_queue import RetryQueue
 from homepot.agent.utils.telemetry import build_telemetry_payload
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
+
+_DEFAULT_CONFIG_PATH = Path(__file__).parent / "agent-config.json"
+
+
+def _config_path() -> Path:
+    override = os.environ.get("HOMEPOT_AGENT_CONFIG")
+    if override:
+        return Path(override)
+    return _DEFAULT_CONFIG_PATH
 
 
 def load_agent_config() -> Dict[str, Any]:
-    """Load and validate the agent configuration JSON file."""
-    config_path = Path(__file__).parent / "agent-config.json"
-    with config_path.open("r", encoding="utf-8") as f:
-        data = cast(Dict[str, Any], json.load(f))
+    """Load and validate the agent configuration.
 
-    required = ["backend_url", "device_id", "api_key", "site_id"]
+    Resolution order:
+    1. ``HOMEPOT_AGENT_CONFIG`` environment variable.
+    2. ``agent-config.json`` shipped with the package.
+    """
+    config_path = _config_path()
+    try:
+        with config_path.open("r", encoding="utf-8") as f:
+            data = cast(Dict[str, Any], json.load(f))
+    except FileNotFoundError:
+        logger.warning("Config not found at %s; using defaults", config_path)
+        data = {}
+
+    # Fill in device identity from the identity module if not set
+    if not data.get("device_id"):
+        data["device_id"] = get_or_create_device_id()
+        logger.info("Using generated device identity: %s", data["device_id"])
+
+    # Fill in credentials from credential storage if not set
+    cred_storage = create_credential_storage()
+    if not data.get("api_key") and cred_storage.is_provisioned():
+        api_key = cred_storage.get_api_key()
+        if api_key:
+            data["api_key"] = api_key
+            logger.info("Using API key from credential storage")
+        site_id = cred_storage.get_metadata("site_id")
+        if site_id and not data.get("site_id"):
+            data["site_id"] = site_id
+
+    required = ["backend_url", "device_id"]
     missing = [field for field in required if not data.get(field)]
     if missing:
-        raise ValueError(f"Missing required config fields: {', '.join(missing)}")
+        raise ValueError(
+            f"Missing required config fields: {', '.join(missing)}. "
+            "Set via config file or environment."
+        )
 
+    data.setdefault("api_key", "")
+    data.setdefault("site_id", "")
     data.setdefault("heartbeat_interval_seconds", 30)
     data.setdefault("telemetry_interval_seconds", 30)
     data.setdefault("retry_flush_interval_seconds", 60)
@@ -76,17 +117,6 @@ async def send_registration(
 ) -> None:
     """Send initial device registration payload with static device DNA."""
     try:
-        # Payload sent to POST /api/v1/agent/device-dna
-        # {
-        #   "device_id": "android-pos-001",
-        #   "site_id": "site-1234",
-        #   "device_name": "Front POS",
-        #   "device_type": "pos_terminal",
-        #   "mac_address": "00:11:22:33:44:55",
-        #   "os_details": "Android 13",
-        #   "local_ip": "192.168.1.20",
-        #   "wan_ip": "203.0.113.10"
-        # }
         payload = {
             "device_id": config["device_id"],
             "site_id": config["site_id"],
@@ -116,13 +146,6 @@ async def heartbeat_loop(
     interval = int(config["heartbeat_interval_seconds"])
     while True:
         try:
-            # Payload sent to POST /api/v1/agent/heartbeat
-            # {
-            #   "device_id": "android-pos-001",
-            #   "site_id": "site-1234",
-            #   "status": "ONLINE",
-            #   "timestamp": "2026-04-13T12:00:00Z"
-            # }
             payload = build_heartbeat_payload(
                 config["device_id"],
                 site_id=config["site_id"],
@@ -132,7 +155,7 @@ async def heartbeat_loop(
             if ok:
                 if ipc_server is not None:
                     update_local_agent_state(
-                        ipc_server.config.app,  # type: ignore[arg-type]
+                        ipc_server.config.app,
                         status="ONLINE",
                         last_heartbeat=payload["timestamp"],
                     )
@@ -140,7 +163,7 @@ async def heartbeat_loop(
                 retry_queue.enqueue({"url": url, "payload": payload})
                 if ipc_server is not None:
                     update_local_agent_state(
-                        ipc_server.config.app,  # type: ignore[arg-type]
+                        ipc_server.config.app,
                         status="OFFLINE",
                     )
         except Exception as e:
@@ -159,21 +182,12 @@ async def telemetry_loop(
     interval = int(config["telemetry_interval_seconds"])
     while True:
         try:
-            # Payload sent to POST /api/v1/agent/telemetry
-            # {
-            #   "device_id": "android-pos-001",
-            #   "site_id": "site-1234",
-            #   "cpu_usage": 20.1,
-            #   "memory_usage": 55.4,
-            #   "disk_usage": 44.8,
-            #   "timestamp": "2026-04-13T12:00:30Z"
-            # }
             payload = build_telemetry_payload(config["device_id"])
             payload["site_id"] = config["site_id"]
             ok = await post_json(client, url, payload, get_auth_headers(config))
             if ok and ipc_server is not None:
                 update_local_agent_state(
-                    ipc_server.config.app,  # type: ignore[arg-type]
+                    ipc_server.config.app,
                     last_telemetry=payload,
                 )
             if not ok:

--- a/backend/tests/test_agent_credential_storage.py
+++ b/backend/tests/test_agent_credential_storage.py
@@ -26,45 +26,56 @@ from homepot.agent.credential_storage import (
 
 
 class TestSimulationStorage:
+    """Tests for the in-memory SimulationStorage."""
+
     def test_save_and_get_api_key(self):
+        """Save an API key and verify it can be retrieved."""
         storage = SimulationStorage()
         storage.save({"api_key": "sk-test-123", "device_id": "dev-1"})
         assert storage.get_api_key() == "sk-test-123"
 
     def test_save_and_get_device_id(self):
+        """Save a device ID and verify it can be retrieved."""
         storage = SimulationStorage()
         storage.save({"device_id": "dev-42"})
         assert storage.get_device_id() == "dev-42"
 
     def test_get_metadata(self):
+        """Save metadata fields and verify they can be retrieved by key."""
         storage = SimulationStorage()
         storage.save({"device_name": "Front POS", "site_id": "site-99"})
         assert storage.get_metadata("device_name") == "Front POS"
         assert storage.get_metadata("site_id") == "site-99"
 
     def test_get_metadata_missing(self):
+        """Requesting a nonexistent metadata key returns None."""
         storage = SimulationStorage()
         storage.save({"device_id": "d1"})
         assert storage.get_metadata("nonexistent") is None
 
     def test_get_api_key_before_save(self):
+        """get_api_key returns None before any credentials are saved."""
         storage = SimulationStorage()
         assert storage.get_api_key() is None
 
     def test_get_device_id_before_save(self):
+        """get_device_id returns None before any credentials are saved."""
         storage = SimulationStorage()
         assert storage.get_device_id() is None
 
     def test_is_provisioned_true(self):
+        """is_provisioned returns True after a device_id is saved."""
         storage = SimulationStorage()
         storage.save({"device_id": "d1"})
         assert storage.is_provisioned() is True
 
     def test_is_provisioned_false(self):
+        """is_provisioned returns False when no credentials exist."""
         storage = SimulationStorage()
         assert storage.is_provisioned() is False
 
     def test_clear_removes_all(self):
+        """Remove all stored credentials and reset provisioned state."""
         storage = SimulationStorage()
         storage.save({"api_key": "sk-test", "device_id": "d1", "site_id": "s1"})
         storage.clear()
@@ -73,6 +84,7 @@ class TestSimulationStorage:
         assert storage.is_provisioned() is False
 
     def test_save_updates_existing(self):
+        """Save merges new fields into existing credentials."""
         storage = SimulationStorage()
         storage.save({"device_id": "d1", "device_name": "Old"})
         storage.save({"device_name": "New", "site_id": "s1"})
@@ -81,12 +93,14 @@ class TestSimulationStorage:
         assert storage.get_metadata("site_id") == "s1"
 
     def test_save_accepts_partial_credentials(self):
+        """Save works with only an API key and no device_id."""
         storage = SimulationStorage()
         storage.save({"api_key": "sk-test"})
         assert storage.get_api_key() == "sk-test"
         assert storage.get_device_id() is None
 
     def test_multiple_independent_instances(self):
+        """Each SimulationStorage instance has its own isolated data."""
         s1 = SimulationStorage()
         s2 = SimulationStorage()
         s1.save({"device_id": "dev-1"})
@@ -101,44 +115,56 @@ class TestSimulationStorage:
 
 
 class TestLinuxFileStorage:
+    """Tests for the Linux file-based credential storage."""
+
     @pytest.fixture
     def temp_storage(self):
+        """Create a LinuxFileStorage backed by a temp directory."""
         with tempfile.TemporaryDirectory() as tmpdir:
             file_path = Path(tmpdir) / ".homepot" / "credentials"
             storage = LinuxFileStorage(file_path=file_path)
             yield storage
 
     def test_save_and_get_api_key(self, temp_storage):
+        """Save an API key and verify it can be retrieved from disk."""
         temp_storage.save({"api_key": "sk-linux-1", "device_id": "dev-linux-1"})
         assert temp_storage.get_api_key() == "sk-linux-1"
 
     def test_save_and_get_device_id(self, temp_storage):
+        """Save a device ID and verify it can be retrieved from disk."""
         temp_storage.save({"device_id": "dev-linux-42"})
         assert temp_storage.get_device_id() == "dev-linux-42"
 
     def test_get_metadata(self, temp_storage):
+        """Save metadata and verify it can be retrieved by key."""
         temp_storage.save({"device_name": "Linux POS", "site_id": "site-linux"})
         assert temp_storage.get_metadata("device_name") == "Linux POS"
         assert temp_storage.get_metadata("site_id") == "site-linux"
 
     def test_get_metadata_missing(self, temp_storage):
+        """get_metadata for a missing key returns None."""
         temp_storage.save({"device_id": "d1"})
         assert temp_storage.get_metadata("nonexistent") is None
 
     def test_get_api_key_before_save(self, temp_storage):
+        """get_api_key returns None when no credentials are stored."""
         assert temp_storage.get_api_key() is None
 
     def test_get_device_id_before_save(self, temp_storage):
+        """get_device_id returns None when no credentials are stored."""
         assert temp_storage.get_device_id() is None
 
     def test_is_provisioned_true(self, temp_storage):
+        """is_provisioned returns True after a device_id is saved."""
         temp_storage.save({"device_id": "d1"})
         assert temp_storage.is_provisioned() is True
 
     def test_is_provisioned_false_before_save(self, temp_storage):
+        """is_provisioned returns False before any data is saved."""
         assert temp_storage.is_provisioned() is False
 
     def test_clear_removes_file(self, temp_storage):
+        """Remove the credentials file from disk."""
         temp_storage.save({"api_key": "sk-test", "device_id": "d1"})
         assert temp_storage._file_path.exists()
         temp_storage.clear()
@@ -146,12 +172,14 @@ class TestLinuxFileStorage:
         assert temp_storage.is_provisioned() is False
 
     def test_file_permissions_are_strict(self, temp_storage):
+        """Credentials file is created with 0o600 permissions."""
         temp_storage.save({"api_key": "sk-test", "device_id": "d1"})
         assert temp_storage._file_path.exists()
         mode = os.stat(temp_storage._file_path).st_mode & 0o777
         assert mode == 0o600, f"Expected 0o600, got {oct(mode)}"
 
     def test_file_content_is_valid_json(self, temp_storage):
+        """Credentials file content is valid JSON with all saved fields."""
         temp_storage.save(
             {"api_key": "sk-json", "device_id": "d-json", "site_id": "s-1"}
         )
@@ -162,10 +190,12 @@ class TestLinuxFileStorage:
         assert data["site_id"] == "s-1"
 
     def test_clear_on_empty_storage(self, temp_storage):
+        """Clear on an empty storage does not raise."""
         temp_storage.clear()
         assert temp_storage.is_provisioned() is False
 
     def test_save_overwrites_existing(self, temp_storage):
+        """Save merges and overwrites fields in the existing file."""
         temp_storage.save({"device_id": "d1", "device_name": "Old Name"})
         temp_storage.save({"device_name": "New Name", "site_id": "s1"})
         data = json.loads(temp_storage._file_path.read_text("utf-8"))
@@ -174,12 +204,14 @@ class TestLinuxFileStorage:
         assert data["site_id"] == "s1"
 
     def test_multiple_instances_same_file(self, temp_storage):
+        """Two LinuxFileStorage instances pointing to the same file see the same data."""
         temp_storage.save({"device_id": "dev-1", "api_key": "sk-1"})
         storage2 = LinuxFileStorage(file_path=temp_storage._file_path)
         assert storage2.get_device_id() == "dev-1"
         assert storage2.get_api_key() == "sk-1"
 
     def test_directory_created_automatically(self):
+        """Parent directories are created automatically when saving."""
         with tempfile.TemporaryDirectory() as tmpdir:
             nested = Path(tmpdir) / "a" / "b" / "c" / "creds.json"
             storage = LinuxFileStorage(file_path=nested)
@@ -188,6 +220,7 @@ class TestLinuxFileStorage:
             assert storage.get_device_id() == "d-nested"
 
     def test_corrupted_file_returns_empty(self, temp_storage):
+        """A corrupted credentials file returns None for all fields."""
         temp_storage._file_path.parent.mkdir(parents=True, exist_ok=True)
         temp_storage._file_path.write_text("not-json", encoding="utf-8")
         assert temp_storage.get_api_key() is None
@@ -195,6 +228,7 @@ class TestLinuxFileStorage:
         assert temp_storage.is_provisioned() is False
 
     def test_save_replaces_corrupted_file(self, temp_storage):
+        """Saving overwrites a corrupted credentials file."""
         temp_storage._file_path.parent.mkdir(parents=True, exist_ok=True)
         temp_storage._file_path.write_text("garbage", encoding="utf-8")
         temp_storage.save({"device_id": "d-fixed", "api_key": "sk-fixed"})
@@ -208,14 +242,18 @@ class TestLinuxFileStorage:
 
 
 class TestCreateCredentialStorage:
+    """Tests for the create_credential_storage factory."""
+
     def test_returns_storage_on_linux(self):
+        """Factory returns LinuxFileStorage on Linux, SimulationStorage elsewhere."""
         storage = create_credential_storage()
         if os.name == "posix" and sys.platform != "darwin":
             assert isinstance(storage, LinuxFileStorage)
         else:
             assert isinstance(storage, SimulationStorage)
 
-    def test_accepts_custom_path_linux(self):
+    def test_accepts_custom_path(self):
+        """Factory accepts an optional storage_path argument."""
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "custom" / "creds.json"
             storage = create_credential_storage(storage_path=path)

--- a/backend/tests/test_agent_credential_storage.py
+++ b/backend/tests/test_agent_credential_storage.py
@@ -8,9 +8,9 @@ Mirrors the TypeScript credentialStorage tests coverage for:
 
 import json
 import os
+from pathlib import Path
 import sys
 import tempfile
-from pathlib import Path
 
 import pytest
 
@@ -19,7 +19,6 @@ from homepot.agent.credential_storage import (
     SimulationStorage,
     create_credential_storage,
 )
-
 
 # ============================================================================
 # SimulationStorage
@@ -153,7 +152,9 @@ class TestLinuxFileStorage:
         assert mode == 0o600, f"Expected 0o600, got {oct(mode)}"
 
     def test_file_content_is_valid_json(self, temp_storage):
-        temp_storage.save({"api_key": "sk-json", "device_id": "d-json", "site_id": "s-1"})
+        temp_storage.save(
+            {"api_key": "sk-json", "device_id": "d-json", "site_id": "s-1"}
+        )
         raw = temp_storage._file_path.read_text("utf-8")
         data = json.loads(raw)
         assert data["api_key"] == "sk-json"

--- a/backend/tests/test_agent_credential_storage.py
+++ b/backend/tests/test_agent_credential_storage.py
@@ -1,0 +1,226 @@
+"""Tests for the Python credential-storage abstraction.
+
+Mirrors the TypeScript credentialStorage tests coverage for:
+- SimulationStorage (in-memory)
+- LinuxFileStorage (file on disk with 0o600 permissions)
+- Factory function (create_credential_storage)
+"""
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from homepot.agent.credential_storage import (
+    LinuxFileStorage,
+    SimulationStorage,
+    create_credential_storage,
+)
+
+
+# ============================================================================
+# SimulationStorage
+# ============================================================================
+
+
+class TestSimulationStorage:
+    def test_save_and_get_api_key(self):
+        storage = SimulationStorage()
+        storage.save({"api_key": "sk-test-123", "device_id": "dev-1"})
+        assert storage.get_api_key() == "sk-test-123"
+
+    def test_save_and_get_device_id(self):
+        storage = SimulationStorage()
+        storage.save({"device_id": "dev-42"})
+        assert storage.get_device_id() == "dev-42"
+
+    def test_get_metadata(self):
+        storage = SimulationStorage()
+        storage.save({"device_name": "Front POS", "site_id": "site-99"})
+        assert storage.get_metadata("device_name") == "Front POS"
+        assert storage.get_metadata("site_id") == "site-99"
+
+    def test_get_metadata_missing(self):
+        storage = SimulationStorage()
+        storage.save({"device_id": "d1"})
+        assert storage.get_metadata("nonexistent") is None
+
+    def test_get_api_key_before_save(self):
+        storage = SimulationStorage()
+        assert storage.get_api_key() is None
+
+    def test_get_device_id_before_save(self):
+        storage = SimulationStorage()
+        assert storage.get_device_id() is None
+
+    def test_is_provisioned_true(self):
+        storage = SimulationStorage()
+        storage.save({"device_id": "d1"})
+        assert storage.is_provisioned() is True
+
+    def test_is_provisioned_false(self):
+        storage = SimulationStorage()
+        assert storage.is_provisioned() is False
+
+    def test_clear_removes_all(self):
+        storage = SimulationStorage()
+        storage.save({"api_key": "sk-test", "device_id": "d1", "site_id": "s1"})
+        storage.clear()
+        assert storage.get_api_key() is None
+        assert storage.get_device_id() is None
+        assert storage.is_provisioned() is False
+
+    def test_save_updates_existing(self):
+        storage = SimulationStorage()
+        storage.save({"device_id": "d1", "device_name": "Old"})
+        storage.save({"device_name": "New", "site_id": "s1"})
+        assert storage.get_device_id() == "d1"
+        assert storage.get_metadata("device_name") == "New"
+        assert storage.get_metadata("site_id") == "s1"
+
+    def test_save_accepts_partial_credentials(self):
+        storage = SimulationStorage()
+        storage.save({"api_key": "sk-test"})
+        assert storage.get_api_key() == "sk-test"
+        assert storage.get_device_id() is None
+
+    def test_multiple_independent_instances(self):
+        s1 = SimulationStorage()
+        s2 = SimulationStorage()
+        s1.save({"device_id": "dev-1"})
+        s2.save({"device_id": "dev-2"})
+        assert s1.get_device_id() == "dev-1"
+        assert s2.get_device_id() == "dev-2"
+
+
+# ============================================================================
+# LinuxFileStorage
+# ============================================================================
+
+
+class TestLinuxFileStorage:
+    @pytest.fixture
+    def temp_storage(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / ".homepot" / "credentials"
+            storage = LinuxFileStorage(file_path=file_path)
+            yield storage
+
+    def test_save_and_get_api_key(self, temp_storage):
+        temp_storage.save({"api_key": "sk-linux-1", "device_id": "dev-linux-1"})
+        assert temp_storage.get_api_key() == "sk-linux-1"
+
+    def test_save_and_get_device_id(self, temp_storage):
+        temp_storage.save({"device_id": "dev-linux-42"})
+        assert temp_storage.get_device_id() == "dev-linux-42"
+
+    def test_get_metadata(self, temp_storage):
+        temp_storage.save({"device_name": "Linux POS", "site_id": "site-linux"})
+        assert temp_storage.get_metadata("device_name") == "Linux POS"
+        assert temp_storage.get_metadata("site_id") == "site-linux"
+
+    def test_get_metadata_missing(self, temp_storage):
+        temp_storage.save({"device_id": "d1"})
+        assert temp_storage.get_metadata("nonexistent") is None
+
+    def test_get_api_key_before_save(self, temp_storage):
+        assert temp_storage.get_api_key() is None
+
+    def test_get_device_id_before_save(self, temp_storage):
+        assert temp_storage.get_device_id() is None
+
+    def test_is_provisioned_true(self, temp_storage):
+        temp_storage.save({"device_id": "d1"})
+        assert temp_storage.is_provisioned() is True
+
+    def test_is_provisioned_false_before_save(self, temp_storage):
+        assert temp_storage.is_provisioned() is False
+
+    def test_clear_removes_file(self, temp_storage):
+        temp_storage.save({"api_key": "sk-test", "device_id": "d1"})
+        assert temp_storage._file_path.exists()
+        temp_storage.clear()
+        assert not temp_storage._file_path.exists()
+        assert temp_storage.is_provisioned() is False
+
+    def test_file_permissions_are_strict(self, temp_storage):
+        temp_storage.save({"api_key": "sk-test", "device_id": "d1"})
+        assert temp_storage._file_path.exists()
+        mode = os.stat(temp_storage._file_path).st_mode & 0o777
+        assert mode == 0o600, f"Expected 0o600, got {oct(mode)}"
+
+    def test_file_content_is_valid_json(self, temp_storage):
+        temp_storage.save({"api_key": "sk-json", "device_id": "d-json", "site_id": "s-1"})
+        raw = temp_storage._file_path.read_text("utf-8")
+        data = json.loads(raw)
+        assert data["api_key"] == "sk-json"
+        assert data["device_id"] == "d-json"
+        assert data["site_id"] == "s-1"
+
+    def test_clear_on_empty_storage(self, temp_storage):
+        temp_storage.clear()
+        assert temp_storage.is_provisioned() is False
+
+    def test_save_overwrites_existing(self, temp_storage):
+        temp_storage.save({"device_id": "d1", "device_name": "Old Name"})
+        temp_storage.save({"device_name": "New Name", "site_id": "s1"})
+        data = json.loads(temp_storage._file_path.read_text("utf-8"))
+        assert data["device_id"] == "d1"
+        assert data["device_name"] == "New Name"
+        assert data["site_id"] == "s1"
+
+    def test_multiple_instances_same_file(self, temp_storage):
+        temp_storage.save({"device_id": "dev-1", "api_key": "sk-1"})
+        storage2 = LinuxFileStorage(file_path=temp_storage._file_path)
+        assert storage2.get_device_id() == "dev-1"
+        assert storage2.get_api_key() == "sk-1"
+
+    def test_directory_created_automatically(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nested = Path(tmpdir) / "a" / "b" / "c" / "creds.json"
+            storage = LinuxFileStorage(file_path=nested)
+            storage.save({"device_id": "d-nested"})
+            assert nested.exists()
+            assert storage.get_device_id() == "d-nested"
+
+    def test_corrupted_file_returns_empty(self, temp_storage):
+        temp_storage._file_path.parent.mkdir(parents=True, exist_ok=True)
+        temp_storage._file_path.write_text("not-json", encoding="utf-8")
+        assert temp_storage.get_api_key() is None
+        assert temp_storage.get_device_id() is None
+        assert temp_storage.is_provisioned() is False
+
+    def test_save_replaces_corrupted_file(self, temp_storage):
+        temp_storage._file_path.parent.mkdir(parents=True, exist_ok=True)
+        temp_storage._file_path.write_text("garbage", encoding="utf-8")
+        temp_storage.save({"device_id": "d-fixed", "api_key": "sk-fixed"})
+        assert temp_storage.get_device_id() == "d-fixed"
+        assert temp_storage.get_api_key() == "sk-fixed"
+
+
+# ============================================================================
+# Factory function
+# ============================================================================
+
+
+class TestCreateCredentialStorage:
+    def test_returns_storage_on_linux(self):
+        storage = create_credential_storage()
+        if os.name == "posix" and sys.platform != "darwin":
+            assert isinstance(storage, LinuxFileStorage)
+        else:
+            assert isinstance(storage, SimulationStorage)
+
+    def test_accepts_custom_path_linux(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "custom" / "creds.json"
+            storage = create_credential_storage(storage_path=path)
+            if os.name == "posix" and sys.platform != "darwin":
+                assert isinstance(storage, LinuxFileStorage)
+            else:
+                assert isinstance(storage, SimulationStorage)
+            storage.save({"device_id": "d1"})
+            assert storage.get_device_id() == "d1"

--- a/backend/tests/test_agent_credential_storage.py
+++ b/backend/tests/test_agent_credential_storage.py
@@ -173,6 +173,8 @@ class TestLinuxFileStorage:
 
     def test_file_permissions_are_strict(self, temp_storage):
         """Credentials file is created with 0o600 permissions."""
+        if sys.platform == "win32":
+            pytest.skip("Windows does not support Unix file permissions")
         temp_storage.save({"api_key": "sk-test", "device_id": "d1"})
         assert temp_storage._file_path.exists()
         mode = os.stat(temp_storage._file_path).st_mode & 0o777

--- a/backend/tests/test_agent_identity.py
+++ b/backend/tests/test_agent_identity.py
@@ -11,6 +11,7 @@ Covers:
 
 import os
 from pathlib import Path
+import sys
 import tempfile
 from unittest.mock import patch
 
@@ -124,6 +125,8 @@ class TestGetOrCreateDeviceId:
 
     def test_id_file_has_correct_permissions(self, tmp_identity_dir):
         """Identity file is created with 0o644 permissions."""
+        if sys.platform == "win32":
+            pytest.skip("Windows does not support Unix file permissions")
         get_or_create_device_id()
         id_file = tmp_identity_dir / "identity"
         mode = os.stat(id_file).st_mode & 0o777

--- a/backend/tests/test_agent_identity.py
+++ b/backend/tests/test_agent_identity.py
@@ -10,15 +10,14 @@ Covers:
 """
 
 import os
-import tempfile
 from pathlib import Path
+import tempfile
 from unittest.mock import patch
 
 import pytest
 
 from homepot.agent.identity import (
     _generate_uuid_identity,
-    _identity_file_path,
     _machine_id_identity,
     get_device_id,
     get_or_create_device_id,
@@ -26,7 +25,6 @@ from homepot.agent.identity import (
     identity_path,
     reset_device_id,
 )
-
 
 # ============================================================================
 # Unit tests for internal helpers
@@ -183,14 +181,19 @@ class TestEdgeCases:
 
     def test_machine_id_with_newlines(self):
         with patch("homepot.agent.identity.Path.exists", return_value=True):
-            with patch("homepot.agent.identity.Path.read_text", return_value="abc123\n"):
+            with patch(
+                "homepot.agent.identity.Path.read_text", return_value="abc123\n"
+            ):
                 result = _machine_id_identity()
                 assert result is not None
                 assert result.startswith("device-")
 
     def test_machine_id_returns_none_on_read_error(self):
         with patch("homepot.agent.identity.Path.exists", return_value=True):
-            with patch("homepot.agent.identity.Path.read_text", side_effect=PermissionError("No")):
+            with patch(
+                "homepot.agent.identity.Path.read_text",
+                side_effect=PermissionError("No"),
+            ):
                 result = _machine_id_identity()
                 assert result is None
 

--- a/backend/tests/test_agent_identity.py
+++ b/backend/tests/test_agent_identity.py
@@ -1,0 +1,206 @@
+"""Tests for persistent device identity management.
+
+Covers:
+- get_or_create_device_id()
+- get_device_id()
+- reset_device_id()
+- identity_path()
+- identity_dir()
+- Fallback to machine-id when identity dir is unwritable
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from homepot.agent.identity import (
+    _generate_uuid_identity,
+    _identity_file_path,
+    _machine_id_identity,
+    get_device_id,
+    get_or_create_device_id,
+    identity_dir,
+    identity_path,
+    reset_device_id,
+)
+
+
+# ============================================================================
+# Unit tests for internal helpers
+# ============================================================================
+
+
+class TestGenerateUuidIdentity:
+    def test_returns_string_with_device_prefix(self):
+        ident = _generate_uuid_identity()
+        assert ident.startswith("device-")
+        assert len(ident) > len("device-")
+
+    def test_returns_unique_values(self):
+        id1 = _generate_uuid_identity()
+        id2 = _generate_uuid_identity()
+        assert id1 != id2
+
+
+class TestMachineIdIdentity:
+    def test_returns_none_when_no_machine_id(self):
+        with patch("homepot.agent.identity.Path.exists", return_value=False):
+            result = _machine_id_identity()
+            assert result is None
+
+    def test_returns_none_on_empty_machine_id(self):
+        with patch("homepot.agent.identity.Path.exists", return_value=True):
+            with patch("homepot.agent.identity.Path.read_text", return_value=""):
+                result = _machine_id_identity()
+                assert result is None
+
+    def test_returns_deterministic_id_from_machine_id(self):
+        fake_id = "abc123def456"
+        expected_prefix = "device-"
+        with patch("homepot.agent.identity.Path.exists", return_value=True):
+            with patch("homepot.agent.identity.Path.read_text", return_value=fake_id):
+                result = _machine_id_identity()
+                assert result is not None
+                assert result.startswith(expected_prefix)
+                assert len(result) > len(expected_prefix)
+
+    def test_same_machine_id_gives_same_device_id(self):
+        fake_id = "same-machine-id"
+        with patch("homepot.agent.identity.Path.exists", return_value=True):
+            with patch("homepot.agent.identity.Path.read_text", return_value=fake_id):
+                r1 = _machine_id_identity()
+                r2 = _machine_id_identity()
+                assert r1 == r2
+
+
+# ============================================================================
+# Integration tests with temporary identity directories
+# ============================================================================
+
+
+@pytest.fixture
+def tmp_identity_dir(monkeypatch):
+    """Redirect identity storage to a temp directory."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        monkeypatch.setattr("homepot.agent.identity._VAR_LIB_PATH", tmp_path)
+        yield tmp_path
+
+
+class TestGetOrCreateDeviceId:
+    def test_creates_and_returns_device_id(self, tmp_identity_dir):
+        device_id = get_or_create_device_id()
+        assert device_id.startswith("device-")
+        id_file = tmp_identity_dir / "identity"
+        assert id_file.exists()
+        assert id_file.read_text("utf-8").strip() == device_id
+
+    def test_returns_same_id_on_second_call(self, tmp_identity_dir):
+        first = get_or_create_device_id()
+        second = get_or_create_device_id()
+        assert first == second
+
+    def test_returns_existing_id_from_file(self, tmp_identity_dir):
+        id_file = tmp_identity_dir / "identity"
+        id_file.write_text("device-preexisting-id\n", encoding="utf-8")
+        device_id = get_or_create_device_id()
+        assert device_id == "device-preexisting-id"
+
+    def test_id_file_has_correct_permissions(self, tmp_identity_dir):
+        get_or_create_device_id()
+        id_file = tmp_identity_dir / "identity"
+        mode = os.stat(id_file).st_mode & 0o777
+        assert mode == 0o644, f"Expected 0o644, got {oct(mode)}"
+
+
+class TestGetDeviceId:
+    def test_returns_none_when_no_identity(self, tmp_identity_dir, monkeypatch):
+        monkeypatch.setattr("homepot.agent.identity._machine_id_identity", lambda: None)
+        assert get_device_id() is None
+
+    def test_returns_id_from_file(self, tmp_identity_dir, monkeypatch):
+        monkeypatch.setattr("homepot.agent.identity._machine_id_identity", lambda: None)
+        id_file = tmp_identity_dir / "identity"
+        id_file.write_text("device-existing\n", encoding="utf-8")
+        assert get_device_id() == "device-existing"
+
+    def test_returns_none_on_corrupted_file(self, tmp_identity_dir, monkeypatch):
+        monkeypatch.setattr("homepot.agent.identity._machine_id_identity", lambda: None)
+        id_file = tmp_identity_dir / "identity"
+        id_file.write_text("", encoding="utf-8")
+        assert get_device_id() is None
+
+
+class TestResetDeviceId:
+    def test_removes_identity_file(self, tmp_identity_dir):
+        get_or_create_device_id()
+        assert (tmp_identity_dir / "identity").exists()
+        reset_device_id()
+        assert not (tmp_identity_dir / "identity").exists()
+
+    def test_after_reset_new_id_is_generated(self, tmp_identity_dir):
+        first = get_or_create_device_id()
+        reset_device_id()
+        second = get_or_create_device_id()
+        assert first != second
+
+    def test_reset_on_empty(self, tmp_identity_dir):
+        reset_device_id()
+
+
+class TestIdentityPaths:
+    def test_identity_path_returns_file(self, tmp_identity_dir):
+        path = identity_path()
+        assert path == tmp_identity_dir / "identity"
+
+    def test_identity_dir_returns_directory(self, tmp_identity_dir):
+        directory = identity_dir()
+        assert directory == tmp_identity_dir
+
+    def test_identity_file_does_not_exist_initially(self, tmp_identity_dir):
+        assert not identity_path().exists()
+
+    def test_identity_file_exists_after_create(self, tmp_identity_dir):
+        get_or_create_device_id()
+        assert identity_path().exists()
+
+
+# ============================================================================
+# Edge cases
+# ============================================================================
+
+
+class TestEdgeCases:
+    def test_uuid_format(self):
+        ident = _generate_uuid_identity()
+        parts = ident.split("-")
+        assert parts[0] == "device"
+        assert len(parts) == 2
+        assert len(parts[1]) == 32
+
+    def test_machine_id_with_newlines(self):
+        with patch("homepot.agent.identity.Path.exists", return_value=True):
+            with patch("homepot.agent.identity.Path.read_text", return_value="abc123\n"):
+                result = _machine_id_identity()
+                assert result is not None
+                assert result.startswith("device-")
+
+    def test_machine_id_returns_none_on_read_error(self):
+        with patch("homepot.agent.identity.Path.exists", return_value=True):
+            with patch("homepot.agent.identity.Path.read_text", side_effect=PermissionError("No")):
+                result = _machine_id_identity()
+                assert result is None
+
+    def test_identity_persistence_survives_object_recreation(self, tmp_identity_dir):
+        first = get_or_create_device_id()
+        with patch("homepot.agent.identity._VAR_LIB_PATH", tmp_identity_dir):
+            second = get_or_create_device_id()
+        assert first == second
+
+    def test_identity_dir_creates_directory(self, tmp_identity_dir):
+        assert tmp_identity_dir.exists()
+        result = identity_dir()
+        assert result == tmp_identity_dir

--- a/backend/tests/test_agent_identity.py
+++ b/backend/tests/test_agent_identity.py
@@ -32,30 +32,39 @@ from homepot.agent.identity import (
 
 
 class TestGenerateUuidIdentity:
+    """Tests for the _generate_uuid_identity helper."""
+
     def test_returns_string_with_device_prefix(self):
+        """Generated identity starts with 'device-' and has sufficient length."""
         ident = _generate_uuid_identity()
         assert ident.startswith("device-")
         assert len(ident) > len("device-")
 
     def test_returns_unique_values(self):
+        """Each call to _generate_uuid_identity returns a unique value."""
         id1 = _generate_uuid_identity()
         id2 = _generate_uuid_identity()
         assert id1 != id2
 
 
 class TestMachineIdIdentity:
+    """Tests for the _machine_id_identity helper."""
+
     def test_returns_none_when_no_machine_id(self):
+        """Returns None when /etc/machine-id does not exist."""
         with patch("homepot.agent.identity.Path.exists", return_value=False):
             result = _machine_id_identity()
             assert result is None
 
     def test_returns_none_on_empty_machine_id(self):
+        """Returns None when machine-id file is empty."""
         with patch("homepot.agent.identity.Path.exists", return_value=True):
             with patch("homepot.agent.identity.Path.read_text", return_value=""):
                 result = _machine_id_identity()
                 assert result is None
 
     def test_returns_deterministic_id_from_machine_id(self):
+        """A known machine-id produces a deterministic device identity."""
         fake_id = "abc123def456"
         expected_prefix = "device-"
         with patch("homepot.agent.identity.Path.exists", return_value=True):
@@ -66,6 +75,7 @@ class TestMachineIdIdentity:
                 assert len(result) > len(expected_prefix)
 
     def test_same_machine_id_gives_same_device_id(self):
+        """The same machine-id always yields the same device identity."""
         fake_id = "same-machine-id"
         with patch("homepot.agent.identity.Path.exists", return_value=True):
             with patch("homepot.agent.identity.Path.read_text", return_value=fake_id):
@@ -89,7 +99,10 @@ def tmp_identity_dir(monkeypatch):
 
 
 class TestGetOrCreateDeviceId:
+    """Tests for get_or_create_device_id with a temporary directory."""
+
     def test_creates_and_returns_device_id(self, tmp_identity_dir):
+        """Creates a new UUID-based identity and persists it to disk."""
         device_id = get_or_create_device_id()
         assert device_id.startswith("device-")
         id_file = tmp_identity_dir / "identity"
@@ -97,17 +110,20 @@ class TestGetOrCreateDeviceId:
         assert id_file.read_text("utf-8").strip() == device_id
 
     def test_returns_same_id_on_second_call(self, tmp_identity_dir):
+        """Calling get_or_create_device_id twice returns the same ID."""
         first = get_or_create_device_id()
         second = get_or_create_device_id()
         assert first == second
 
     def test_returns_existing_id_from_file(self, tmp_identity_dir):
+        """If an identity file already exists, its content is returned."""
         id_file = tmp_identity_dir / "identity"
         id_file.write_text("device-preexisting-id\n", encoding="utf-8")
         device_id = get_or_create_device_id()
         assert device_id == "device-preexisting-id"
 
     def test_id_file_has_correct_permissions(self, tmp_identity_dir):
+        """Identity file is created with 0o644 permissions."""
         get_or_create_device_id()
         id_file = tmp_identity_dir / "identity"
         mode = os.stat(id_file).st_mode & 0o777
@@ -115,17 +131,22 @@ class TestGetOrCreateDeviceId:
 
 
 class TestGetDeviceId:
+    """Tests for get_device_id (read-only, no creation)."""
+
     def test_returns_none_when_no_identity(self, tmp_identity_dir, monkeypatch):
+        """Returns None when no identity file or machine-id exists."""
         monkeypatch.setattr("homepot.agent.identity._machine_id_identity", lambda: None)
         assert get_device_id() is None
 
     def test_returns_id_from_file(self, tmp_identity_dir, monkeypatch):
+        """Returns the device ID from an existing identity file."""
         monkeypatch.setattr("homepot.agent.identity._machine_id_identity", lambda: None)
         id_file = tmp_identity_dir / "identity"
         id_file.write_text("device-existing\n", encoding="utf-8")
         assert get_device_id() == "device-existing"
 
     def test_returns_none_on_corrupted_file(self, tmp_identity_dir, monkeypatch):
+        """Returns None when the identity file is empty."""
         monkeypatch.setattr("homepot.agent.identity._machine_id_identity", lambda: None)
         id_file = tmp_identity_dir / "identity"
         id_file.write_text("", encoding="utf-8")
@@ -133,35 +154,46 @@ class TestGetDeviceId:
 
 
 class TestResetDeviceId:
+    """Tests for reset_device_id."""
+
     def test_removes_identity_file(self, tmp_identity_dir):
+        """reset_device_id removes the identity file from disk."""
         get_or_create_device_id()
         assert (tmp_identity_dir / "identity").exists()
         reset_device_id()
         assert not (tmp_identity_dir / "identity").exists()
 
     def test_after_reset_new_id_is_generated(self, tmp_identity_dir):
+        """After reset, get_or_create_device_id generates a new ID."""
         first = get_or_create_device_id()
         reset_device_id()
         second = get_or_create_device_id()
         assert first != second
 
     def test_reset_on_empty(self, tmp_identity_dir):
+        """Calling reset_device_id when no identity file exists does not raise."""
         reset_device_id()
 
 
 class TestIdentityPaths:
+    """Tests for identity_path and identity_dir."""
+
     def test_identity_path_returns_file(self, tmp_identity_dir):
+        """identity_path returns the path to the identity file."""
         path = identity_path()
         assert path == tmp_identity_dir / "identity"
 
     def test_identity_dir_returns_directory(self, tmp_identity_dir):
+        """identity_dir returns the directory containing the identity file."""
         directory = identity_dir()
         assert directory == tmp_identity_dir
 
     def test_identity_file_does_not_exist_initially(self, tmp_identity_dir):
+        """The identity file does not exist before any call to create it."""
         assert not identity_path().exists()
 
     def test_identity_file_exists_after_create(self, tmp_identity_dir):
+        """The identity file exists after get_or_create_device_id is called."""
         get_or_create_device_id()
         assert identity_path().exists()
 
@@ -172,7 +204,10 @@ class TestIdentityPaths:
 
 
 class TestEdgeCases:
+    """Edge-case tests for device identity."""
+
     def test_uuid_format(self):
+        """Generated UUID identity has the expected 'device-<hex>' format."""
         ident = _generate_uuid_identity()
         parts = ident.split("-")
         assert parts[0] == "device"
@@ -180,6 +215,7 @@ class TestEdgeCases:
         assert len(parts[1]) == 32
 
     def test_machine_id_with_newlines(self):
+        """machine-id with trailing newline is stripped correctly."""
         with patch("homepot.agent.identity.Path.exists", return_value=True):
             with patch(
                 "homepot.agent.identity.Path.read_text", return_value="abc123\n"
@@ -189,6 +225,7 @@ class TestEdgeCases:
                 assert result.startswith("device-")
 
     def test_machine_id_returns_none_on_read_error(self):
+        """A PermissionError reading machine-id returns None."""
         with patch("homepot.agent.identity.Path.exists", return_value=True):
             with patch(
                 "homepot.agent.identity.Path.read_text",
@@ -198,12 +235,14 @@ class TestEdgeCases:
                 assert result is None
 
     def test_identity_persistence_survives_object_recreation(self, tmp_identity_dir):
+        """Identity persists across re-creation of the directory reference."""
         first = get_or_create_device_id()
         with patch("homepot.agent.identity._VAR_LIB_PATH", tmp_identity_dir):
             second = get_or_create_device_id()
         assert first == second
 
     def test_identity_dir_creates_directory(self, tmp_identity_dir):
+        """identity_dir creates the directory if it does not exist."""
         assert tmp_identity_dir.exists()
         result = identity_dir()
         assert result == tmp_identity_dir

--- a/docs/agent-packaging-and-identity.md
+++ b/docs/agent-packaging-and-identity.md
@@ -1,0 +1,260 @@
+# Agent Packaging and Identity — PR 12
+
+## Purpose
+
+PR 12 delivers the foundational scaffolding for deploying the HOMEPOT Agent
+as a production Linux daemon. It covers three concerns:
+
+1. **Packaging** — systemd service unit, install script, FHS-compliant data
+   directories, and Python entry point.
+2. **Identity** — a persistent, stable device identifier that survives restarts,
+   re-enrolment, and OS reinstallation (as long as the data partition is
+   retained).
+3. **Credential storage** — a Python implementation of the `CredentialStorage`
+   interface that mirrors the TypeScript abstraction in the User App, so that
+   agent code can read/write credentials using the same contract on the backend
+   side.
+
+## Files created or modified
+
+| File | Purpose |
+|------|---------|
+| `backend/src/homepot/agent/credential_storage.py` | Python credential-storage abstraction (SimulationStorage + LinuxFileStorage + factory) |
+| `backend/src/homepot/agent/identity.py` | Persistent device-identity generation and management |
+| `backend/src/homepot/agent/cli.py` | `homepot-agent` CLI with `run`, `identity`, `reset-identity`, `status`, `show-config`, `credentials`, `clear-credentials` commands |
+| `backend/src/homepot/agent/__init__.py` | Updated to export the new public API |
+| `backend/src/homepot/agent/real_device_agent.py` | Updated to load identity from `identity.py` and credentials from `credential_storage.py` |
+| `backend/pyproject.toml` | Added `agent` optional-dependency group and `homepot-agent` console script |
+| `scripts/homepot-agent.service` | systemd unit file with security hardening |
+| `scripts/install-agent.sh` | Install/uninstall script for the agent systemd service |
+| `tests/test_agent_credential_storage.py` | 31 tests for credential storage |
+| `tests/test_agent_identity.py` | 25 tests for device identity |
+| `docs/agent-packaging-and-identity.md` | This document |
+
+## Architecture
+
+```
+homepot-agent CLI (cli.py)
+│
+├── identity.py        ─── persistent device ID
+│   ├── /var/lib/homepot/identity   (preferred, daemon)
+│   └── ~/.local/share/homepot/identity  (fallback, dev)
+│
+├── credential_storage.py ─── OS-protected credential file
+│   └── ~/.homepot/credentials  (0600 permissions)
+│
+└── real_device_agent.py ─── runtime loops
+    ├── registration (device-dna)
+    ├── heartbeat
+    ├── telemetry
+    └── retry queue
+```
+
+## Device identity
+
+### Resolution order
+
+`get_or_create_device_id()` follows this resolution:
+
+1. **Read existing identity file** at `/var/lib/homepot/identity` (or
+   `$XDG_DATA_HOME/homepot/identity` for unprivileged runs).
+2. **Generate a new UUID** (`device-<32 hex chars>`) and persist it to the
+   identity file.
+3. **Fallback to `/etc/machine-id`** if the identity directory is not writable.
+   The machine ID is salted with a domain-specific string and SHA-256-hashed to
+   produce a deterministic but non-reversible device identity.
+
+### Identity file format
+
+A single line of text containing the device ID string:
+
+```
+device-a1b2c3d4e5f6789012345678abcdef01
+```
+
+The file is created with mode `0o644`.
+
+### Resetting identity
+
+```bash
+homepot-agent reset-identity
+```
+
+This removes the identity file. A new one is generated on the next
+`homepot-agent run` or `homepot-agent identity` invocation. It does **not**
+affect `/etc/machine-id`.
+
+## Credential storage
+
+### Interface
+
+`CredentialStorage` is an abstract base class with the same methods as the
+TypeScript `CredentialStorage` from `user_app/src/services/credentialStorage.ts`:
+
+| Method | Description |
+|--------|-------------|
+| `save(creds)` | Persist credentials after a successful provision or claim |
+| `get_api_key()` | Retrieve the stored API key |
+| `get_device_id()` | Retrieve the stored device ID |
+| `get_metadata(key)` | Retrieve a metadata field by key |
+| `clear()` | Remove all stored credentials (unpair / factory-reset) |
+| `is_provisioned()` | `True` if credentials are present |
+
+### Implementations
+
+| Class | Platform | Storage |
+|-------|----------|---------|
+| `SimulationStorage` | Any (testing/dev) | In-memory dict |
+| `LinuxFileStorage` | Linux | `~/.homepot/credentials` with `0o600` permissions |
+
+### Factory
+
+```python
+from homepot.agent.credential_storage import create_credential_storage
+
+storage = create_credential_storage()
+# Returns LinuxFileStorage on Linux, SimulationStorage elsewhere
+```
+
+## Systemd service
+
+### Unit file
+
+`scripts/homepot-agent.service` provides a hardened systemd unit:
+
+- Runs as the `homepot` system user (no login shell).
+- Uses `ProtectSystem=full`, `PrivateTmp=true`, `NoNewPrivileges=true`,
+  `MemoryDenyWriteExecute=true`, and other security hardening directives.
+- Stores runtime state in `/run/homepot-agent`.
+- Stores persistent state in `/var/lib/homepot` (identity, credentials).
+- Restarts on failure with a 10-second delay (up to 5 times per 60 seconds).
+
+### Installation
+
+```bash
+# From the repository root
+sudo ./scripts/install-agent.sh
+
+# Verify
+systemctl status homepot-agent
+
+# View logs
+journalctl -u homepot-agent -f
+```
+
+### Uninstallation
+
+```bash
+sudo ./scripts/install-agent.sh --uninstall
+```
+
+## CLI reference
+
+```text
+Usage: homepot-agent [OPTIONS] COMMAND [ARGS]...
+
+  HOMEPOT Device Agent - managed endpoint runtime
+
+Options:
+  --verbose, -v     Enable verbose logging
+  --config, -c PATH  Path to agent configuration JSON
+  --help            Show this message and exit
+
+Commands:
+  run                Run the agent runtime (main daemon entry point)
+  identity           Show the current device identity
+  reset-identity     Remove the stored device identity
+  status             Show the current agent status
+  show-config        Show the effective agent configuration
+  credentials        Show credential storage status
+  clear-credentials  Remove all stored credentials (local unpair)
+```
+
+### Typical workflow
+
+```bash
+# Generate identity and show it
+homepot-agent identity
+
+# Check status
+homepot-agent status
+
+# Run the agent (foreground)
+homepot-agent run
+
+# Run with a custom config file
+homepot-agent -c /etc/homepot/agent.json run
+```
+
+## Packaging
+
+### Python entry points
+
+The `pyproject.toml` registers two console scripts:
+
+```toml
+[project.scripts]
+homepot-client = "homepot.cli:main"
+homepot-agent = "homepot.agent.cli:main"
+```
+
+### Optional dependencies
+
+The `agent` extra installs agent-specific runtime dependencies:
+
+```bash
+pip install homepot-client[agent]
+```
+
+These are intentionally kept minimal: `httpx`, `psutil`, `platformdirs`.
+
+### FHS layout (installed system)
+
+| Path | Contents |
+|------|----------|
+| `/usr/bin/homepot-agent` | Console script entry point |
+| `/etc/systemd/system/homepot-agent.service` | systemd unit |
+| `/var/lib/homepot/identity` | Persistent device identity |
+| `~/.homepot/credentials` | Device API credentials (`0o600`) |
+
+## Backward compatibility
+
+- The existing `agent-config.json` file continues to work. Values in the JSON
+  file take precedence over generated identity and credential storage values.
+- The `agent_config` environment variable `HOMEPOT_AGENT_CONFIG` overrides the
+  default config path.
+- If no config file is found, the agent generates an identity and uses
+  credential storage (requiring prior provisioning before it can authenticate
+  with the backend).
+
+## Testing
+
+```bash
+cd backend
+pytest tests/test_agent_credential_storage.py tests/test_agent_identity.py -v
+```
+
+**Test coverage** (new code):
+
+| Module | Coverage |
+|--------|----------|
+| `credential_storage.py` | 97% |
+| `identity.py` | 84% |
+
+The uncovered lines in `identity.py` are the permission-denied branch of
+`_machine_id_identity()` (requires a real `/etc/machine-id` with read
+restrictions) and the fallback-to-machine-id branch in
+`get_or_create_device_id()` (requires identity dir to be unwritable).
+
+## PR checklist
+
+- [x] Python credential storage mirrors TypeScript interface
+- [x] Persistent device identity with UUID and machine-id fallback
+- [x] systemd service unit with security hardening
+- [x] Install/uninstall script
+- [x] CLI with `run`, `identity`, `status`, `config`, `credentials` commands
+- [x] `pyproject.toml` updated with agent entry points and deps
+- [x] `real_device_agent.py` updated to use new modules
+- [x] 31 credential storage tests pass
+- [x] 25 identity tests pass
+- [x] Minimum 10% project coverage maintained

--- a/docs/device-lifecycle-and-ownership.md
+++ b/docs/device-lifecycle-and-ownership.md
@@ -375,3 +375,46 @@ Implement authorised transitions with audit reasons:
 - unpaired → active through a new epoch
 - eligible states → retired
 Transfer between sites should create a new assignment and epoch, revoke old credentials, and require permission in both scopes.
+
+## Linux real-device readiness
+Once the lifecycle and credential contract is stable:
+- package the Linux agent;
+- generate a persistent stable device identity;
+- secure credentials on disk or in a keyring;
+- configure backend URL and trust anchors;
+- implement authenticated DNA registration;
+- implement heartbeat and telemetry retry queues;
+- implement command polling/push wake-up;
+- implement command acknowledgement and result reporting;
+- add log rotation and service supervision;
+- test restart, network loss, token revocation, duplicate enrolment, and unpairing.
+The Linux agent should be the reference implementation for the later Windows agent.
+
+PR 12: Agent packaging & identity
+- Package the Python code as a proper Linux daemon (systemd service, deb/rpm, FHS layout)
+- Generate a persistent stable device identity (e.g. /etc/machine-id + salt, or a generated UUID stored in /var/lib/homepot/identity)
+- Placeholder for LinuxFileStorage in credentialStorage.ts → actually implement it on the Python side
+  
+PR 13: Linux credential storage
+- Implement real OS-protected credential storage (file with 0600 at ~/.homepot/credentials or a keyring integration)
+- Backend URL and TLS trust anchor configuration
+  
+PR 14: Authenticated agent bootstrap
+- Implement the full agent bootstrap flow: identity generation → DNA registration → heartbeat start
+- Move from manual TestClient provision to the agent calling /devices/provision itself
+
+PR 15: Heartbeat & telemetry with retry
+- Implement the heartbeat loop with authenticated X-Device-ID / X-API-Key
+- Add a retry queue for offline periods (exponential backoff, persistent queue on disk)
+
+PR 16: Command polling & push wake-up
+- Implement /devices/pending polling loop
+- Add push wake-up integration (MQTT/FCM) so the agent doesn't need to poll constantly
+
+PR 17: Command ack & result reporting
+- Implement /devices/{device_id}/commands/{command_id}/ack and result submission
+- Wire up to local IPC so the real device can execute commands
+
+PR 18: Production hardening
+- Log rotation, service supervision (systemd watchdog), graceful shutdown
+- Comprehensive failure tests: restart, network loss, token revocation, duplicate enrolment, unpairing

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -161,6 +161,7 @@ nav:
           - POS System (Dummy): POSDummy-Integration.md
       - Agents & Simulation:
           - Agent Simulation: agent-simulation.md
+          - Agent Packaging & Identity: agent-packaging-and-identity.md
           - Fleet Load Testing: fleet-simulation.md
           - Real Device Transition: real-device-transition.md
           - Team Tasks (Readiness): real-device-readiness-tasks.md

--- a/scripts/homepot-agent.service
+++ b/scripts/homepot-agent.service
@@ -1,0 +1,48 @@
+[Unit]
+Description=HOMEPOT Device Agent
+Documentation=https://github.com/brunel-opensim/homepot-client
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=homepot
+Group=homepot
+RuntimeDirectory=homepot-agent
+RuntimeDirectoryMode=0755
+StateDirectory=homepot-agent
+StateDirectoryMode=0700
+CacheDirectory=homepot-agent
+CacheDirectoryMode=0755
+
+ExecStart=/usr/bin/homepot-agent run
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=10
+StartLimitBurst=5
+StartLimitIntervalSec=60
+
+# Security hardening
+ProtectSystem=full
+ProtectHome=read-only
+PrivateTmp=true
+NoNewPrivileges=true
+CapabilityBoundingSet=
+AmbientCapabilities=
+ProtectClock=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+MemoryDenyWriteExecute=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+SystemCallArchitectures=native
+LockPersonality=true
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/install-agent.sh
+++ b/scripts/install-agent.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Install the HOMEPOT Agent as a systemd service on Linux.
+#
+# Usage:
+#   sudo ./scripts/install-agent.sh              # install from repo checkout
+#   sudo ./scripts/install-agent.sh --uninstall   # remove the service
+#
+# This script:
+#   1. Installs the Python package into the system Python or a venv.
+#   2. Creates the homepot system user.
+#   3. Installs the systemd service unit.
+#   4. Creates /var/lib/homepot for identity persistence.
+#   5. Enables and starts the service.
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+INSTALL_PREFIX="${INSTALL_PREFIX:-/usr/local}"
+SERVICE_NAME="homepot-agent"
+SYSTEMD_DIR="/etc/systemd/system"
+HOMEPOT_USER="homepot"
+HOMEPOT_GROUP="homepot"
+VAR_LIB="/var/lib/homepot"
+
+# ---- helpers ---------------------------------------------------------------
+die() { echo "[ERROR] $*" >&2; exit 1; }
+info() { echo "[INFO] $*"; }
+
+# ---- parse flags -----------------------------------------------------------
+UNINSTALL=false
+for arg in "$@"; do
+    case "$arg" in
+        --uninstall) UNINSTALL=true ;;
+        --help) echo "Usage: $0 [--uninstall]" ; exit 0 ;;
+    esac
+done
+
+# ---- uninstall -------------------------------------------------------------
+if $UNINSTALL; then
+    info "Stopping and disabling $SERVICE_NAME..."
+    systemctl stop "$SERVICE_NAME" 2>/dev/null || true
+    systemctl disable "$SERVICE_NAME" 2>/dev/null || true
+    rm -f "$SYSTEMD_DIR/$SERVICE_NAME.service"
+    systemctl daemon-reload
+    info "Service removed."
+    exit 0
+fi
+
+# ---- check prerequisites ---------------------------------------------------
+if [[ $EUID -ne 0 ]]; then
+    die "This script must be run as root (sudo)."
+fi
+
+if ! command -v python3 &>/dev/null; then
+    die "python3 is required but not found."
+fi
+
+if ! command -v systemctl &>/dev/null; then
+    die "systemctl not found. This script only supports systemd-based systems."
+fi
+
+# ---- create system user ----------------------------------------------------
+if ! id -u "$HOMEPOT_USER" &>/dev/null; then
+    info "Creating system user '$HOMEPOT_USER'..."
+    useradd --system --no-create-home --shell /usr/sbin/nologin "$HOMEPOT_USER"
+fi
+
+# ---- install Python package ------------------------------------------------
+info "Installing homepot-agent Python package..."
+cd "$REPO_ROOT/backend"
+
+if [ -d ".venv" ]; then
+    info "Using existing virtual environment at backend/.venv"
+    PIP=".venv/bin/pip"
+    PYTHON=".venv/bin/python"
+else
+    PIP="pip3"
+    PYTHON="python3"
+fi
+
+$PIP install --upgrade pip
+$PIP install -e ".[agent]"
+
+# ---- create data directories -----------------------------------------------
+info "Creating /var/lib/homepot..."
+mkdir -p "$VAR_LIB"
+chown "$HOMEPOT_USER:$HOMEPOT_GROUP" "$VAR_LIB"
+chmod 0755 "$VAR_LIB"
+
+# ---- install systemd unit --------------------------------------------------
+info "Installing systemd service unit..."
+cp "$SCRIPT_DIR/homepot-agent.service" "$SYSTEMD_DIR/$SERVICE_NAME.service"
+chmod 0644 "$SYSTEMD_DIR/$SERVICE_NAME.service"
+
+# Update the ExecStart to point to the installed agent binary
+AGENT_BIN="$INSTALL_PREFIX/bin/homepot-agent"
+sed -i "s|ExecStart=.*|ExecStart=$AGENT_BIN run|" "$SYSTEMD_DIR/$SERVICE_NAME.service"
+
+systemctl daemon-reload
+
+# ---- enable and start ------------------------------------------------------
+info "Enabling and starting $SERVICE_NAME..."
+systemctl enable "$SERVICE_NAME"
+systemctl start "$SERVICE_NAME"
+
+info "Checking service status..."
+systemctl status "$SERVICE_NAME" --no-pager || true
+
+echo ""
+echo "HOMEPOT Agent installed successfully."
+echo "  Service:  $SERVICE_NAME"
+echo "  Binary:   $AGENT_BIN"
+echo "  Data:     $VAR_LIB"
+echo ""
+echo "Manage with:"
+echo "  sudo systemctl status $SERVICE_NAME"
+echo "  sudo journalctl -u $SERVICE_NAME -f"


### PR DESCRIPTION
## Summary

PR 12 delivers the foundational scaffolding for deploying the HOMEPOT Agent as a production Linux daemon: packaging (systemd, FHS layout, install script), persistent device identity, and Python credential storage mirroring the TypeScript abstraction.

### Changes

**New modules**
- `backend/src/homepot/agent/credential_storage.py` — Python `CredentialStorage` ABC with `SimulationStorage` (in-memory) and `LinuxFileStorage` (~/.homepot/credentials, 0o600 perms) + platform factory
- `backend/src/homepot/agent/identity.py` — Persistent device identity: UUID stored at /var/lib/homepot/identity, SHA-256(/etc/machine-id + salt) fallback
- `backend/src/homepot/agent/cli.py` — `homepot-agent` CLI: run, identity, reset-identity, status, show-config, credentials, clear-credentials

**Service & packaging**
- `scripts/homepot-agent.service` — Hardened systemd unit (ProtectSystem, NoNewPrivileges, MemoryDenyWriteExecute, PrivateTmp, etc.)
- `scripts/install-agent.sh` — Install/uninstall script
- `backend/pyproject.toml` — Added `agent` optional-deps group, `homepot-agent` console script, `platformdirs` to core deps

**Updated modules**
- `real_device_agent.py` — Loads identity from identity.py and credentials from credential_storage.py with fallback to config file
- `agent/__init__.py` — Exports new public API

**Documentation**
- `docs/agent-packaging-and-identity.md` — Full design doc with architecture, CLI reference, FHS layout, and PR checklist
- `docs/device-lifecycle-and-ownership.md` — PR 12–18 roadmap added
- `mkdocs.yml` — Added to nav tree

### Tests

- 31 tests for credential storage (97% coverage)
- 25 tests for identity (84% coverage)
- All 66 agent-related tests pass (56 new + 10 existing)

```
cd backend && pytest tests/test_agent_credential_storage.py tests/test_agent_identity.py -v
# 56 passed
```

### Checklist

- [x] Python credential storage mirrors TypeScript interface
- [x] Persistent device identity with UUID and machine-id fallback
- [x] systemd service unit with security hardening
- [x] CLI with run, identity, status, config, credentials commands
- [x] pyproject.toml updated with agent entry points and deps
- [x] real_device_agent.py updated to use new modules
- [x] 31 credential storage tests pass
- [x] 25 identity tests pass
- [x] Minimum 10% project coverage maintained (34.92%)