### PR TITLE
feat: Heartbeat & telemetry with retry queue

### DIFF
--- a/backend/src/homepot/agent/real_device_agent.py
+++ b/backend/src/homepot/agent/real_device_agent.py
@@ -221,12 +221,16 @@ async def retry_flush_loop(
     config: Dict[str, Any],
     retry_queue: RetryQueue,
 ) -> None:
-    """Flush queued failed payloads to backend at a fixed interval."""
+    """Flush queued failed payloads to backend at a fixed interval.
+
+    Uses :meth:`~RetryQueue.dequeue_ready` so that each item respects
+    exponential backoff.  Items that still fail are re-enqueued with an
+    incremented retry count via :meth:`~RetryQueue.requeue`.
+    """
     interval = int(config["retry_flush_interval_seconds"])
     while True:
         try:
-            queued_items = retry_queue.dequeue_all()
-            pending: list[dict] = []
+            queued_items = retry_queue.dequeue_ready()
             for item in queued_items:
                 ok = await post_json(
                     client,
@@ -235,10 +239,7 @@ async def retry_flush_loop(
                     get_auth_headers(config),
                 )
                 if not ok:
-                    pending.append(item)
-            if pending:
-                for item in pending:
-                    retry_queue.enqueue(item)
+                    retry_queue.requeue(item)
         except Exception as e:
             logger.error("Retry flush loop error: %s", e, exc_info=True)
         await asyncio.sleep(interval)

--- a/backend/src/homepot/agent/utils/retry_queue.py
+++ b/backend/src/homepot/agent/utils/retry_queue.py
@@ -1,16 +1,53 @@
-"""Simple persistent retry queue for offline agent submissions."""
+"""File-backed retry queue with exponential backoff for offline submissions."""
 
+from datetime import datetime, timedelta, timezone
 import json
 from pathlib import Path
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List, Optional, cast
+
+from homepot.agent.identity import identity_dir
+
+_BASE_DELAY = 30.0
+_MAX_DELAY = 3600.0
+
+
+def _backoff_delay(retry_count: int) -> float:
+    """Return the exponential backoff delay in seconds for the given retry count.
+
+    Formula: min(30 * 2^retry_count, 3600)
+    """
+    return min(_BASE_DELAY * (2**retry_count), _MAX_DELAY)  # type: ignore[no-any-return]
+
+
+def _compute_next_retry(retry_count: int) -> str:
+    """Return an ISO-8601 UTC timestamp for the next allowed retry time."""
+    return (
+        datetime.now(timezone.utc) + timedelta(seconds=_backoff_delay(retry_count))
+    ).isoformat()
+
+
+def _default_queue_path() -> Path:
+    """Return the default queue file path inside the homepot identity directory."""
+    return identity_dir() / ".agent_retry_queue.json"
 
 
 class RetryQueue:
-    """Small file-backed retry queue for payload delivery retries."""
+    """File-backed retry queue with exponential backoff for payload delivery retries.
 
-    def __init__(self, queue_file: str = ".agent_retry_queue.json") -> None:
-        """Initialize queue with a local JSON file path."""
-        self.path = Path(queue_file)
+    Each item tracks ``retry_count`` and ``next_retry_at`` (ISO-8601 UTC).
+    Use :meth:`dequeue_ready` to retrieve only items whose backoff has elapsed.
+    """
+
+    def __init__(self, queue_file: Optional[Path] = None) -> None:
+        """Initialize queue.
+
+        Parameters
+        ----------
+        queue_file:
+            Path to the JSON file.  Defaults to
+            ``<identity_dir>/.agent_retry_queue.json``.
+        """
+        self.path = queue_file or _default_queue_path()
 
     def load(self) -> List[Dict[str, Any]]:
         """Load queued payloads from disk."""
@@ -26,16 +63,79 @@ class RetryQueue:
 
     def save(self, items: List[Dict[str, Any]]) -> None:
         """Persist queued payloads to disk."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
         self.path.write_text(json.dumps(items, indent=2), encoding="utf-8")
 
     def enqueue(self, item: Dict[str, Any]) -> None:
-        """Add a payload to the retry queue."""
+        """Add a payload to the retry queue.
+
+        If the item already contains ``retry_count`` it is kept;
+        otherwise it is initialised to ``0``.  ``next_retry_at`` is
+        recalculated from the current count.
+        """
+        retry_count = item.get("retry_count", 0)
+        if not isinstance(retry_count, int):
+            retry_count = 0
+        enriched: Dict[str, Any] = {
+            "url": item["url"],
+            "payload": item["payload"],
+            "retry_count": retry_count,
+            "next_retry_at": _compute_next_retry(retry_count),
+        }
         items = self.load()
-        items.append(item)
+        items.append(enriched)
         self.save(items)
 
+    def requeue(self, item: Dict[str, Any]) -> None:
+        """Re-enqueue a failed item, incrementing its retry count.
+
+        Shortcut for ``enqueue`` after bumping ``retry_count`` by one.
+        """
+        retry_count = item.get("retry_count", 0)
+        if not isinstance(retry_count, int):
+            retry_count = 0
+        item["retry_count"] = retry_count + 1  # type: ignore[typeddict-item]
+        self.enqueue(item)
+
+    def dequeue_ready(self) -> List[Dict[str, Any]]:
+        """Return items whose backoff delay has elapsed.
+
+        Items that are still within their backoff window remain queued.
+        """
+        now = datetime.now(timezone.utc)
+        items = self.load()
+        ready: List[Dict[str, Any]] = []
+        pending: List[Dict[str, Any]] = []
+        for item in items:
+            next_at_str: Optional[str] = item.get("next_retry_at")
+            if next_at_str:
+                try:
+                    next_at = datetime.fromisoformat(next_at_str)
+                    if next_at <= now:
+                        ready.append(item)
+                    else:
+                        pending.append(item)
+                    continue
+                except (ValueError, TypeError):
+                    pass
+            ready.append(item)
+        self.save(pending)
+        return ready
+
     def dequeue_all(self) -> List[Dict[str, Any]]:
-        """Return all queued payloads and clear the queue."""
+        """Return all queued payloads regardless of backoff and clear the queue.
+
+        Provided for compatibility; prefer :meth:`dequeue_ready` to
+        respect exponential backoff.
+        """
         items = self.load()
         self.save([])
         return items
+
+    def clear(self) -> None:
+        """Remove all items from the queue."""
+        self.save([])
+
+    def __len__(self) -> int:
+        """Return the number of queued items."""
+        return len(self.load())

--- a/backend/tests/test_agent_heartbeat_telemetry.py
+++ b/backend/tests/test_agent_heartbeat_telemetry.py
@@ -1,0 +1,171 @@
+"""Tests for heartbeat and telemetry payload utilities."""
+
+from datetime import datetime, timezone
+
+from homepot.agent.utils.heartbeat import build_heartbeat_payload, utc_now_iso
+from homepot.agent.utils.telemetry import (
+    build_telemetry_payload,
+    collect_system_telemetry,
+)
+from homepot.agent.utils.telemetry import utc_now_iso as te_utc_now
+
+
+class TestHeartbeatUtcNowIso:
+    """Tests for the heartbeat ``utc_now_iso`` helper."""
+
+    def test_returns_iso_format_string(self):
+        """Returned string is parseable as an ISO-8601 datetime."""
+        result = utc_now_iso()
+        assert isinstance(result, str)
+        parsed = datetime.fromisoformat(result)
+        assert parsed.tzinfo is not None
+
+    def test_returns_utc_time(self):
+        """Returned timestamp is within 5 seconds of current UTC time."""
+        result = utc_now_iso()
+        parsed = datetime.fromisoformat(result)
+        diff = abs((datetime.now(timezone.utc) - parsed).total_seconds())
+        assert diff < 5
+
+
+class TestBuildHeartbeatPayload:
+    """Tests for ``build_heartbeat_payload``."""
+
+    def test_requires_device_id(self):
+        """Payload includes the provided device_id."""
+        payload = build_heartbeat_payload("dev-1")
+        assert payload["device_id"] == "dev-1"
+
+    def test_includes_timestamp(self):
+        """Payload includes an ISO-8601 timestamp."""
+        payload = build_heartbeat_payload("dev-1")
+        assert "timestamp" in payload
+        parsed = datetime.fromisoformat(payload["timestamp"])
+        assert parsed.tzinfo is not None
+
+    def test_includes_status_default(self):
+        """Default status is ONLINE."""
+        payload = build_heartbeat_payload("dev-1")
+        assert payload["status"] == "ONLINE"
+
+    def test_accepts_custom_status(self):
+        """Accepts a custom status string."""
+        payload = build_heartbeat_payload("dev-1", status="OFFLINE")
+        assert payload["status"] == "OFFLINE"
+
+    def test_includes_site_id_when_provided(self):
+        """Site ID is included when provided."""
+        payload = build_heartbeat_payload("dev-1", site_id="site-99")
+        assert payload["site_id"] == "site-99"
+
+    def test_omits_site_id_when_not_provided(self):
+        """Site ID is omitted when not provided."""
+        payload = build_heartbeat_payload("dev-1")
+        assert "site_id" not in payload
+
+    def test_includes_extra_fields(self):
+        """Extra fields are included in the payload."""
+        payload = build_heartbeat_payload("dev-1", extra={"battery": 85})
+        assert payload["extra"] == {"battery": 85}
+
+    def test_timestamp_is_recent(self):
+        """Timestamp is within 5 seconds of now."""
+        payload = build_heartbeat_payload("dev-1")
+        parsed = datetime.fromisoformat(payload["timestamp"])
+        diff = abs((datetime.now(timezone.utc) - parsed).total_seconds())
+        assert diff < 5
+
+
+class TestTelemetryUtcNowIso:
+    """Tests for the telemetry ``utc_now_iso`` helper."""
+
+    def test_returns_iso_format_string(self):
+        """Returned string is parseable as an ISO-8601 datetime."""
+        result = te_utc_now()
+        assert isinstance(result, str)
+        parsed = datetime.fromisoformat(result)
+        assert parsed.tzinfo is not None
+
+    def test_returns_utc_time(self):
+        """Returned timestamp is within 5 seconds of current UTC time."""
+        result = te_utc_now()
+        parsed = datetime.fromisoformat(result)
+        diff = abs((datetime.now(timezone.utc) - parsed).total_seconds())
+        assert diff < 5
+
+
+class TestCollectSystemTelemetry:
+    """Tests for ``collect_system_telemetry``."""
+
+    def test_returns_dict_with_expected_keys(self):
+        """Returned dict contains cpu, memory, and disk keys."""
+        metrics = collect_system_telemetry()
+        assert "cpu_usage" in metrics
+        assert "memory_usage" in metrics
+        assert "disk_usage" in metrics
+
+    def test_values_are_floats(self):
+        """All metric values are floats."""
+        metrics = collect_system_telemetry()
+        for key in ("cpu_usage", "memory_usage", "disk_usage"):
+            assert isinstance(metrics[key], float), f"{key} should be float"
+
+    def test_cpu_usage_in_range(self):
+        """CPU usage is between 0 and 100."""
+        metrics = collect_system_telemetry()
+        assert 0 <= metrics["cpu_usage"] <= 100
+
+    def test_memory_usage_in_range(self):
+        """Memory usage is between 0 and 100."""
+        metrics = collect_system_telemetry()
+        assert 0 <= metrics["memory_usage"] <= 100
+
+    def test_disk_usage_in_range(self):
+        """Disk usage is between 0 and 100."""
+        metrics = collect_system_telemetry()
+        assert 0 <= metrics["disk_usage"] <= 100
+
+
+class TestBuildTelemetryPayload:
+    """Tests for ``build_telemetry_payload``."""
+
+    def test_requires_device_id(self):
+        """Payload includes the provided device_id."""
+        payload = build_telemetry_payload("dev-1")
+        assert payload["device_id"] == "dev-1"
+
+    def test_includes_timestamp(self):
+        """Payload includes an ISO-8601 timestamp."""
+        payload = build_telemetry_payload("dev-1")
+        assert "timestamp" in payload
+        parsed = datetime.fromisoformat(payload["timestamp"])
+        assert parsed.tzinfo is not None
+
+    def test_includes_system_metrics(self):
+        """Payload includes cpu, memory, and disk metrics."""
+        payload = build_telemetry_payload("dev-1")
+        assert "cpu_usage" in payload
+        assert "memory_usage" in payload
+        assert "disk_usage" in payload
+
+    def test_cpu_is_float(self):
+        """CPU usage is a float."""
+        payload = build_telemetry_payload("dev-1")
+        assert isinstance(payload["cpu_usage"], float)
+
+    def test_includes_extra_fields(self):
+        """Extra fields are included in the payload."""
+        payload = build_telemetry_payload("dev-1", extra={"network_rx": 1024})
+        assert payload["extra"] == {"network_rx": 1024}
+
+    def test_omits_extra_when_not_provided(self):
+        """Extra key is omitted when not provided."""
+        payload = build_telemetry_payload("dev-1")
+        assert "extra" not in payload
+
+    def test_timestamp_is_recent(self):
+        """Timestamp is within 5 seconds of now."""
+        payload = build_telemetry_payload("dev-1")
+        parsed = datetime.fromisoformat(payload["timestamp"])
+        diff = abs((datetime.now(timezone.utc) - parsed).total_seconds())
+        assert diff < 5

--- a/backend/tests/test_agent_retry_queue.py
+++ b/backend/tests/test_agent_retry_queue.py
@@ -1,0 +1,294 @@
+"""Tests for the RetryQueue with exponential backoff."""
+
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+import tempfile
+
+import pytest
+
+from homepot.agent.utils.retry_queue import RetryQueue, _backoff_delay
+
+
+def _make_item(
+    url: str = "http://localhost/api/v1/agent/heartbeat",
+    retry_count: int = 0,
+    offset_seconds: float = 0,
+) -> dict:
+    """Build an item dict with optional retry metadata."""
+    item: dict = {"url": url, "payload": {"device_id": "d1"}}
+    if retry_count:
+        item["retry_count"] = retry_count
+    if offset_seconds:
+        next_at = datetime.now(timezone.utc) + timedelta(seconds=offset_seconds)
+        item["next_retry_at"] = next_at.isoformat()
+    return item
+
+
+# ---------------------------------------------------------------------------
+# Backoff helper
+# ---------------------------------------------------------------------------
+
+
+class TestBackoffDelay:
+    """Tests for the exponential backoff delay helper."""
+
+    def test_retry_0_is_30_seconds(self):
+        """Retry count 0 yields a 30-second delay."""
+        assert _backoff_delay(0) == 30.0
+
+    def test_retry_1_is_60_seconds(self):
+        """Retry count 1 yields a 60-second delay."""
+        assert _backoff_delay(1) == 60.0
+
+    def test_retry_2_is_120_seconds(self):
+        """Retry count 2 yields a 120-second delay."""
+        assert _backoff_delay(2) == 120.0
+
+    def test_retry_3_is_240_seconds(self):
+        """Retry count 3 yields a 240-second delay."""
+        assert _backoff_delay(3) == 240.0
+
+    def test_retry_4_is_480_seconds(self):
+        """Retry count 4 yields a 480-second delay."""
+        assert _backoff_delay(4) == 480.0
+
+    def test_retry_5_is_960_seconds(self):
+        """Retry count 5 yields a 960-second delay."""
+        assert _backoff_delay(5) == 960.0
+
+    def test_retry_6_is_1920_seconds(self):
+        """Retry count 6 yields a 1920-second delay."""
+        assert _backoff_delay(6) == 1920.0
+
+    def test_retry_7_is_capped_at_3600(self):
+        """Retry count 7 is capped at 3600 seconds."""
+        assert _backoff_delay(7) == 3600.0
+
+    def test_retry_10_is_capped_at_3600(self):
+        """Retry count 10 is still capped at 3600 seconds."""
+        assert _backoff_delay(10) == 3600.0
+
+
+# ---------------------------------------------------------------------------
+# RetryQueue
+# ---------------------------------------------------------------------------
+
+
+class TestRetryQueue:
+    """Tests for the RetryQueue with exponential backoff and disk persistence."""
+
+    @pytest.fixture
+    def queue_file(self):
+        """Yield a temporary path for the queue file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir) / "retry_queue.json"
+
+    @pytest.fixture
+    def queue(self, queue_file):
+        """Yield a RetryQueue backed by the temporary file."""
+        return RetryQueue(queue_file=queue_file)
+
+    # enqueue
+
+    def test_enqueue_adds_item(self, queue, queue_file):
+        """Enqueued item is persisted to disk and contains expected fields."""
+        queue.enqueue(_make_item())
+        data = json.loads(queue_file.read_text("utf-8"))
+        assert len(data) == 1
+        assert data[0]["url"] == "http://localhost/api/v1/agent/heartbeat"
+        assert data[0]["payload"] == {"device_id": "d1"}
+        assert data[0]["retry_count"] == 0
+        assert "next_retry_at" in data[0]
+
+    def test_enqueue_initialises_retry_count(self, queue, queue_file):
+        """An item without retry_count gets initialised to 0."""
+        queue.enqueue({"url": "http://example.com", "payload": {"k": "v"}})
+        data = json.loads(queue_file.read_text("utf-8"))
+        assert data[0]["retry_count"] == 0
+
+    def test_enqueue_preserves_existing_retry_count(self, queue, queue_file):
+        """An item with an existing retry_count keeps its value."""
+        queue.enqueue(_make_item(retry_count=3))
+        data = json.loads(queue_file.read_text("utf-8"))
+        assert data[0]["retry_count"] == 3
+
+    def test_enqueue_multiple_items(self, queue, queue_file):
+        """Multiple enqueued items are all persisted."""
+        queue.enqueue(_make_item(url="http://a.com"))
+        queue.enqueue(_make_item(url="http://b.com"))
+        data = json.loads(queue_file.read_text("utf-8"))
+        assert len(data) == 2
+
+    # requeue
+
+    def test_requeue_increments_retry_count(self, queue, queue_file):
+        """Requeuing an item increments its retry_count by 1."""
+        queue.enqueue(_make_item())
+        items = queue.dequeue_all()
+        assert items[0]["retry_count"] == 0
+        queue.requeue(items[0])
+        data = json.loads(queue_file.read_text("utf-8"))
+        assert data[0]["retry_count"] == 1
+
+    def test_requeue_recalculates_next_retry_at(self, queue, queue_file):
+        """Requeuing updates next_retry_at to a new future timestamp."""
+        queue.enqueue(_make_item())
+        items = queue.dequeue_all()
+        first_next = items[0]["next_retry_at"]
+        queue.requeue(items[0])
+        data = json.loads(queue_file.read_text("utf-8"))
+        assert data[0]["next_retry_at"] != first_next
+
+    def test_requeue_preserves_url_and_payload(self, queue, queue_file):
+        """Requeuing preserves the original url and payload."""
+        queue.enqueue(_make_item(url="http://test.io", retry_count=0))
+        items = queue.dequeue_all()
+        queue.requeue(items[0])
+        data = json.loads(queue_file.read_text("utf-8"))
+        assert data[0]["url"] == "http://test.io"
+        assert data[0]["payload"] == {"device_id": "d1"}
+
+    # dequeue_ready
+
+    def _save_with_offset(
+        self, queue, offset_seconds: float, url: str = "http://example.com"
+    ) -> None:
+        """Save an item directly with a specific next_retry_at offset."""
+        now = datetime.now(timezone.utc) + timedelta(seconds=offset_seconds)
+        queue.save(
+            [
+                {
+                    "url": url,
+                    "payload": {"device_id": "d1"},
+                    "retry_count": 0,
+                    "next_retry_at": now.isoformat(),
+                }
+            ]
+        )
+
+    def test_dequeue_ready_returns_past_items(self, queue):
+        """Items with a past next_retry_at are returned as ready."""
+        self._save_with_offset(queue, -10)
+        ready = queue.dequeue_ready()
+        assert len(ready) == 1
+
+    def test_dequeue_ready_skips_future_items(self, queue):
+        """Items with a future next_retry_at are not returned."""
+        self._save_with_offset(queue, 600)
+        ready = queue.dequeue_ready()
+        assert len(ready) == 0
+
+    def test_dequeue_ready_keeps_future_items_queued(self, queue, queue_file):
+        """Future items remain on disk after dequeue_ready."""
+        self._save_with_offset(queue, 600)
+        queue.dequeue_ready()
+        data = json.loads(queue_file.read_text("utf-8"))
+        assert len(data) == 1
+
+    def test_dequeue_ready_removes_past_items(self, queue, queue_file):
+        """Past items are removed from disk after dequeue_ready."""
+        self._save_with_offset(queue, -10)
+        queue.dequeue_ready()
+        data = json.loads(queue_file.read_text("utf-8"))
+        assert len(data) == 0
+
+    def test_dequeue_ready_mixed(self, queue):
+        """Only past items are returned from a mixed set."""
+        now = datetime.now(timezone.utc)
+        queue.save(
+            [
+                {
+                    "url": "http://a.com",
+                    "payload": {"device_id": "d1"},
+                    "retry_count": 0,
+                    "next_retry_at": (now - timedelta(seconds=10)).isoformat(),
+                },
+                {
+                    "url": "http://b.com",
+                    "payload": {"device_id": "d1"},
+                    "retry_count": 0,
+                    "next_retry_at": (now + timedelta(seconds=600)).isoformat(),
+                },
+                {
+                    "url": "http://c.com",
+                    "payload": {"device_id": "d1"},
+                    "retry_count": 0,
+                    "next_retry_at": (now - timedelta(seconds=5)).isoformat(),
+                },
+            ]
+        )
+        ready = queue.dequeue_ready()
+        assert len(ready) == 2
+
+    def test_dequeue_ready_handles_missing_next_retry_at(self, queue):
+        """Items without next_retry_at are treated as ready."""
+        queue.save(
+            [
+                {
+                    "url": "http://x.com",
+                    "payload": {},
+                    "retry_count": 0,
+                }
+            ]
+        )
+        ready = queue.dequeue_ready()
+        assert len(ready) == 1
+
+    # dequeue_all
+
+    def test_dequeue_all_returns_all_and_clears(self, queue, queue_file):
+        """dequeue_all returns every item and empties the file."""
+        queue.enqueue(_make_item(url="http://a.com"))
+        queue.enqueue(_make_item(url="http://b.com"))
+        items = queue.dequeue_all()
+        assert len(items) == 2
+        assert json.loads(queue_file.read_text("utf-8")) == []
+
+    def test_dequeue_all_ignores_backoff(self, queue):
+        """dequeue_all returns future items regardless of backoff."""
+        queue.enqueue(_make_item(offset_seconds=600))
+        items = queue.dequeue_all()
+        assert len(items) == 1
+
+    # clear
+
+    def test_clear_empties_queue(self, queue, queue_file):
+        """Clear removes all items from the queue."""
+        queue.enqueue(_make_item())
+        queue.clear()
+        assert json.loads(queue_file.read_text("utf-8")) == []
+
+    def test_clear_on_empty_does_not_raise(self, queue):
+        """Clear on an empty queue does not raise."""
+        queue.clear()
+
+    # __len__
+
+    def test_len_returns_count(self, queue):
+        """len(queue) reflects the number of enqueued items."""
+        assert len(queue) == 0
+        queue.enqueue(_make_item())
+        assert len(queue) == 1
+        queue.enqueue(_make_item(url="http://b.com"))
+        assert len(queue) == 2
+
+    # file operations
+
+    def test_load_returns_empty_when_no_file(self, queue, queue_file):
+        """Load returns [] when the queue file does not exist."""
+        assert not queue_file.exists()
+        assert queue.load() == []
+
+    def test_load_returns_empty_on_corrupted_file(self, queue, queue_file):
+        """Load returns [] when the queue file contains garbage."""
+        queue_file.parent.mkdir(parents=True, exist_ok=True)
+        queue_file.write_text("garbage", encoding="utf-8")
+        assert queue.load() == []
+
+    def test_save_creates_parent_directory(self, queue_file):
+        """Save creates intermediate parent directories."""
+        nested = queue_file.parent / "sub" / "queue.json"
+        queue = RetryQueue(queue_file=nested)
+        queue.save([{"url": "http://x.com", "payload": {}}])
+        assert nested.exists()


### PR DESCRIPTION
## Summary

Enhanced the agent's retry mechanism and added heartbeat/telemetry payload builders.

### Changes

- **RetryQueue** (): Added exponential backoff with formula `min(30 * 2^retry_count, 3600)` seconds. New methods: `enqueue()`, `requeue()`, `dequeue_ready()`. Default queue file: `<identity_dir>/.agent_retry_queue.json` (persistent across restarts).
- **retry_flush_loop** (): Updated to use `dequeue_ready()` (respects backoff) and `requeue()` (increments retry count on failure).
- **Heartbeat payload** (`heartbeat.py`): `build_heartbeat_payload()` with device_id, timestamp, status, site_id, extra fields.
- **Telemetry payload** (`telemetry.py`): `build_telemetry_payload()` and `collect_system_telemetry()` for CPU/memory/disk metrics.

### Tests
- `test_agent_retry_queue.py`: 30 tests covering backoff, enqueue, requeue, dequeue_ready, dequeue_all, clear, len, file operations.
- `test_agent_heartbeat_telemetry.py`: 24 tests covering heartbeat and telemetry utilities.
- All 54 tests pass. All quality checks (black, isort, flake8, mypy) pass.