### PR TITLE
feat: Modernise legacy agent endpoint + push-log stub fill

### DIFF
--- a/backend/src/homepot/app/api/API_v1/Endpoints/AgentsEndpoints.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/AgentsEndpoints.py
@@ -5,7 +5,9 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException
 
+from homepot.app.api.API_v1.Endpoints.DevicesEndpoints import _compute_connectivity
 from homepot.client import HomepotClient
+from homepot.models import ConnectivityState, HealthState
 
 client_instance: Optional[HomepotClient] = None
 
@@ -31,7 +33,7 @@ async def list_agents() -> Dict[str, List[Dict]]:
         from sqlalchemy import select
 
         from homepot.database import get_database_service
-        from homepot.models import Device, DeviceStatus, HealthCheck
+        from homepot.models import Device, HealthCheck
 
         db_service = await get_database_service()
         agents_status = []
@@ -83,18 +85,23 @@ async def list_agents() -> Dict[str, List[Dict]]:
                         hc_data["timestamp"] = latest_hc.timestamp.isoformat()
                 else:
                     # Log warning if no health check found for active device
-                    if device.status == DeviceStatus.ONLINE:
+                    if _compute_connectivity(device) == ConnectivityState.ONLINE.value:
                         logger.warning(
                             f"No health check found for online device {device.device_id} (PK: {device.id})"
                         )
 
+                conn = _compute_connectivity(device)
                 status_data = {
                     "device_id": device.device_id,
-                    "state": device.status,
+                    "lifecycle_state": device.lifecycle_state,
+                    "connectivity_state": conn,
+                    "health_state": device.health_state or HealthState.UNKNOWN.value,
                     "config_version": device.firmware_version or "unknown",
                     "last_health_check": hc_data,
                     "uptime": (
-                        "running" if device.status == DeviceStatus.ONLINE else "stopped"
+                        "running"
+                        if conn == ConnectivityState.ONLINE.value
+                        else "stopped"
                     ),
                 }
                 agents_status.append(status_data)
@@ -115,7 +122,7 @@ async def get_agent_status(device_id: str) -> Dict[str, Any]:
         from sqlalchemy import desc, select
 
         from homepot.database import get_database_service
-        from homepot.models import Device, DeviceStatus, HealthCheck
+        from homepot.models import Device, HealthCheck
 
         db_service = await get_database_service()
 
@@ -140,13 +147,16 @@ async def get_agent_status(device_id: str) -> Dict[str, Any]:
             )
             latest_hc = hc_result.scalar_one_or_none()
 
+            conn = _compute_connectivity(device)
             return {
                 "device_id": device.device_id,
-                "state": device.status,
+                "lifecycle_state": device.lifecycle_state,
+                "connectivity_state": conn,
+                "health_state": device.health_state or HealthState.UNKNOWN.value,
                 "config_version": device.firmware_version or "unknown",
                 "last_health_check": latest_hc.response_data if latest_hc else None,
                 "uptime": (
-                    "running" if device.status == DeviceStatus.ONLINE else "stopped"
+                    "running" if conn == ConnectivityState.ONLINE.value else "stopped"
                 ),
             }
 

--- a/backend/tests/test_device_commands.py
+++ b/backend/tests/test_device_commands.py
@@ -408,3 +408,69 @@ def test_expire_stale_enrolment_intents(client: TestClient) -> None:
         assert active.status == EnrolmentIntentStatus.PENDING
     finally:
         db.close()
+
+
+def test_agent_list_includes_modern_state_fields(client: TestClient) -> None:
+    """GET /agents returns lifecycle_state, connectivity_state, health_state."""
+    ctx = _setup_site_and_device(client)
+    h = ctx["auth_headers"]
+    device_id = ctx["device_id"]
+
+    resp = client.get("/api/v1/agents", headers=h)
+    assert resp.status_code == 200
+    agents = resp.json().get("agents", [])
+    assert len(agents) > 0
+
+    agent = next((a for a in agents if a["device_id"] == device_id), None)
+    assert agent is not None, f"Device {device_id} not found in agent list"
+
+    assert "lifecycle_state" in agent
+    assert "connectivity_state" in agent
+    assert "health_state" in agent
+    assert "state" not in agent  # deprecated field removed
+
+    assert agent["lifecycle_state"] in (
+        "pending",
+        "active",
+        "suspended",
+        "unpaired",
+        "retired",
+    )
+    assert agent["connectivity_state"] in ("unknown", "online", "offline")
+    assert agent["health_state"] in (
+        "healthy",
+        "warning",
+        "error",
+        "maintenance",
+        "unknown",
+    )
+    assert "device_id" in agent
+    assert "config_version" in agent
+    assert "last_health_check" in agent
+    assert "uptime" in agent
+
+
+def test_agent_detail_includes_modern_state_fields(client: TestClient) -> None:
+    """GET /agents/{device_id} returns lifecycle_state, connectivity_state, health_state."""
+    ctx = _setup_site_and_device(client)
+    h = ctx["auth_headers"]
+    device_id = ctx["device_id"]
+
+    resp = client.get(f"/api/v1/agents/{device_id}", headers=h)
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert "lifecycle_state" in data
+    assert "connectivity_state" in data
+    assert "health_state" in data
+    assert "state" not in data  # deprecated field removed
+
+    assert data["lifecycle_state"] in (
+        "pending",
+        "active",
+        "suspended",
+        "unpaired",
+        "retired",
+    )
+    assert data["connectivity_state"] in ("unknown", "online", "offline")
+    assert data["device_id"] == device_id


### PR DESCRIPTION
Implements PR 23 from docs/device-lifecycle-and-ownership.md.

## Changes

**AgentsEndpoints.py:**
- `GET /agents` and `GET /agents/{device_id}` now return `lifecycle_state`, `connectivity_state`, `health_state` instead of the deprecated `state` field
- `connectivity_state` is computed from `last_heartbeat_at` via `_compute_connectivity()`
- `uptime` derived from connectivity instead of `device.status`

**Push-logs:** The `GET /device/{device_id}/push-logs` endpoint remains stubbed — `device_id` column does not exist in the `push_notification_logs` table schema, so the unblocking requires a migration.

**Tests:**
- `test_agent_list_includes_modern_state_fields` — verifies list response has the new fields
- `test_agent_detail_includes_modern_state_fields` — verifies detail response has the new fields