### PR TITLE
feat: Surface hidden device/site fields + credential status reader

### DIFF
--- a/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
@@ -313,7 +313,7 @@ async def list_device(
         async with db_service.get_session() as session:
             query = (
                 select(Device)
-                .options(joinedload(Device.site))
+                .options(joinedload(Device.site), joinedload(Device.credentials))
                 .where(Device.is_active.is_(True))
             )
 
@@ -394,52 +394,61 @@ async def get_device(
     try:
         db_service = await get_database_service()
 
-        # Look up site by device_id
-        device = await db_service.get_device_by_device_id(device_id)
-
-        if not device:
-            raise HTTPException(
-                status_code=404, detail=f"Device '{device_id}' not found"
+        async with db_service.get_session() as session:
+            result = await session.execute(
+                select(Device)
+                .options(joinedload(Device.site), joinedload(Device.credentials))
+                .where(Device.device_id == device_id)
             )
+            device = result.scalar_one_or_none()
 
-        # Verify user can access this device's site
-        db_user = cast(
-            User, db.query(User).filter(User.email == current_user["email"]).first()
-        )
-        verify_device_belongs_to_user(db_user, device, db)
+            if not device:
+                raise HTTPException(
+                    status_code=404, detail=f"Device '{device_id}' not found"
+                )
 
-        return {
-            "site_id": device.site.site_id,
-            "site_name": device.site.name if device.site else "Unknown Site",
-            "device_id": device.device_id,
-            "name": device.name,
-            "device_type": device.device_type,
-            "lifecycle_state": device.lifecycle_state,
-            "connectivity_state": _compute_connectivity(device),
-            "health_state": device.health_state or HealthState.UNKNOWN.value,
-            "status": device.status,
-            "ip_address": device.ip_address or "N/A",
-            "os_details": device.os_details
-            or (device.config.get("os_details") if device.config else "N/A"),
-            "mac_address": device.mac_address
-            or (device.config.get("mac_address") if device.config else "N/A"),
-            "firmware_version": device.firmware_version
-            or (device.config.get("firmware_version") if device.config else "N/A"),
-            "last_seen": device.last_seen.isoformat() if device.last_seen else None,
-            "last_heartbeat_at": (
-                device.last_heartbeat_at.isoformat()
-                if device.last_heartbeat_at
-                else None
-            ),
-            "credential_status": (
-                "active"
-                if any(c.is_active for c in (device.credentials or []))
-                else "inactive"
-            ),
-            "is_monitored": device.is_monitored,
-            "created_at": device.created_at.isoformat() if device.created_at else None,
-            "updated_at": device.updated_at.isoformat() if device.updated_at else None,
-        }
+            # Verify user can access this device's site
+            db_user = cast(
+                User, db.query(User).filter(User.email == current_user["email"]).first()
+            )
+            verify_device_belongs_to_user(db_user, device, db)
+
+            return {
+                "site_id": device.site.site_id,
+                "site_name": device.site.name if device.site else "Unknown Site",
+                "device_id": device.device_id,
+                "name": device.name,
+                "device_type": device.device_type,
+                "lifecycle_state": device.lifecycle_state,
+                "connectivity_state": _compute_connectivity(device),
+                "health_state": device.health_state or HealthState.UNKNOWN.value,
+                "status": device.status,
+                "ip_address": device.ip_address or "N/A",
+                "os_details": device.os_details
+                or (device.config.get("os_details") if device.config else "N/A"),
+                "mac_address": device.mac_address
+                or (device.config.get("mac_address") if device.config else "N/A"),
+                "firmware_version": device.firmware_version
+                or (device.config.get("firmware_version") if device.config else "N/A"),
+                "last_seen": device.last_seen.isoformat() if device.last_seen else None,
+                "last_heartbeat_at": (
+                    device.last_heartbeat_at.isoformat()
+                    if device.last_heartbeat_at
+                    else None
+                ),
+                "credential_status": (
+                    "active"
+                    if any(c.is_active for c in (device.credentials or []))
+                    else "inactive"
+                ),
+                "is_monitored": device.is_monitored,
+                "created_at": (
+                    device.created_at.isoformat() if device.created_at else None
+                ),
+                "updated_at": (
+                    device.updated_at.isoformat() if device.updated_at else None
+                ),
+            }
 
     except HTTPException:
         raise

--- a/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
@@ -358,6 +358,16 @@ async def list_device(
                         or HealthState.UNKNOWN.value,
                         "status": device.status,
                         "ip_address": device.ip_address,
+                        "last_heartbeat_at": (
+                            device.last_heartbeat_at.isoformat()
+                            if device.last_heartbeat_at
+                            else None
+                        ),
+                        "credential_status": (
+                            "active"
+                            if any(c.is_active for c in (device.credentials or []))
+                            else "inactive"
+                        ),
                         "is_monitored": device.is_monitored,
                         "created_at": (
                             device.created_at.isoformat() if device.created_at else None
@@ -416,6 +426,16 @@ async def get_device(
             "firmware_version": device.firmware_version
             or (device.config.get("firmware_version") if device.config else "N/A"),
             "last_seen": device.last_seen.isoformat() if device.last_seen else None,
+            "last_heartbeat_at": (
+                device.last_heartbeat_at.isoformat()
+                if device.last_heartbeat_at
+                else None
+            ),
+            "credential_status": (
+                "active"
+                if any(c.is_active for c in (device.credentials or []))
+                else "inactive"
+            ),
             "is_monitored": device.is_monitored,
             "created_at": device.created_at.isoformat() if device.created_at else None,
             "updated_at": device.updated_at.isoformat() if device.updated_at else None,
@@ -427,6 +447,50 @@ async def get_device(
         logger.error(f"Failed to get Device {device_id}: {e}", exc_info=True)
         raise HTTPException(
             status_code=500, detail="Failed to get Device. Please check server logs."
+        )
+
+
+@router.get("/device/{device_id}/credentials", tags=["Devices"])
+async def get_device_credentials(
+    device_id: str,
+    db: SASession = Depends(get_db),
+    current_user: UserDict = Depends(require_user()),
+) -> Dict[str, Any]:
+    """Return credential history for a device (without secrets)."""
+    try:
+        db_service = await get_database_service()
+        device = await db_service.get_device_by_device_id(device_id)
+        if not device:
+            raise HTTPException(
+                status_code=404, detail=f"Device '{device_id}' not found"
+            )
+        db_user = cast(
+            User, db.query(User).filter(User.email == current_user["email"]).first()
+        )
+        verify_device_belongs_to_user(db_user, device, db)
+
+        return {
+            "device_id": device.device_id,
+            "credentials": [
+                {
+                    "credential_id": c.credential_id,
+                    "is_active": c.is_active,
+                    "created_at": c.created_at.isoformat() if c.created_at else None,
+                    "rotated_at": c.rotated_at.isoformat() if c.rotated_at else None,
+                    "revoked_at": c.revoked_at.isoformat() if c.revoked_at else None,
+                }
+                for c in (device.credentials or [])
+            ],
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(
+            f"Failed to get credentials for Device {device_id}: {e}", exc_info=True
+        )
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to get device credentials. Please check server logs.",
         )
 
 
@@ -1641,6 +1705,14 @@ async def get_devices_by_site(
                 "active_alerts": alert_map.get(d.device_id, 0),
                 "enrollment_method": getattr(d, "enrollment_method", "pre-provisioned"),
                 "last_seen": d.last_seen.isoformat() if d.last_seen else None,
+                "last_heartbeat_at": (
+                    d.last_heartbeat_at.isoformat() if d.last_heartbeat_at else None
+                ),
+                "credential_status": (
+                    "active"
+                    if any(c.is_active for c in (d.credentials or []))
+                    else "inactive"
+                ),
                 "created_at": d.created_at.isoformat() if d.created_at else None,
                 "updated_at": d.updated_at.isoformat() if d.updated_at else None,
             }

--- a/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
@@ -341,7 +341,7 @@ async def list_device(
 
             query = query.order_by(Device.created_at.desc())
             result = await session.execute(query)
-            devices = result.scalars().all()
+            devices = result.unique().scalars().all()
 
             device_list = []
             for device in devices:
@@ -400,7 +400,7 @@ async def get_device(
                 .options(joinedload(Device.site), joinedload(Device.credentials))
                 .where(Device.device_id == device_id)
             )
-            device = result.scalar_one_or_none()
+            device = result.unique().scalar_one_or_none()
 
             if not device:
                 raise HTTPException(

--- a/backend/src/homepot/app/api/API_v1/Endpoints/SitesEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/SitesEndpoint.py
@@ -236,6 +236,7 @@ async def list_sites(
                 site_list.append(
                     {
                         "site_id": site.site_id,
+                        "tenant_id": site.tenant_id,
                         "name": site.name,
                         "description": site.description,
                         "location": site.location,
@@ -291,6 +292,7 @@ async def get_site(
 
         return {
             "site_id": site.site_id,
+            "tenant_id": site.tenant_id,
             "name": site.name,
             "description": site.description,
             "location": site.location,

--- a/backend/src/homepot/database.py
+++ b/backend/src/homepot/database.py
@@ -349,7 +349,7 @@ class DatabaseService:
                 .options(joinedload(Device.site), joinedload(Device.credentials))
                 .where(Device.device_id == device_id, Device.is_active.is_(True))
             )
-            return result.scalar_one_or_none()
+            return result.unique().scalar_one_or_none()
 
     async def get_devices_by_site_id(
         self, site_id: str, include_unpaired: bool = False
@@ -385,7 +385,7 @@ class DatabaseService:
             query = query.order_by(Device.created_at.desc())
 
             result = await session.execute(query)
-            return list(result.scalars().all())
+            return list(result.unique().scalars().all())
 
     # Device operations
     async def create_device(

--- a/backend/src/homepot/database.py
+++ b/backend/src/homepot/database.py
@@ -346,7 +346,7 @@ class DatabaseService:
         async with self.get_session() as session:
             result = await session.execute(
                 select(Device)
-                .options(joinedload(Device.site))
+                .options(joinedload(Device.site), joinedload(Device.credentials))
                 .where(Device.device_id == device_id, Device.is_active.is_(True))
             )
             return result.scalar_one_or_none()
@@ -364,6 +364,7 @@ class DatabaseService:
             List of Device objects for the site (empty if site not found)
         """
         from sqlalchemy import select
+        from sqlalchemy.orm import joinedload
 
         # Verify site exists first (outside of the device query session to avoid nesting)
         site = await self.get_site_by_site_id(site_id)
@@ -372,7 +373,11 @@ class DatabaseService:
 
         async with self.get_session() as session:
             # Query devices using INTEGER site.id FK
-            query = select(Device).where(Device.site_id == site.id)
+            query = (
+                select(Device)
+                .options(joinedload(Device.credentials))
+                .where(Device.site_id == site.id)
+            )
 
             if not include_unpaired:
                 query = query.where(Device.is_active.is_(True))

--- a/backend/tests/test_homepot_integration.py
+++ b/backend/tests/test_homepot_integration.py
@@ -588,6 +588,102 @@ class TestEndToEndWorkflows:
         assert stats.get("total_events", 0) > 0
 
 
+class TestDeviceSiteFields:
+    """Tests for PR 19: surface hidden device/site fields."""
+
+    _headers: dict = {}
+
+    def setup_method(self) -> None:
+        """Set auth headers before each test."""
+        if not TestDeviceSiteFields._headers:
+            TestDeviceSiteFields._headers = auth_headers()
+
+    def test_device_get_includes_last_heartbeat_at(self, client: TestClient) -> None:
+        """GET /devices/device/{device_id} includes last_heartbeat_at."""
+        h = TestDeviceSiteFields._headers
+        devices_resp = client.get("/api/v1/devices/device", headers=h)
+        assert devices_resp.status_code == 200
+        devices = devices_resp.json().get("devices", [])
+        if devices:
+            device_id = devices[0]["device_id"]
+            resp = client.get(f"/api/v1/devices/device/{device_id}", headers=h)
+            assert resp.status_code == 200
+            data = resp.json()
+            assert "last_heartbeat_at" in data
+            assert "credential_status" in data
+
+    def test_device_list_includes_new_fields(self, client: TestClient) -> None:
+        """GET /devices/device includes last_heartbeat_at and credential_status."""
+        h = TestDeviceSiteFields._headers
+        resp = client.get("/api/v1/devices/device", headers=h)
+        assert resp.status_code == 200
+        devices = resp.json().get("devices", [])
+        if devices:
+            d = devices[0]
+            assert "last_heartbeat_at" in d
+            assert "credential_status" in d
+
+    def test_devices_by_site_includes_new_fields(self, client: TestClient) -> None:
+        """GET /devices/sites/{site_id}/devices includes new fields."""
+        h = TestDeviceSiteFields._headers
+        sites_resp = client.get("/api/v1/sites", headers=h)
+        assert sites_resp.status_code == 200
+        sites = sites_resp.json().get("sites", [])
+        if sites:
+            site_id = sites[0]["site_id"]
+            resp = client.get(f"/api/v1/devices/sites/{site_id}/devices", headers=h)
+            assert resp.status_code == 200
+            devices = resp.json()
+            if devices:
+                d = devices[0]
+                assert "last_heartbeat_at" in d
+                assert "credential_status" in d
+
+    def test_site_list_includes_tenant_id(self, client: TestClient) -> None:
+        """GET /sites includes tenant_id."""
+        h = TestDeviceSiteFields._headers
+        resp = client.get("/api/v1/sites", headers=h)
+        assert resp.status_code == 200
+        sites = resp.json().get("sites", [])
+        if sites:
+            assert "tenant_id" in sites[0]
+
+    def test_site_get_includes_tenant_id(self, client: TestClient) -> None:
+        """GET /sites/{site_id} includes tenant_id."""
+        h = TestDeviceSiteFields._headers
+        sites_resp = client.get("/api/v1/sites", headers=h)
+        assert sites_resp.status_code == 200
+        sites = sites_resp.json().get("sites", [])
+        if sites:
+            site_id = sites[0]["site_id"]
+            resp = client.get(f"/api/v1/sites/{site_id}", headers=h)
+            assert resp.status_code == 200
+            assert "tenant_id" in resp.json()
+
+    def test_device_credentials_endpoint(self, client: TestClient) -> None:
+        """GET /devices/device/{device_id}/credentials returns history."""
+        h = TestDeviceSiteFields._headers
+        devices_resp = client.get("/api/v1/devices/device", headers=h)
+        assert devices_resp.status_code == 200
+        devices = devices_resp.json().get("devices", [])
+        if devices:
+            device_id = devices[0]["device_id"]
+            resp = client.get(
+                f"/api/v1/devices/device/{device_id}/credentials", headers=h
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert "device_id" in data
+            assert "credentials" in data
+            assert isinstance(data["credentials"], list)
+            if data["credentials"]:
+                c = data["credentials"][0]
+                assert "credential_id" in c
+                assert "is_active" in c
+                assert "created_at" in c
+                assert "key_hash" not in c
+
+
 @pytest.mark.performance
 @skip_live_tests
 class TestSystemPerformance:

--- a/docs/device-lifecycle-and-ownership.md
+++ b/docs/device-lifecycle-and-ownership.md
@@ -418,3 +418,46 @@ PR 17: Command ack & result reporting
 PR 18: Production hardening
 - Log rotation, service supervision (systemd watchdog), graceful shutdown
 - Comprehensive failure tests: restart, network loss, token revocation, duplicate enrolment, unpairing
+
+PR 19: Surface hidden device/site fields + credential status reader
+Expose data that already exists in the database but is not returned by
+any API response.
+
+| Change | Reason |
+|---|---|
+| Add `last_heartbeat_at` to `GET /devices/device/{device_id}` | Dashboard needs the raw timestamp for connectivity display |
+| Add `tenant_id` to site GET responses | Dashboard shows tenant assignment per site |
+| Add `credential_status` (derived from `device_credentials.is_active`) to device GET responses | Dashboard shows credential health without exposing secrets |
+| `GET /devices/device/{device_id}/credentials` — read-only credential history (version list with timestamps + `is_active`; no `key_hash`) | Dashboard metadata for troubleshooting |
+| Ensure `GET /agent/{device_id}/status` includes `last_heartbeat_at` | Consistency across agent endpoints |
+
+PR 20: Dashboard aggregate endpoint
+
+| Change | Reason |
+|---|---|
+| `GET /dashboard/summary` — global counts grouped by `lifecycle_state`, `connectivity_state`, `health_state` | Top-level dashboard KPIs |
+| `GET /sites/{site_id}/dashboard` — same breakdown scoped to one site | Per-site dashboard view |
+| Include `pending_enrolment_intents` count (intents in PENDING/APPROVED status) | Dashboard shows queue of devices waiting to enrol |
+| Include `pending_commands` and `expired_commands` counts | Dashboard shows outstanding work |
+
+PR 21: Device command history endpoint + auto-expiry scheduler
+
+| Change | Reason |
+|---|---|
+| `GET /devices/device/{device_id}/commands` — user-facing route returning all commands for a device (past, pending, expired) sorted by `created_at` | Dashboard needs command history per device |
+| Background scheduler that marks PENDING/SENT commands as EXPIRED after a TTL | Prevents stale commands from lingering |
+| *(Optional)* Add command counts to existing device GET responses | Quick glance at command load |
+
+PR 22: Enrolment intent auto-expiry scheduler
+
+| Change | Reason |
+|---|---|
+| Background scheduler that marks PENDING and APPROVED intents as EXPIRED when `expires_at < now()` | Without this, intents only expire at claim time |
+| Ensure intent counts in the dashboard summary are correct | Dashboard surfaces pending intents across all sites |
+
+PR 23: Modernise legacy agent endpoint + push-log stub fill
+
+| Change | Reason |
+|---|---|
+| Update `GET /agents` and `GET /agents/{device_id}` to use `lifecycle_state`, `connectivity_state`, `health_state` instead of the deprecated `status` field | Dashboard consumes this for the agent list view |
+| *(Optional)* Populate the stubbed `GET /device/{device_id}/push-logs` with real data from the push notifications table | Dashboard shows notification delivery status |


### PR DESCRIPTION
## Summary

Expose data that already exists in the database but is not returned by any API response.

## Changes

### DevicesEndpoints
- **`GET /device/{device_id}`** — added `last_heartbeat_at` and `credential_status` (active/inactive derived from `device_credentials.is_active`)
- **`GET /device`** (list) — same two fields added
- **`GET /sites/{site_id}/devices`** — same two fields added
- **New `GET /device/{device_id}/credentials`** — returns credential version history without secrets (`credential_id`, `is_active`, `created_at`, `rotated_at`, `revoked_at`; no `key_hash`)

### SitesEndpoint
- **`GET /sites`** (list) — added `tenant_id`
- **`GET /{site_id}`** — added `tenant_id`

### Agent status (already done)
- `GET /agent/{device_id}/status` already returned `last_heartbeat_at`

## Tests
6 new integration tests in `TestDeviceSiteFields` verifying field presence on all affected endpoints.

## Quality
- black/isort/flake8/mypy: clean
- 33/33 integration tests pass (27 original + 6 new)