### PR TITLE
PR 22: Enrolment intent auto-expiry scheduler

### DIFF
--- a/backend/src/homepot/database.py
+++ b/backend/src/homepot/database.py
@@ -912,6 +912,30 @@ class DatabaseService:
             result = await session.execute(query)
             return list(result.scalars().all())
 
+    async def expire_stale_enrolment_intents(self) -> int:
+        """Mark PENDING and APPROVED intents past their expires_at as EXPIRED.
+
+        Returns the number of intents expired.
+        """
+        now = datetime.datetime.now(datetime.timezone.utc)
+        async with self.get_session() as session:
+            result = await session.execute(
+                select(EnrolmentIntent).where(
+                    EnrolmentIntent.status.in_(
+                        [
+                            EnrolmentIntentStatus.PENDING,
+                            EnrolmentIntentStatus.APPROVED,
+                        ]
+                    ),
+                    EnrolmentIntent.expires_at < now,
+                )
+            )
+            intents = list(result.scalars().all())
+            for intent in intents:
+                intent.status = EnrolmentIntentStatus.EXPIRED  # type: ignore[assignment]
+            await session.commit()
+            return len(intents)
+
     async def update_enrolment_intent_status(
         self,
         intent_id: str,

--- a/backend/src/homepot/main.py
+++ b/backend/src/homepot/main.py
@@ -43,6 +43,7 @@ client_instance: Optional[HomepotClient] = None
 
 # Background task for command expiry
 _command_expiry_task: Optional[asyncio.Task[None]] = None
+_intent_expiry_task: Optional[asyncio.Task[None]] = None
 
 
 async def _run_command_expiry_loop() -> None:
@@ -60,10 +61,24 @@ async def _run_command_expiry_loop() -> None:
         await asyncio.sleep(POLL_INTERVAL_SECONDS)
 
 
+async def _run_intent_expiry_loop() -> None:
+    """Periodically expire PENDING/APPROVED enrolment intents past expires_at."""
+    POLL_INTERVAL_SECONDS = 120
+    while True:
+        try:
+            db = await get_database_service()
+            expired = await db.expire_stale_enrolment_intents()
+            if expired:
+                logger.info(f"Expired {expired} stale enrolment intent(s)")
+        except Exception as e:
+            logger.error(f"Intent expiry error: {e}", exc_info=True)
+        await asyncio.sleep(POLL_INTERVAL_SECONDS)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Manage application lifespan events."""
-    global client_instance, _command_expiry_task
+    global client_instance, _command_expiry_task, _intent_expiry_task
 
     # Startup
     logger.info("Starting HOMEPOT Client application...")
@@ -79,6 +94,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # Start background command expiry task
     _command_expiry_task = asyncio.create_task(_run_command_expiry_loop())
     logger.info("Command expiry background task started")
+
+    # Start background enrolment intent expiry task
+    _intent_expiry_task = asyncio.create_task(_run_intent_expiry_loop())
+    logger.info("Enrolment intent expiry background task started")
 
     # Initialize job orchestrator
     try:
@@ -171,6 +190,16 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             pass
         _command_expiry_task = None
         logger.info("Command expiry background task stopped")
+
+    # Cancel background enrolment intent expiry task
+    if _intent_expiry_task is not None:
+        _intent_expiry_task.cancel()
+        try:
+            await _intent_expiry_task
+        except asyncio.CancelledError:
+            pass
+        _intent_expiry_task = None
+        logger.info("Enrolment intent expiry background task stopped")
 
     # Shutdown database
     try:

--- a/backend/tests/test_device_commands.py
+++ b/backend/tests/test_device_commands.py
@@ -20,6 +20,8 @@ from homepot.models import (
     CommandStatus,
     Device,
     DeviceCommand,
+    EnrolmentIntent,
+    EnrolmentIntentStatus,
     LifecycleState,
     Site,
     User,
@@ -335,5 +337,74 @@ def test_expire_stale_commands(client: TestClient) -> None:
         cmd = db.query(DeviceCommand).filter(DeviceCommand.command_id == cmd_id).first()
         assert cmd is not None
         assert cmd.status == CommandStatus.EXPIRED
+    finally:
+        db.close()
+
+
+def test_expire_stale_enrolment_intents(client: TestClient) -> None:
+    """expire_stale_enrolment_intents marks past-expiry intents as EXPIRED."""
+    ctx = _setup_site_and_device(client)
+    site_id = ctx["site_id"]
+
+    db = homepot.database.SessionLocal()
+    intent_id = None
+    try:
+        site = db.query(Site).filter(Site.site_id == site_id).first()
+        assert site is not None
+
+        # Create an intent that expired 1 hour ago
+        intent = EnrolmentIntent(
+            intent_id="test-expired-intent",
+            site_id=site.id,
+            enrolment_method="pre-provisioned",
+            expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            creator_id=1,  # admin user
+            status=EnrolmentIntentStatus.PENDING,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        db.add(intent)
+
+        # Create a non-expired intent for comparison
+        active_intent = EnrolmentIntent(
+            intent_id="test-active-intent",
+            site_id=site.id,
+            enrolment_method="pre-provisioned",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
+            creator_id=1,
+            status=EnrolmentIntentStatus.PENDING,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        db.add(active_intent)
+        db.commit()
+        intent_id = intent.intent_id
+    finally:
+        db.close()
+
+    async def _expire():
+        svc = await homepot.database.get_database_service()
+        return await svc.expire_stale_enrolment_intents()
+
+    expired_count = asyncio.run(_expire())
+    assert expired_count >= 1
+
+    db = homepot.database.SessionLocal()
+    try:
+        expired = (
+            db.query(EnrolmentIntent)
+            .filter(EnrolmentIntent.intent_id == intent_id)
+            .first()
+        )
+        assert expired is not None
+        assert expired.status == EnrolmentIntentStatus.EXPIRED
+
+        active = (
+            db.query(EnrolmentIntent)
+            .filter(EnrolmentIntent.intent_id == "test-active-intent")
+            .first()
+        )
+        assert active is not None
+        assert active.status == EnrolmentIntentStatus.PENDING
     finally:
         db.close()


### PR DESCRIPTION
Implements PR 22 from docs/device-lifecycle-and-ownership.md.

## Changes

**DatabaseService:**
- `expire_stale_enrolment_intents()` — marks PENDING and APPROVED intents whose `expires_at < now()` as EXPIRED

**Background scheduler:**
- `_run_intent_expiry_loop()` in `main.py` — asyncio task polling every 120 seconds
- Gracefully cancelled during shutdown

**Tests:**
- `test_expire_stale_enrolment_intents` — verifies expired intents are marked and non-expired intents are preserved