### PR TITLE
feat: Device command history endpoint + auto-expiry scheduler

### DIFF
--- a/backend/src/homepot/app/api/API_v1/Endpoints/DeviceCommandsEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DeviceCommandsEndpoint.py
@@ -25,6 +25,20 @@ class CreateCommandRequest(BaseModel):
     payload: Optional[Dict[str, Any]] = None
 
 
+class CommandHistoryResponse(BaseModel):
+    """Response model for command history listing."""
+
+    command_id: str
+    command_type: str
+    payload: Optional[Dict[str, Any]] = None
+    status: CommandStatus
+    result: Optional[Dict[str, Any]] = None
+    created_at: str
+    executed_at: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class UpdateCommandStatusRequest(BaseModel):
     """Request model for updating command status."""
 
@@ -194,3 +208,42 @@ async def update_command_status(
         status=updated_command.status,  # type: ignore
         created_at=updated_command.created_at.isoformat(),  # type: ignore
     )
+
+
+# 5. Get Device Command History (User-facing)
+@router.get(
+    "/device/{device_id}/commands",
+    response_model=List[CommandHistoryResponse],
+)
+async def get_device_command_history(
+    device_id: str,
+    sync_db: SASession = Depends(get_db),
+    current_user: UserDict = Depends(require_user()),
+) -> List[CommandHistoryResponse]:
+    """Get all commands for a device, sorted by created_at descending.
+
+    Requires viewer-level access on the device's site.
+    """
+    db_user = cast(
+        User, sync_db.query(User).filter(User.email == current_user["email"]).first()
+    )
+    db = await get_database_service()
+    device = await db.get_device_by_device_id(device_id)
+    if not device:
+        raise HTTPException(status_code=404, detail="Device not found")
+
+    verify_device_belongs_to_user(db_user, device, sync_db, minimum_role="viewer")
+
+    commands = await db.get_commands_for_device(device.id)  # type: ignore
+    return [
+        CommandHistoryResponse(
+            command_id=cmd.command_id,  # type: ignore
+            command_type=cmd.command_type,  # type: ignore
+            payload=cmd.payload,  # type: ignore
+            status=cmd.status,  # type: ignore
+            result=cmd.result,  # type: ignore
+            created_at=cmd.created_at.isoformat(),  # type: ignore
+            executed_at=cmd.executed_at.isoformat() if cmd.executed_at else None,  # type: ignore
+        )
+        for cmd in commands
+    ]

--- a/backend/src/homepot/database.py
+++ b/backend/src/homepot/database.py
@@ -724,6 +724,43 @@ class DatabaseService:
                 return command
             return None
 
+    async def get_commands_for_device(
+        self, device_id: int, limit: int = 100, offset: int = 0
+    ) -> List[DeviceCommand]:
+        """Get all commands for a device, sorted by created_at descending."""
+        async with self.get_session() as session:
+            result = await session.execute(
+                select(DeviceCommand)
+                .where(DeviceCommand.device_id == device_id)
+                .order_by(DeviceCommand.created_at.desc())
+                .limit(limit)
+                .offset(offset)
+            )
+            return list(result.scalars().all())
+
+    async def expire_stale_commands(self, ttl_seconds: int = 300) -> int:
+        """Mark PENDING and SENT commands older than ttl_seconds as EXPIRED.
+
+        Returns the number of commands expired.
+        """
+        cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+            seconds=ttl_seconds
+        )
+        async with self.get_session() as session:
+            result = await session.execute(
+                select(DeviceCommand).where(
+                    DeviceCommand.status.in_(
+                        [CommandStatus.PENDING, CommandStatus.SENT]
+                    ),
+                    DeviceCommand.created_at < cutoff,
+                )
+            )
+            commands = list(result.scalars().all())
+            for cmd in commands:
+                cmd.status = CommandStatus.EXPIRED  # type: ignore[assignment]
+            await session.commit()
+            return len(commands)
+
     # Health check operations
     async def create_health_check(
         self,

--- a/backend/src/homepot/main.py
+++ b/backend/src/homepot/main.py
@@ -41,11 +41,29 @@ logger = logging.getLogger(__name__)
 # Global client instance
 client_instance: Optional[HomepotClient] = None
 
+# Background task for command expiry
+_command_expiry_task: Optional[asyncio.Task[None]] = None
+
+
+async def _run_command_expiry_loop() -> None:
+    """Periodically expire stale PENDING/SENT commands."""
+    COMMAND_TTL_SECONDS = 300  # 5 minutes
+    POLL_INTERVAL_SECONDS = 60
+    while True:
+        try:
+            db = await get_database_service()
+            expired = await db.expire_stale_commands(ttl_seconds=COMMAND_TTL_SECONDS)
+            if expired:
+                logger.info(f"Expired {expired} stale command(s)")
+        except Exception as e:
+            logger.error(f"Command expiry error: {e}", exc_info=True)
+        await asyncio.sleep(POLL_INTERVAL_SECONDS)
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Manage application lifespan events."""
-    global client_instance
+    global client_instance, _command_expiry_task
 
     # Startup
     logger.info("Starting HOMEPOT Client application...")
@@ -57,6 +75,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     except Exception as e:
         logger.error(f"Failed to initialize database: {e}")
         raise
+
+    # Start background command expiry task
+    _command_expiry_task = asyncio.create_task(_run_command_expiry_loop())
+    logger.info("Command expiry background task started")
 
     # Initialize job orchestrator
     try:
@@ -139,6 +161,16 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         logger.info("Job orchestrator stopped")
     except Exception as e:
         logger.error(f"Error stopping orchestrator: {e}")
+
+    # Cancel background command expiry task
+    if _command_expiry_task is not None:
+        _command_expiry_task.cancel()
+        try:
+            await _command_expiry_task
+        except asyncio.CancelledError:
+            pass
+        _command_expiry_task = None
+        logger.info("Command expiry background task stopped")
 
     # Shutdown database
     try:

--- a/backend/tests/test_device_commands.py
+++ b/backend/tests/test_device_commands.py
@@ -1,10 +1,11 @@
 """Tests for device command management."""
 
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import os
 import secrets
 import tempfile
+from typing import Any, Dict
 
 from fastapi.testclient import TestClient
 import pytest
@@ -14,7 +15,15 @@ from sqlalchemy.orm import sessionmaker
 from homepot.app.auth_utils import create_access_token, hash_password
 from homepot.config import reload_settings
 import homepot.database
-from homepot.models import Base, Device, LifecycleState, Site, User
+from homepot.models import (
+    Base,
+    CommandStatus,
+    Device,
+    DeviceCommand,
+    LifecycleState,
+    Site,
+    User,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -167,3 +176,164 @@ def test_device_auth_failure(client: TestClient):
     headers = {"X-Device-ID": "non-existent-device", "X-API-Key": "invalid-key"}
     response = client.get("/api/v1/devices/pending", headers=headers)
     assert response.status_code == 401
+
+
+# -- Helpers for command history tests --
+
+TEST_ADMIN_EMAIL = "admin.history@test.local"
+
+
+def _setup_site_and_device(client: TestClient) -> Dict[str, Any]:
+    """Create a site and device, returning IDs and auth headers."""
+    db = homepot.database.SessionLocal()
+    try:
+        existing = db.query(User).filter(User.email == TEST_ADMIN_EMAIL).first()
+        if not existing:
+            admin = User(
+                email=TEST_ADMIN_EMAIL,
+                username="admin_history",
+                hashed_password=hash_password("pass"),
+                is_admin=True,
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            )
+            db.add(admin)
+            db.commit()
+    finally:
+        db.close()
+
+    token = create_access_token({"sub": TEST_ADMIN_EMAIL})
+    auth_headers = {"Authorization": f"Bearer {token}"}
+
+    site_id = "test-site-history"
+    resp = client.post(
+        "/api/v1/sites",
+        json={
+            "site_id": site_id,
+            "name": "History Test Site",
+        },
+        headers=auth_headers,
+    )
+    if resp.status_code not in (200, 409):
+        assert False, f"Failed to create site: {resp.text}"
+
+    device_id = "test-device-history"
+    api_key = secrets.token_urlsafe(32)
+    api_key_hash = hash_password(api_key)
+
+    db = homepot.database.SessionLocal()
+    try:
+        site = db.query(Site).filter(Site.site_id == site_id).first()
+        assert site is not None
+        existing_dev = db.query(Device).filter(Device.device_id == device_id).first()
+        if not existing_dev:
+            device = Device(
+                device_id=device_id,
+                name="History Device",
+                device_type="pos_terminal",
+                site_id=site.id,
+                api_key_hash=api_key_hash,
+                is_active=True,
+                lifecycle_state=LifecycleState.ACTIVE.value,
+            )
+            db.add(device)
+            db.commit()
+            db.refresh(device)
+    finally:
+        db.close()
+
+    return {
+        "site_id": site_id,
+        "device_id": device_id,
+        "auth_headers": auth_headers,
+    }
+
+
+def _queue_command(
+    client: TestClient,
+    device_id: str,
+    headers: Dict[str, str],
+    command_type: str = "REBOOT",
+) -> str:
+    """Queue a command and return its command_id."""
+    resp = client.post(
+        f"/api/v1/devices/{device_id}/commands",
+        json={"command_type": command_type, "payload": {"test": True}},
+        headers=headers,
+    )
+    assert resp.status_code == 201, f"Failed to queue command: {resp.text}"
+    return resp.json()["command_id"]
+
+
+def test_command_history_endpoint(client: TestClient) -> None:
+    """GET /devices/device/{device_id}/commands returns command history."""
+    ctx = _setup_site_and_device(client)
+    h = ctx["auth_headers"]
+    device_id = ctx["device_id"]
+
+    cmd1 = _queue_command(client, device_id, h, "REBOOT")
+    cmd2 = _queue_command(client, device_id, h, "UPDATE_CONFIG")
+
+    resp = client.get(f"/api/v1/devices/device/{device_id}/commands", headers=h)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) >= 2
+
+    # Most recent command first (desc by created_at)
+    assert data[0]["command_type"] == "UPDATE_CONFIG"
+    assert data[1]["command_type"] == "REBOOT"
+    assert data[0]["command_id"] == cmd2
+    assert data[1]["command_id"] == cmd1
+
+    # Verify all expected fields
+    cmd = data[0]
+    assert "command_id" in cmd
+    assert "command_type" in cmd
+    assert "status" in cmd
+    assert cmd["status"] == "pending"
+    assert "payload" in cmd
+    assert "created_at" in cmd
+    assert "executed_at" in cmd  # None for pending
+
+
+def test_command_history_unauthorized(client: TestClient) -> None:
+    """Command history endpoint returns 401 without auth."""
+    resp = client.get("/api/v1/devices/device/unknown/commands")
+    assert resp.status_code == 401
+
+
+def test_expire_stale_commands(client: TestClient) -> None:
+    """expire_stale_commands marks old PENDING commands as EXPIRED."""
+    ctx = _setup_site_and_device(client)
+    h = ctx["auth_headers"]
+    device_id = ctx["device_id"]
+
+    cmd_id = _queue_command(client, device_id, h, "PING")
+
+    # Directly manipulate the command's created_at to be in the past
+    db = homepot.database.SessionLocal()
+    try:
+        cmd = db.query(DeviceCommand).filter(DeviceCommand.command_id == cmd_id).first()
+        assert cmd is not None
+        cmd.created_at = datetime.now(timezone.utc) - timedelta(hours=1)
+        db.commit()
+    finally:
+        db.close()
+
+    # Run expiry with a short TTL
+    async def _expire():
+        svc = await homepot.database.get_database_service()
+        return await svc.expire_stale_commands(ttl_seconds=60)
+
+    expired_count = asyncio.run(_expire())
+    assert expired_count >= 1
+
+    # Verify the command is now expired
+    db = homepot.database.SessionLocal()
+    try:
+        cmd = db.query(DeviceCommand).filter(DeviceCommand.command_id == cmd_id).first()
+        assert cmd is not None
+        assert cmd.status == CommandStatus.EXPIRED
+    finally:
+        db.close()


### PR DESCRIPTION
Implements PR 21 from docs/device-lifecycle-and-ownership.md.

## Changes

**New endpoint:**
- `GET /device/{device_id}/commands` in DeviceCommandsEndpoint — returns all commands for a device (past, pending, expired) sorted by `created_at` desc

**DatabaseService:**
- `get_commands_for_device(device_id, limit, offset)` — list commands with ordering and pagination
- `expire_stale_commands(ttl_seconds)` — marks PENDING/SENT commands older than the TTL as EXPIRED

**Background scheduler:**
- `_run_command_expiry_loop()` in `main.py` — asyncio task started during app lifespan
- Polls every 60 seconds, expires stale commands after 5 minutes (300s TTL)
- Gracefully cancelled during shutdown

**Tests:**
- `test_command_history_endpoint` — verifies ordering, field presence
- `test_command_history_unauthorized` — unauthenticated access returns 401
- `test_expire_stale_commands` — end-to-end expiry with direct DB manipulation