### PR TITLE
feat: Authenticated agent bootstrap

### DIFF
--- a/backend/src/homepot/agent/cli.py
+++ b/backend/src/homepot/agent/cli.py
@@ -24,7 +24,11 @@ from homepot.agent.identity import (
     identity_path,
     reset_device_id,
 )
-from homepot.agent.real_device_agent import load_agent_config, run_agent
+from homepot.agent.real_device_agent import (
+    bootstrap_agent,
+    load_agent_config,
+    run_agent,
+)
 
 app = typer.Typer(
     name="homepot-agent",
@@ -84,6 +88,82 @@ def run(
         os.environ["HOMEPOT_AGENT_CONFIG"] = str(config.resolve())
     ensure_identity()
     asyncio.run(run_agent())
+
+
+# ---------------------------------------------------------------------------
+# bootstrap
+# ---------------------------------------------------------------------------
+
+
+@app.command()
+def bootstrap(
+    backend_url: str = typer.Argument(
+        ..., help="Backend URL (e.g. https://api.homepot.example.com)"
+    ),
+    intent_id: str = typer.Argument(
+        ..., help="Public ID of a pre-approved enrolment intent"
+    ),
+    claim_token: str = typer.Argument(
+        ..., help="One-time claim token created with the intent"
+    ),
+    device_name: Optional[str] = typer.Option(
+        None, "--device-name", help="Human-friendly display name for the device"
+    ),
+    device_type: str = typer.Option(
+        "pos_terminal", "--device-type", help="Device type identifier"
+    ),
+    os_details: Optional[str] = typer.Option(
+        None, "--os-details", help="OS version string reported by the device"
+    ),
+    run_after: bool = typer.Option(
+        False, "--run", help="Start the agent runtime loop after bootstrap"
+    ),
+) -> None:
+    """Provision this device by claiming an enrolment intent.
+
+    Generates a device identity, calls the backend claim endpoint,
+    persists the returned credentials, registers device DNA, and
+    optionally starts the full agent runtime (heartbeat / telemetry).
+    """
+    if run_after:
+
+        async def _bootstrap_and_run() -> None:
+            ensure_identity()
+            config = await bootstrap_agent(
+                backend_url=backend_url,
+                intent_id=intent_id,
+                claim_token=claim_token,
+                device_name=device_name,
+                device_type=device_type,
+                os_details=os_details,
+            )
+            logger.info(
+                "Device %s provisioned on site %s",
+                config["device_id"],
+                config["site_id"],
+            )
+            await run_agent()
+
+        asyncio.run(_bootstrap_and_run())
+    else:
+
+        async def _bootstrap() -> None:
+            ensure_identity()
+            config = await bootstrap_agent(
+                backend_url=backend_url,
+                intent_id=intent_id,
+                claim_token=claim_token,
+                device_name=device_name,
+                device_type=device_type,
+                os_details=os_details,
+            )
+            logger.info(
+                "Device %s provisioned on site %s",
+                config["device_id"],
+                config["site_id"],
+            )
+
+        asyncio.run(_bootstrap())
 
 
 def ensure_identity() -> str:

--- a/backend/src/homepot/agent/real_device_agent.py
+++ b/backend/src/homepot/agent/real_device_agent.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 import ssl
 import threading
-from typing import Any, Dict, cast
+from typing import Any, Dict, Optional, cast
 
 import httpx
 from uvicorn import Config, Server
@@ -59,6 +59,15 @@ def load_agent_config() -> Dict[str, Any]:
         site_id = cred.get_metadata("site_id")
         if site_id:
             data["site_id"] = site_id
+        device_name = cred.get_metadata("device_name")
+        if device_name:
+            data["device_name"] = device_name
+        device_type = cred.get_metadata("device_type")
+        if device_type:
+            data["device_type"] = device_type
+        os_details = cred.get_metadata("os_details")
+        if os_details:
+            data["os_details"] = os_details
 
     data.setdefault("heartbeat_interval_seconds", 30)
     data.setdefault("telemetry_interval_seconds", 30)
@@ -286,6 +295,111 @@ def _build_tls_config(cred: CredentialStorage) -> Dict[str, Any]:
         tls_kw["cert"] = client_cert
 
     return tls_kw
+
+
+async def bootstrap_agent(
+    backend_url: str,
+    intent_id: str,
+    claim_token: str,
+    device_name: Optional[str] = None,
+    device_type: str = "pos_terminal",
+    os_details: Optional[str] = None,
+    expected_device_identity: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Provision this device by claiming an enrolment intent.
+
+    Steps
+    -----
+    1. Ensure a persistent device identity exists.
+    2. Call ``POST /api/v1/enrolment-intents/{intent_id}/claim``.
+    3. Persist the returned credentials in ``CredentialStorage``.
+    4. Register device DNA via ``POST /api/v1/agent/device-dna``.
+    5. Return the effective agent configuration.
+
+    Parameters
+    ----------
+    backend_url:
+        Root URL of the Homepot backend (e.g. ``https://api.example.com``).
+    intent_id:
+        The public ``intent_id`` of a pre-approved enrolment intent.
+    claim_token:
+        The one-time claim token created with the intent.
+    device_name:
+        Optional human-friendly display name for this device.
+    device_type:
+        Device type identifier (default ``"pos_terminal"``).
+    os_details:
+        Optional OS version string reported by the device.
+    expected_device_identity:
+        Optional stable hardware identifier for extra validation.
+    """
+    from homepot.agent.identity import get_or_create_device_id
+
+    device_identity = get_or_create_device_id()
+    logger.info("Bootstrapping with device identity: %s", device_identity)
+
+    cred = create_credential_storage()
+
+    claim_payload: Dict[str, Any] = {
+        "claim_token": claim_token,
+        "device_name": device_name or device_identity,
+        "device_type": device_type,
+        "os_details": os_details,
+    }
+    if expected_device_identity:
+        claim_payload["expected_device_identity"] = expected_device_identity
+
+    claim_url = f"{backend_url.rstrip('/')}/api/v1/enrolment-intents/{intent_id}/claim"
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(claim_url, json=claim_payload, timeout=30.0)
+        response.raise_for_status()
+        result = await response.json()
+
+        device_id: str = result["device_id"]
+        api_key: str = result["api_key"]
+        site_id: str = result["site_id"]
+
+    cred.save(
+        {
+            "device_id": device_id,
+            "api_key": api_key,
+            "backend_url": backend_url,
+            "site_id": site_id,
+            "device_name": device_name or "",
+            "device_type": device_type,
+            "os_details": os_details or "",
+        }
+    )
+
+    logger.info("Device provisioned: %s (site: %s)", device_id, site_id)
+
+    config = load_agent_config()
+    tls_kw = _build_tls_config(cred)
+
+    try:
+        async with httpx.AsyncClient(**tls_kw) as client:
+            payload: Dict[str, Any] = {
+                "device_id": config["device_id"],
+                "site_id": config["site_id"],
+                "device_name": config.get("device_name"),
+                "device_type": config.get("device_type", "pos_terminal"),
+                "mac_address": get_mac_address(),
+                "os_details": config.get("os_details"),
+                "local_ip": get_local_ip(),
+                "wan_ip": get_wan_ip(),
+                "peripherals": get_connected_peripherals(),
+            }
+            dna_url = f"{config['backend_url'].rstrip('/')}/api/v1/agent/device-dna"
+            dna_resp = await client.post(
+                dna_url, json=payload, headers=get_auth_headers(config), timeout=30.0
+            )
+            dna_resp.raise_for_status()
+            logger.info("Device DNA registered: %s", device_id)
+    except Exception as e:
+        logger.warning("Device DNA registration failed during bootstrap: %s", e)
+
+    return config
 
 
 async def run_agent() -> None:

--- a/backend/tests/test_agent_bootstrap.py
+++ b/backend/tests/test_agent_bootstrap.py
@@ -1,0 +1,207 @@
+"""Tests for the agent bootstrap flow (claim enrolment intent + DNA registration)."""
+
+from pathlib import Path
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homepot.agent.credential_storage import SimulationStorage
+
+
+@pytest.fixture
+def mock_identity(monkeypatch):
+    """Return a fixed device identity without touching the filesystem."""
+    monkeypatch.setattr(
+        "homepot.agent.identity.get_or_create_device_id",
+        lambda: "device-test-bootstrap-identity",
+    )
+
+
+@pytest.fixture
+def mock_mac(monkeypatch):
+    """Return a fixed MAC address so DNA payload is deterministic."""
+    monkeypatch.setattr(
+        "homepot.agent.utils.device_dna.get_mac_address",
+        lambda: "aa:bb:cc:dd:ee:ff",
+    )
+
+
+@pytest.fixture
+def mock_ip(monkeypatch):
+    """Return fixed IP addresses so DNA payload is deterministic."""
+    monkeypatch.setattr(
+        "homepot.agent.utils.device_dna.get_local_ip",
+        lambda: "192.168.1.99",
+    )
+    monkeypatch.setattr(
+        "homepot.agent.utils.device_dna.get_wan_ip",
+        lambda: "203.0.113.99",
+    )
+
+
+@pytest.fixture
+def mock_peripherals(monkeypatch):
+    """Return an empty peripherals dict."""
+    monkeypatch.setattr(
+        "homepot.agent.utils.real_device_discovery.get_connected_peripherals",
+        lambda: {},
+    )
+
+
+@pytest.fixture
+def cred_storage():
+    """Provide a clean SimulationStorage for each test."""
+    return SimulationStorage()
+
+
+@pytest.fixture(autouse=True)
+def patch_credential_storage(cred_storage, monkeypatch):
+    """Replace the storage factory so bootstrap_agent uses our test storage."""
+    monkeypatch.setattr(
+        "homepot.agent.real_device_agent.create_credential_storage",
+        lambda: cred_storage,
+    )
+
+
+@pytest.fixture
+def agent_config_file(monkeypatch):
+    """Point load_agent_config at a minimal temp config."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cfg_path = Path(tmpdir) / "agent-config.json"
+        cfg_path.write_text(
+            '{"backend_url": "http://localhost:8000", "device_id": "dummy", '
+            '"site_id": "s-dummy", "api_key": "dummy", '
+            '"device_name": "Test", "device_type": "pos_terminal", '
+            '"os_details": "Linux"}',
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HOMEPOT_AGENT_CONFIG", str(cfg_path))
+        yield
+
+
+async def test_bootstrap_agent_success(
+    mock_identity, mock_mac, mock_ip, mock_peripherals, cred_storage, agent_config_file
+):
+    """Happy path: claim endpoint returns credentials and DNA is registered."""
+    claim_response = {
+        "status": "success",
+        "message": "Device claimed successfully",
+        "device_id": "pos-terminal-a1b2c3d4",
+        "api_key": "test-api-key-12345",
+        "site_id": "site-test-001",
+        "epoch_id": "epoch-001",
+    }
+
+    dna_response = {
+        "status": "success",
+        "data": {"device_id": "pos-terminal-a1b2c3d4", "created": True},
+    }
+
+    async def _mock_post(url, **kwargs):
+        mock_resp = AsyncMock()
+        mock_resp.raise_for_status = MagicMock()
+        if "/enrolment-intents/" in url and "/claim" in url:
+            mock_resp.json.return_value = claim_response
+        elif "/device-dna" in url:
+            mock_resp.json.return_value = dna_response
+        else:
+            mock_resp.status_code = 404
+        return mock_resp
+
+    with patch("homepot.agent.real_device_agent.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+        mock_client.post = _mock_post
+
+        from homepot.agent.real_device_agent import bootstrap_agent
+
+        config = await bootstrap_agent(
+            backend_url="http://test-backend:8000",
+            intent_id="intent-abc-123",
+            claim_token="tok-secret-999",
+            device_name="Test POS",
+            device_type="pos_terminal",
+            os_details="TestOS 1.0",
+        )
+
+    assert config["device_id"] == "pos-terminal-a1b2c3d4"
+    assert config["site_id"] == "site-test-001"
+    assert config["api_key"] == "test-api-key-12345"
+    assert config["device_name"] == "Test POS"
+
+    assert cred_storage.get_device_id() == "pos-terminal-a1b2c3d4"
+    assert cred_storage.get_api_key() == "test-api-key-12345"
+    assert cred_storage.get_backend_url() == "http://test-backend:8000"
+    assert cred_storage.get_metadata("site_id") == "site-test-001"
+    assert cred_storage.get_metadata("device_name") == "Test POS"
+    assert cred_storage.get_metadata("device_type") == "pos_terminal"
+    assert cred_storage.get_metadata("os_details") == "TestOS 1.0"
+
+
+async def test_bootstrap_agent_claim_fails(
+    mock_identity, cred_storage, agent_config_file
+):
+    """When the claim endpoint returns an error, bootstrap_agent should raise."""
+
+    async def _mock_post(url, **kwargs):
+        mock_resp = AsyncMock()
+        mock_resp.raise_for_status = MagicMock(
+            side_effect=Exception("401 Unauthorized")
+        )
+        mock_resp.status_code = 401
+        return mock_resp
+
+    with patch("homepot.agent.real_device_agent.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+        mock_client.post = _mock_post
+
+        from homepot.agent.real_device_agent import bootstrap_agent
+
+        with pytest.raises(Exception, match="401 Unauthorized"):
+            await bootstrap_agent(
+                backend_url="http://test-backend:8000",
+                intent_id="intent-bad",
+                claim_token="tok-bad",
+            )
+
+    assert cred_storage.is_provisioned() is False
+
+
+async def test_bootstrap_agent_passes_expected_identity(
+    mock_identity, mock_mac, mock_ip, mock_peripherals, cred_storage, agent_config_file
+):
+    """expected_device_identity is forwarded in the claim payload."""
+    sent_payload = {}
+
+    async def _mock_post(url, json=None, **kwargs):
+        nonlocal sent_payload
+        mock_resp = AsyncMock()
+        mock_resp.raise_for_status = MagicMock()
+        if "/claim" in url:
+            sent_payload = json or {}
+            mock_resp.json.return_value = {
+                "device_id": "d-1234",
+                "api_key": "ak-5678",
+                "site_id": "s-999",
+            }
+        elif "/device-dna" in url:
+            mock_resp.json.return_value = {"status": "success"}
+        return mock_resp
+
+    with patch("homepot.agent.real_device_agent.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+        mock_client.post = _mock_post
+
+        from homepot.agent.real_device_agent import bootstrap_agent
+
+        await bootstrap_agent(
+            backend_url="http://localhost:8000",
+            intent_id="intent-ei-1",
+            claim_token="tok-ei-1",
+            expected_device_identity="SN-ABCDEF",
+        )
+
+    assert sent_payload.get("expected_device_identity") == "SN-ABCDEF"


### PR DESCRIPTION
## Summary

Implements the full agent bootstrap flow: identity generation → claim enrolment intent → persist credentials → register device DNA → start heartbeat/telemetry.

## Changes

### Agent runtime (`real_device_agent.py`)
- Added `bootstrap_agent()` async function that:
  1. Generates persistent device identity via `get_or_create_device_id()`
  2. Calls `POST /api/v1/enrolment-intents/{intent_id}/claim` with the claim token
  3. Persists returned credentials (`device_id`, `api_key`, `site_id`, `backend_url`, metadata) in `CredentialStorage`
  4. Registers device DNA via `POST /api/v1/agent/device-dna`
  5. Returns the effective agent configuration
- Enhanced `load_agent_config()` to overlay `device_name`, `device_type`, and `os_details` from credential storage

### CLI (`cli.py`)
- Added `bootstrap` subcommand:
  ```bash
  homepot-agent bootstrap <backend-url> <intent-id> <claim-token> \
      [--device-name] [--device-type] [--os-details] [--run]
  ```
- `--run` flag starts the full agent runtime (heartbeat/telemetry) after bootstrap

### Tests
- 3 tests covering: happy path, claim failure, and expected_device_identity forwarding

## Usage

1. Operator creates an enrolment intent:
   ```bash
   curl -X POST /api/v1/sites/{site_id}/enrolment-intents \
     -H "Authorization: Bearer <jwt>" \
     -H "Content-Type: application/json" \
     -d '{"enrolment_method": "pre-provisioned"}'
   # Returns: {"intent_id": "...", "claim_token": "..."}
   ```

2. Operator approves the intent (PUT .../enrolment-intents/{id} {"status": "approved"})

3. Agent bootstraps:
   ```bash
   homepot-agent bootstrap https://api.example.com <intent-id> <claim-token> --run
   ```

The agent generates its identity, claims the intent, stores credentials, registers DNA, and starts the runtime loop.