### PR TITLE
feat: Windows proxy & HTTPS configuration

### DIFF
--- a/backend/src/homepot/agent/real_device_agent.py
+++ b/backend/src/homepot/agent/real_device_agent.py
@@ -36,6 +36,7 @@ from homepot.agent.utils.log_setup import (
     configure_agent_logging,
     logging_config_from_config,
 )
+from homepot.agent.utils.proxy_settings import build_httpx_proxy_kwargs
 from homepot.agent.utils.push_listener import create_push_listener
 from homepot.agent.utils.real_device_discovery import get_connected_peripherals
 from homepot.agent.utils.retry_queue import RetryQueue
@@ -538,6 +539,17 @@ def _build_tls_config(cred: CredentialStorage) -> Dict[str, Any]:
     return tls_kw
 
 
+def _build_client_config(cred: CredentialStorage) -> Dict[str, Any]:
+    """Build an httpx-compatible client config combining TLS and proxy.
+
+    Returns a dict that can be unpacked into ``httpx.AsyncClient(...)``.
+    """
+    config: Dict[str, Any] = _build_tls_config(cred)
+    proxy_kw = build_httpx_proxy_kwargs()
+    config.update(proxy_kw)
+    return config
+
+
 async def bootstrap_agent(
     backend_url: str,
     intent_id: str,
@@ -596,7 +608,7 @@ async def bootstrap_agent(
 
     claim_url = f"{backend_url.rstrip('/')}/api/v1/enrolment-intents/{intent_id}/claim"
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(**build_httpx_proxy_kwargs()) as client:
         response = await client.post(claim_url, json=claim_payload, timeout=30.0)
         response.raise_for_status()
         result = await response.json()
@@ -620,10 +632,10 @@ async def bootstrap_agent(
     logger.info("Device provisioned: %s (site: %s)", device_id, site_id)
 
     config = load_agent_config()
-    tls_kw = _build_tls_config(cred)
+    client_kw = _build_client_config(cred)
 
     try:
-        async with httpx.AsyncClient(**tls_kw) as client:
+        async with httpx.AsyncClient(**client_kw) as client:
             payload: Dict[str, Any] = {
                 "device_id": config["device_id"],
                 "site_id": config["site_id"],
@@ -673,7 +685,7 @@ async def run_agent(
     push_listener = create_push_listener(config)
     await push_listener.start()
 
-    tls_kw = _build_tls_config(cred)
+    client_kw = _build_client_config(cred)
 
     if shutdown_event is None:
         shutdown_event = asyncio.Event()
@@ -711,7 +723,7 @@ async def run_agent(
         for t in tasks:
             t.cancel()
 
-    async with httpx.AsyncClient(**tls_kw) as client:
+    async with httpx.AsyncClient(**client_kw) as client:
         await send_registration(client, config, retry_queue)
 
         tasks = [

--- a/backend/src/homepot/agent/utils/proxy_settings.py
+++ b/backend/src/homepot/agent/utils/proxy_settings.py
@@ -1,0 +1,187 @@
+r"""Platform-aware proxy configuration for the HOMEPOT agent.
+
+Reads system proxy settings and returns a configuration suitable for
+``httpx.AsyncClient(proxy=...)``.
+
+**Cross-platform (env vars):**
+    Respects ``HTTP_PROXY``, ``HTTPS_PROXY``, ``NO_PROXY`` environment
+    variables on all platforms.
+
+**Windows IE proxy:**
+    Reads Internet Explorer / system proxy settings from the Windows
+    registry (``HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings``).
+    This is the same source that ``WinHttpGetIEProxyConfigForCurrentUser``
+    and most Windows applications use.
+
+**Linux/macOS:**
+    Only environment variables are consulted.  Desktop environments
+    (GNOME, KDE) may set ``HTTP_PROXY``/``HTTPS_PROXY`` automatically.
+"""
+
+import logging
+import os
+import sys
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Environment-variable lookup (all platforms)
+# ---------------------------------------------------------------------------
+
+
+def _env_proxy() -> Dict[str, Optional[str]]:
+    """Read proxy settings from environment variables.
+
+    Returns
+    -------
+    dict with keys ``http``, ``https``, ``no_proxy``.
+    Values are ``None`` when the respective variable is not set.
+    """
+    return {
+        "http": os.environ.get("HTTP_PROXY") or os.environ.get("http_proxy"),
+        "https": os.environ.get("HTTPS_PROXY") or os.environ.get("https_proxy"),
+        "no_proxy": os.environ.get("NO_PROXY") or os.environ.get("no_proxy"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Windows IE/System proxy (registry)
+# ---------------------------------------------------------------------------
+
+
+def _windows_ie_proxy() -> Dict[str, Optional[str]]:
+    r"""Read Internet Explorer / system proxy from the Windows registry.
+
+    Reads ``HKCU\Software\Microsoft\Windows\CurrentVersion\Internet
+    Settings``.
+
+    Returns
+    -------
+    dict with keys ``http``, ``https``, ``no_proxy``.
+    All values are ``None`` if the registry key does not exist or
+    proxy is disabled.
+    """
+    result: Dict[str, Optional[str]] = {
+        "http": None,
+        "https": None,
+        "no_proxy": None,
+    }
+
+    winreg: Any
+    try:
+        import winreg as winreg  # type: ignore[import-untyped]
+    except ModuleNotFoundError:
+        logger.debug("winreg not available (not Windows)")
+        return result
+
+    key_path = r"Software\Microsoft\Windows\CurrentVersion\Internet Settings"
+    try:
+        with winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER, key_path, 0, winreg.KEY_READ
+        ) as key:
+            proxy_enable, _ = winreg.QueryValueEx(key, "ProxyEnable")
+            if not proxy_enable:
+                return result
+
+            proxy_server, _ = winreg.QueryValueEx(key, "ProxyServer")
+            if not proxy_server:
+                return result
+
+            proxy_override, _ = winreg.QueryValueEx(key, "ProxyOverride")
+            if proxy_override:
+                result["no_proxy"] = proxy_override
+
+            proxy_server = proxy_server.strip()
+
+            if "=" not in proxy_server and ";" not in proxy_server:
+                result["http"] = proxy_server
+                result["https"] = proxy_server
+            else:
+                parts = proxy_server.replace(";", " ").split()
+                for part in parts:
+                    if "=" in part:
+                        protocol, server = part.split("=", 1)
+                        protocol = protocol.strip().lower()
+                        server = server.strip()
+                        if protocol == "http":
+                            result["http"] = server
+                        elif protocol == "https":
+                            result["https"] = server
+                        elif protocol == "socks":
+                            result["http"] = server
+                            result["https"] = server
+    except (OSError, FileNotFoundError) as exc:
+        logger.debug("Failed to read Windows IE proxy: %s", exc)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def get_proxy_settings() -> Dict[str, Optional[str]]:
+    """Return the best available proxy configuration for the current platform.
+
+    Priority:
+    1. Environment variables ``HTTP_PROXY`` / ``HTTPS_PROXY`` / ``NO_PROXY``.
+    2. Windows IE / system proxy (registry on Windows only).
+
+    Returns
+    -------
+    dict with keys ``http``, ``https``, ``no_proxy``.
+    """
+    settings = _env_proxy()
+
+    if any(settings.values()):
+        logger.debug(
+            "Using proxy from environment: http=%s https=%s",
+            settings["http"],
+            settings["https"],
+        )
+        return settings
+
+    if sys.platform == "win32":
+        ie_settings = _windows_ie_proxy()
+        if any(ie_settings.values()):
+            logger.debug(
+                "Using proxy from Windows IE settings: http=%s https=%s",
+                ie_settings["http"],
+                ie_settings["https"],
+            )
+            return ie_settings
+
+    return settings
+
+
+def build_httpx_proxy_kwargs(
+    settings: Optional[Dict[str, Optional[str]]] = None,
+) -> Dict[str, Any]:
+    """Build ``**kwargs`` for ``httpx.AsyncClient`` from proxy settings.
+
+    Parameters
+    ----------
+    settings:
+        Proxy settings dict as returned by ``get_proxy_settings()``.
+        If ``None``, settings are auto-detected.
+
+    Returns
+    -------
+    A dict suitable for ``httpx.AsyncClient(**build_httpx_proxy_kwargs())``.
+    If no proxy is configured, returns an empty dict.
+    """
+    if settings is None:
+        settings = get_proxy_settings()
+
+    https_proxy = settings.get("https")
+    if https_proxy:
+        return {"proxy": https_proxy}
+
+    http_proxy = settings.get("http")
+    if http_proxy:
+        return {"proxy": http_proxy}
+
+    return {}


### PR DESCRIPTION
## Summary

Adds Windows-aware proxy detection and integrates it with the agent's HTTP client configuration.

### Changes

- **New** `backend/src/homepot/agent/utils/proxy_settings.py`: Platform-aware proxy reader
  - Environment variables (`HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`)
  - Windows IE / system proxy via registry (`HKCU\\...\\Internet Settings`) 
  - `build_httpx_proxy_kwargs()` returns dict that can be unpacked into `httpx.AsyncClient(**...)`
- **Updated** `backend/src/homepot/agent/real_device_agent.py`:
  - New `_build_client_config()` merges TLS config + proxy kwargs
  - Claim endpoint client uses proxy (no TLS before credentials)
  - `bootstrap_agent()` and `run_agent()` use `_build_client_config` instead of `_build_tls_config`

### Testing

- `tests/test_agent_bootstrap.py`: 5 passed
- mypy, flake8, isort, black: all clean