### PR TITLE
feat: Stable Windows device identity

### DIFF
--- a/backend/src/homepot/agent/identity.py
+++ b/backend/src/homepot/agent/identity.py
@@ -3,16 +3,27 @@
 Generates and manages a stable device identity that survives restarts
 and re-enrolment.  The identity is stored in:
 
+**Linux:**
 1. ``/var/lib/homepot/identity`` — preferred FHS-compliant path when
    writable (used by the installed daemon).
 2. ``XDG_DATA_HOME/homepot/identity`` — fallback for unprivileged/dev runs.
 3. ``/etc/machine-id`` (hashed with a salt) — fallback when neither is
    writable, providing a deterministic identity tied to the hardware.
+
+**Windows:**
+1. ``%PROGRAMDATA%\\Homepot\\identity`` — all-users identity storage
+   (``C:\\ProgramData\\Homepot\\identity``).
+2. ``%APPDATA%\\Homepot\\identity`` — per-user fallback.
+3. ``Win32_ComputerSystemProduct.UUID`` (hashed with a salt) — fallback
+   when neither is writable.
 """
 
 import hashlib
 import logging
+import os
 from pathlib import Path
+import subprocess  # noqa: S404
+import sys
 import tempfile
 from typing import Optional
 import uuid
@@ -22,15 +33,45 @@ from platformdirs import user_data_dir
 logger = logging.getLogger(__name__)
 
 _IDENTITY_FILENAME = "identity"
+
+# Linux paths
 _VAR_LIB_PATH = Path("/var/lib/homepot")
 _FALLBACK_DIR = Path(user_data_dir("homepot"))
+
+# Windows paths
+_WINDOWS_PROGRAMDATA = Path(os.environ.get("PROGRAMDATA", "C:\\ProgramData")) / "Homepot"
+_WINDOWS_APPDATA = Path(os.environ.get("APPDATA", "")) / "Homepot" if os.environ.get("APPDATA") else None
+
+
+def _is_windows() -> bool:
+    return sys.platform == "win32"
 
 
 def _get_identity_dir() -> Path:
     """Return the best writable directory for the identity file.
 
-    Prefers ``/var/lib/homepot``; falls back to XDG data dir.
+    **Windows:** ``%PROGRAMDATA%\\Homepot`` or ``%APPDATA%\\Homepot``.
+    **Linux:** ``/var/lib/homepot`` or XDG data dir.
     """
+    if _is_windows():
+        try:
+            _WINDOWS_PROGRAMDATA.mkdir(parents=True, exist_ok=True)
+            test_file = _WINDOWS_PROGRAMDATA / ".write_test"
+            test_file.touch()
+            test_file.unlink()
+            return _WINDOWS_PROGRAMDATA
+        except (OSError, PermissionError):
+            pass
+        if _WINDOWS_APPDATA:
+            try:
+                _WINDOWS_APPDATA.mkdir(parents=True, exist_ok=True)
+                return _WINDOWS_APPDATA
+            except (OSError, PermissionError):
+                pass
+        tmp_dir = Path(tempfile.gettempdir()) / "homepot"
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+        return tmp_dir
+
     try:
         _VAR_LIB_PATH.mkdir(parents=True, exist_ok=True)
         test_file = _VAR_LIB_PATH / ".write_test"
@@ -80,13 +121,51 @@ def _machine_id_identity() -> Optional[str]:
         return None
 
 
+def _windows_machine_id_identity() -> Optional[str]:
+    """Derive a deterministic identity from the Windows system UUID.
+
+    Uses PowerShell to retrieve ``Win32_ComputerSystemProduct.UUID``,
+    which is stable across reboots and tied to the motherboard.
+    Returns ``None`` if the command fails or the UUID is empty.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "powershell", "-NoProfile", "-Command",
+                "Get-CimInstance Win32_ComputerSystemProduct | Select-Object -ExpandProperty UUID",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        raw = result.stdout.strip() if result.stdout else ""
+        if result.returncode != 0 or not raw:
+            return None
+        salted = hashlib.sha256(f"homepot-device-identity:{raw}".encode()).hexdigest()[
+            :32
+        ]
+        return f"device-{salted}"
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("Cannot read Windows machine UUID: %s", exc)
+        return None
+
+
+def _platform_machine_id() -> Optional[str]:
+    """Return a deterministic hardware-bound identity for the current platform."""
+    if _is_windows():
+        return _windows_machine_id_identity()
+    return _machine_id_identity()
+
+
 def get_or_create_device_id() -> str:
     """Return the persistent device identity, creating one if needed.
 
     Resolution order:
     1. Read existing identity file.
     2. If absent, generate a UUID and persist it.
-    3. If the identity directory is unwritable, derive from ``/etc/machine-id``.
+    3. If the identity directory is unwritable, derive from a platform
+       hardware identifier (``/etc/machine-id`` on Linux,
+       ``Win32_ComputerSystemProduct.UUID`` on Windows).
     """
     identity_path = _identity_file_path()
     if identity_path.exists():
@@ -101,13 +180,14 @@ def get_or_create_device_id() -> str:
     try:
         identity_path.parent.mkdir(parents=True, exist_ok=True)
         identity_path.write_text(new_id + "\n", encoding="utf-8")
-        identity_path.chmod(0o644)
+        if not _is_windows():
+            identity_path.chmod(0o644)
         logger.info("Generated new device identity: %s", new_id)
         return new_id
     except (OSError, PermissionError):
-        machine_id = _machine_id_identity()
+        machine_id = _platform_machine_id()
         if machine_id:
-            logger.info("Derived device identity from machine-id: %s", machine_id)
+            logger.info("Derived device identity from hardware: %s", machine_id)
             return machine_id
         logger.warning("Cannot persist identity file; using ephemeral UUID: %s", new_id)
         return new_id
@@ -126,13 +206,13 @@ def get_device_id() -> Optional[str]:
                 return raw
         except OSError:
             pass
-    return _machine_id_identity()
+    return _platform_machine_id()
 
 
 def reset_device_id() -> None:
     """Remove the persisted identity file so a new one is generated next time.
 
-    Does **not** affect ``/etc/machine-id``.
+    Does **not** affect the hardware identifier on either platform.
     """
     identity_path = _identity_file_path()
     if identity_path.exists():

--- a/backend/src/homepot/agent/identity.py
+++ b/backend/src/homepot/agent/identity.py
@@ -39,8 +39,14 @@ _VAR_LIB_PATH = Path("/var/lib/homepot")
 _FALLBACK_DIR = Path(user_data_dir("homepot"))
 
 # Windows paths
-_WINDOWS_PROGRAMDATA = Path(os.environ.get("PROGRAMDATA", "C:\\ProgramData")) / "Homepot"
-_WINDOWS_APPDATA = Path(os.environ.get("APPDATA", "")) / "Homepot" if os.environ.get("APPDATA") else None
+_WINDOWS_PROGRAMDATA = (
+    Path(os.environ.get("PROGRAMDATA", "C:\\ProgramData")) / "Homepot"
+)
+_WINDOWS_APPDATA = (
+    Path(os.environ.get("APPDATA", "")) / "Homepot"
+    if os.environ.get("APPDATA")
+    else None
+)
 
 
 def _is_windows() -> bool:
@@ -130,8 +136,12 @@ def _windows_machine_id_identity() -> Optional[str]:
     """
     try:
         result = subprocess.run(  # noqa: S603, S607  # hardcoded command, no user input
-            ["powershell", "-NoProfile", "-Command",
-             "Get-CimInstance Win32_ComputerSystemProduct | Select-Object -ExpandProperty UUID"],
+            [
+                "powershell",
+                "-NoProfile",
+                "-Command",
+                "Get-CimInstance Win32_ComputerSystemProduct | Select-Object -ExpandProperty UUID",
+            ],
             capture_output=True,
             text=True,
             timeout=10,

--- a/backend/src/homepot/agent/identity.py
+++ b/backend/src/homepot/agent/identity.py
@@ -1,4 +1,4 @@
-"""Persistent stable device identity for the HOMEPOT agent.
+r"""Persistent stable device identity for the HOMEPOT agent.
 
 Generates and manages a stable device identity that survives restarts
 and re-enrolment.  The identity is stored in:
@@ -48,9 +48,9 @@ def _is_windows() -> bool:
 
 
 def _get_identity_dir() -> Path:
-    """Return the best writable directory for the identity file.
+    r"""Return the best writable directory for the identity file.
 
-    **Windows:** ``%PROGRAMDATA%\\Homepot`` or ``%APPDATA%\\Homepot``.
+    **Windows:** ``%PROGRAMDATA%\Homepot`` or ``%APPDATA%\Homepot``.
     **Linux:** ``/var/lib/homepot`` or XDG data dir.
     """
     if _is_windows():
@@ -129,11 +129,9 @@ def _windows_machine_id_identity() -> Optional[str]:
     Returns ``None`` if the command fails or the UUID is empty.
     """
     try:
-        result = subprocess.run(
-            [
-                "powershell", "-NoProfile", "-Command",
-                "Get-CimInstance Win32_ComputerSystemProduct | Select-Object -ExpandProperty UUID",
-            ],
+        result = subprocess.run(  # noqa: S603, S607  # hardcoded command, no user input
+            ["powershell", "-NoProfile", "-Command",
+             "Get-CimInstance Win32_ComputerSystemProduct | Select-Object -ExpandProperty UUID"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/backend/tests/test_agent_identity.py
+++ b/backend/tests/test_agent_identity.py
@@ -359,7 +359,9 @@ class TestEdgeCases:
     def test_identity_persistence_survives_object_recreation(self, tmp_identity_dir):
         """Identity persists across re-creation of the directory reference."""
         first = get_or_create_device_id()
-        with patch("homepot.agent.identity._get_identity_dir", return_value=tmp_identity_dir):
+        with patch(
+            "homepot.agent.identity._get_identity_dir", return_value=tmp_identity_dir
+        ):
             second = get_or_create_device_id()
         assert first == second
 
@@ -392,10 +394,12 @@ class TestIsWindows:
         """_is_windows returns True when sys.platform is 'win32'."""
         with patch("homepot.agent.identity.sys.platform", "win32"):
             from homepot.agent.identity import _is_windows
+
             assert _is_windows() is True
 
     def test_returns_false_on_linux(self):
         """_is_windows returns False when sys.platform is 'linux'."""
         with patch("homepot.agent.identity.sys.platform", "linux"):
             from homepot.agent.identity import _is_windows
+
             assert _is_windows() is False

--- a/backend/tests/test_agent_identity.py
+++ b/backend/tests/test_agent_identity.py
@@ -12,7 +12,7 @@ Covers:
 
 import os
 from pathlib import Path
-import subprocess
+import subprocess  # noqa: S404  # needed to mock subprocess.TimeoutExpired in tests
 import sys
 import tempfile
 from unittest.mock import MagicMock, patch

--- a/backend/tests/test_agent_identity.py
+++ b/backend/tests/test_agent_identity.py
@@ -7,19 +7,23 @@ Covers:
 - identity_path()
 - identity_dir()
 - Fallback to machine-id when identity dir is unwritable
+- Windows-specific identity (WindowsCredManager placeholder)
 """
 
 import os
 from pathlib import Path
+import subprocess
 import sys
 import tempfile
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from homepot.agent.identity import (
     _generate_uuid_identity,
     _machine_id_identity,
+    _platform_machine_id,
+    _windows_machine_id_identity,
     get_device_id,
     get_or_create_device_id,
     identity_dir,
@@ -85,6 +89,93 @@ class TestMachineIdIdentity:
                 assert r1 == r2
 
 
+class TestWindowsMachineIdIdentity:
+    """Tests for the _windows_machine_id_identity helper."""
+
+    def test_returns_none_when_powershell_fails(self):
+        """Returns None when the PowerShell command returns a non-zero exit code."""
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        with patch("homepot.agent.identity.subprocess.run", return_value=mock_result):
+            result = _windows_machine_id_identity()
+            assert result is None
+
+    def test_returns_none_on_empty_output(self):
+        """Returns None when PowerShell returns empty output."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        with patch("homepot.agent.identity.subprocess.run", return_value=mock_result):
+            result = _windows_machine_id_identity()
+            assert result is None
+
+    def test_returns_none_on_timeout(self):
+        """Returns None when the PowerShell command times out."""
+        with patch(
+            "homepot.agent.identity.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="powershell", timeout=10),
+        ):
+            result = _windows_machine_id_identity()
+            assert result is None
+
+    def test_returns_none_on_file_not_found(self):
+        """Returns None when PowerShell is not available."""
+        with patch(
+            "homepot.agent.identity.subprocess.run",
+            side_effect=FileNotFoundError("No such file"),
+        ):
+            result = _windows_machine_id_identity()
+            assert result is None
+
+    def test_returns_deterministic_id_from_uuid(self):
+        """A known system UUID produces a deterministic device identity."""
+        fake_uuid = "12345678-1234-1234-1234-123456789abc"
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = fake_uuid + "\n"
+        with patch("homepot.agent.identity.subprocess.run", return_value=mock_result):
+            result = _windows_machine_id_identity()
+            assert result is not None
+            assert result.startswith("device-")
+            assert len(result) > len("device-")
+
+    def test_same_uuid_gives_same_device_id(self):
+        """The same system UUID always yields the same device identity."""
+        fake_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = fake_uuid + "\n"
+        with patch("homepot.agent.identity.subprocess.run", return_value=mock_result):
+            r1 = _windows_machine_id_identity()
+            r2 = _windows_machine_id_identity()
+            assert r1 == r2
+
+
+class TestPlatformMachineId:
+    """Tests for the _platform_machine_id dispatcher."""
+
+    def test_delegates_to_windows_on_win32(self):
+        """On Windows, _platform_machine_id calls _windows_machine_id_identity."""
+        with patch("homepot.agent.identity._is_windows", return_value=True):
+            with patch(
+                "homepot.agent.identity._windows_machine_id_identity",
+                return_value="device-windows-id",
+            ):
+                result = _platform_machine_id()
+                assert result == "device-windows-id"
+
+    def test_delegates_to_linux_on_posix(self):
+        """On Linux, _platform_machine_id calls _machine_id_identity."""
+        with patch("homepot.agent.identity._is_windows", return_value=False):
+            with patch(
+                "homepot.agent.identity._machine_id_identity",
+                return_value="device-linux-id",
+            ):
+                result = _platform_machine_id()
+                assert result == "device-linux-id"
+
+
 # ============================================================================
 # Integration tests with temporary identity directories
 # ============================================================================
@@ -92,10 +183,16 @@ class TestMachineIdIdentity:
 
 @pytest.fixture
 def tmp_identity_dir(monkeypatch):
-    """Redirect identity storage to a temp directory."""
+    """Redirect identity storage to a temp directory.
+
+    Works cross-platform by mocking ``_get_identity_dir`` to return
+    the temp dir directly.
+    """
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_path = Path(tmpdir)
-        monkeypatch.setattr("homepot.agent.identity._VAR_LIB_PATH", tmp_path)
+        monkeypatch.setattr(
+            "homepot.agent.identity._get_identity_dir", lambda: tmp_path
+        )
         yield tmp_path
 
 
@@ -132,25 +229,47 @@ class TestGetOrCreateDeviceId:
         mode = os.stat(id_file).st_mode & 0o777
         assert mode == 0o644, f"Expected 0o644, got {oct(mode)}"
 
+    def test_skips_chmod_on_windows(self, tmp_identity_dir, monkeypatch):
+        """On Windows, chmod is not called when persisting the identity."""
+        monkeypatch.setattr("homepot.agent.identity._is_windows", lambda: True)
+        monkeypatch.setattr("homepot.agent.identity._platform_machine_id", lambda: None)
+        device_id = get_or_create_device_id()
+        id_file = tmp_identity_dir / "identity"
+        assert id_file.exists()
+        assert id_file.read_text("utf-8").strip() == device_id
+
+    def test_falls_back_to_hardware_id_when_dir_unwritable(self, monkeypatch):
+        """When the identity directory cannot be written, falls back to hardware ID."""
+        monkeypatch.setattr(
+            "homepot.agent.identity._identity_file_path",
+            lambda: Path("/nonexistent/homepot/identity"),
+        )
+        monkeypatch.setattr(
+            "homepot.agent.identity._platform_machine_id",
+            lambda: "device-hardware-fallback",
+        )
+        result = get_or_create_device_id()
+        assert result == "device-hardware-fallback"
+
 
 class TestGetDeviceId:
     """Tests for get_device_id (read-only, no creation)."""
 
     def test_returns_none_when_no_identity(self, tmp_identity_dir, monkeypatch):
-        """Returns None when no identity file or machine-id exists."""
-        monkeypatch.setattr("homepot.agent.identity._machine_id_identity", lambda: None)
+        """Returns None when no identity file or hardware ID exists."""
+        monkeypatch.setattr("homepot.agent.identity._platform_machine_id", lambda: None)
         assert get_device_id() is None
 
     def test_returns_id_from_file(self, tmp_identity_dir, monkeypatch):
         """Returns the device ID from an existing identity file."""
-        monkeypatch.setattr("homepot.agent.identity._machine_id_identity", lambda: None)
+        monkeypatch.setattr("homepot.agent.identity._platform_machine_id", lambda: None)
         id_file = tmp_identity_dir / "identity"
         id_file.write_text("device-existing\n", encoding="utf-8")
         assert get_device_id() == "device-existing"
 
     def test_returns_none_on_corrupted_file(self, tmp_identity_dir, monkeypatch):
         """Returns None when the identity file is empty."""
-        monkeypatch.setattr("homepot.agent.identity._machine_id_identity", lambda: None)
+        monkeypatch.setattr("homepot.agent.identity._platform_machine_id", lambda: None)
         id_file = tmp_identity_dir / "identity"
         id_file.write_text("", encoding="utf-8")
         assert get_device_id() is None
@@ -240,7 +359,7 @@ class TestEdgeCases:
     def test_identity_persistence_survives_object_recreation(self, tmp_identity_dir):
         """Identity persists across re-creation of the directory reference."""
         first = get_or_create_device_id()
-        with patch("homepot.agent.identity._VAR_LIB_PATH", tmp_identity_dir):
+        with patch("homepot.agent.identity._get_identity_dir", return_value=tmp_identity_dir):
             second = get_or_create_device_id()
         assert first == second
 
@@ -249,3 +368,34 @@ class TestEdgeCases:
         assert tmp_identity_dir.exists()
         result = identity_dir()
         assert result == tmp_identity_dir
+
+    def test_windows_machine_id_strips_whitespace(self):
+        """Windows machine ID handles leading/trailing whitespace in output."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "  abc-def-ghi  \n"
+        with patch("homepot.agent.identity.subprocess.run", return_value=mock_result):
+            result = _windows_machine_id_identity()
+            assert result is not None
+            assert result.startswith("device-")
+
+
+# ============================================================================
+# _is_windows helper
+# ============================================================================
+
+
+class TestIsWindows:
+    """Tests for the _is_windows platform detection helper."""
+
+    def test_returns_true_on_win32(self):
+        """_is_windows returns True when sys.platform is 'win32'."""
+        with patch("homepot.agent.identity.sys.platform", "win32"):
+            from homepot.agent.identity import _is_windows
+            assert _is_windows() is True
+
+    def test_returns_false_on_linux(self):
+        """_is_windows returns False when sys.platform is 'linux'."""
+        with patch("homepot.agent.identity.sys.platform", "linux"):
+            from homepot.agent.identity import _is_windows
+            assert _is_windows() is False

--- a/backend/tests/test_agent_identity.py
+++ b/backend/tests/test_agent_identity.py
@@ -240,9 +240,13 @@ class TestGetOrCreateDeviceId:
 
     def test_falls_back_to_hardware_id_when_dir_unwritable(self, monkeypatch):
         """When the identity directory cannot be written, falls back to hardware ID."""
+        mock_path = MagicMock(spec=Path)
+        mock_path.exists.return_value = False
+        mock_path.parent = MagicMock()
+        mock_path.parent.mkdir.side_effect = PermissionError("No permission")
         monkeypatch.setattr(
             "homepot.agent.identity._identity_file_path",
-            lambda: Path("/nonexistent/homepot/identity"),
+            lambda: mock_path,
         )
         monkeypatch.setattr(
             "homepot.agent.identity._platform_machine_id",

--- a/docs/device-lifecycle-and-ownership.md
+++ b/docs/device-lifecycle-and-ownership.md
@@ -461,3 +461,40 @@ PR 23: Modernise legacy agent endpoint + push-log stub fill
 |---|---|
 | Update `GET /agents` and `GET /agents/{device_id}` to use `lifecycle_state`, `connectivity_state`, `health_state` instead of the deprecated `status` field | Dashboard consumes this for the agent list view |
 | *(Optional)* Populate the stubbed `GET /device/{device_id}/push-logs` with real data from the push notifications table | Dashboard shows notification delivery status |
+
+## Frontend
+
+These five PRs deliver the backend API surface a dashboard UI would
+consume.  A separate frontend PR builds the React components that call
+these endpoints.
+
+PR 24: frontend/src/services/api.js — 3 new API methods:
+- dashboard.summary() → GET /dashboard/summary
+- sites.getDashboard(siteId) → GET /sites/{sid}/dashboard
+- devices.getCredentials(deviceId) → GET /device/{id}/credentials
+- devices.getCommands(deviceId) → GET /device/{did}/commands
+frontend/src/pages/Dashboard.jsx — Fetches dashboard.summary() and renders 4 aggregate stat cards (Total Devices, Online, Offline, Active) above the monitored resources.
+
+## Windows adaptation
+Only after the Linux real-device contract works:
+- implement stable Windows device identity;
+- use Windows Credential Manager or DPAPI;
+- package as a signed Windows service/MSI;
+- implement HTTPS and proxy handling;
+- add WNS or the selected wake-up mechanism;
+- implement service recovery and upgrades;
+- test restricted users, reboot, firewall, proxy, sleep/resume, and credential revocation.
+The backend APIs and lifecycle rules should remain platform-neutral.
+
+## Windows adaptation PRs
+
+| PR  | Focus | Description |
+| --- | ----- | ----------- |
+| W1  | **Stable Windows device identity** | Generate/persist a stable identity (e.g. from `WMID`/`Get-CimInstance Win32_ComputerSystemProduct` + salt, or a generated UUID in `%PROGRAMDATA%\Homepot\identity`). Add `WindowsIdentityProvider` to the agent. |
+| W2  | **Windows credential storage** | Implement `WindowsCredManager` using `keyring` with Credential Manager backend, or direct DPAPI via `crypt32`. Replace the `SimulationStorage` fallback on Windows. |
+| W3  | **Windows agent bootstrap & enrolment** | Wire identity + credential storage into the agent's bootstrap flow on Windows. Test end-to-end enrolment from a Windows host. |
+| W4  | **Windows service packaging** | Package the agent as a Windows service (pywin32), create an MSI (WiX or similar), handle `SERVICE_AUTO_START`, service recovery policy (restart on failure). |
+| W5  | **Windows proxy & HTTPS** | Read system-proxy settings (IE/WinHTTP proxy), configure `httpx`/`requests` to respect them. Validate Windows certificate store for TLS. |
+| W6  | **Agent-side WNS push wake-up** | The backend WNS provider is done; add the agent-side push channel registration and wake-up handler so the agent does not have to poll constantly on Windows. |
+| W7  | **Windows service recovery & upgrades** | Log rotation (Windows EventLog or rolling file), graceful shutdown via `SERVICE_CONTROL_PRESHUTDOWN`, atomic in-place upgrade strategy for MSI. |
+| W8  | **Windows resilience tests** | CI tests on `windows-latest` covering: restricted users, reboot resilience, firewall blocks, proxy misconfiguration, sleep/resume, credential revocation, duplicate enrolment. |


### PR DESCRIPTION
## Summary

Make the device identity module platform-aware so the agent generates and persists a stable identity on Windows, matching the existing Linux behaviour.

### Changes

**`backend/src/homepot/agent/identity.py`**
- Windows identity file stored in `%PROGRAMDATA%\\Homepot\\identity` (all-users), falling back to `%APPDATA%\\Homepot\\identity` then tempdir
- Windows hardware-ID fallback via PowerShell `Get-CimInstance Win32_ComputerSystemProduct.UUID`, hashed with salt — same `device-<hash>` format as Linux `/etc/machine-id` fallback
- Linux behaviour completely unchanged
- `chmod(0o644)` skipped on Windows (no-op)
- New internal helpers: `_is_windows()`, `_windows_machine_id_identity()`, `_platform_machine_id()`
- Public API unchanged — zero breakage

**`backend/tests/test_agent_identity.py`**
- Refactored `tmp_identity_dir` fixture to mock `_get_identity_dir` directly (cross-platform)
- 6 new tests for `_windows_machine_id_identity()`: non-zero exit, empty output, timeout, file-not-found, deterministic output, whitespace stripping
- `TestPlatformMachineId` dispatcher tests
- `TestIsWindows` platform detection tests
- Integration test for chmod skip on Windows and hardware-ID fallback

**`docs/device-lifecycle-and-ownership.md`**
- Appended Windows adaptation PR plan (W1–W8)

### PR checklist

- [x] All 38 identity tests pass (97 total including credential storage)