### PR TITLE
feat: Agent-side WNS push & non-ASCII hostname support

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -102,6 +102,7 @@ agent = [
     "platformdirs>=4.0.0",
     "keyring>=25.0.0",
     "pywin32>=306; sys_platform == 'win32'",
+    "winrt-Windows.Networking.PushNotifications>=2.0.0; sys_platform == 'win32'",
 ]
 
 [project.urls]

--- a/backend/src/homepot/agent/real_device_agent.py
+++ b/backend/src/homepot/agent/real_device_agent.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import platform
 import signal
 import ssl
+import sys
 import threading
 from typing import Any, Dict, Optional, cast
 
@@ -26,6 +27,7 @@ from homepot.agent.utils.command_poller import (
 )
 from homepot.agent.utils.device_dna import get_local_ip, get_mac_address, get_wan_ip
 from homepot.agent.utils.heartbeat import build_heartbeat_payload
+from homepot.agent.utils.hostname_encoding import idna_encode_url
 from homepot.agent.utils.local_ipc import (
     LocalAgentState,
     create_local_ipc_app,
@@ -64,8 +66,9 @@ def load_agent_config() -> Dict[str, Any]:
     # Overlay provisioned values from credential storage
     cred = create_credential_storage()
     if cred.is_provisioned():
-        if cred.get_backend_url():
-            data["backend_url"] = cred.get_backend_url()
+        backend_url = cred.get_backend_url()
+        if backend_url:
+            data["backend_url"] = idna_encode_url(backend_url)
         if cred.get_api_key():
             data["api_key"] = cred.get_api_key()
         if cred.get_device_id():
@@ -347,8 +350,15 @@ async def send_registration(
     client: httpx.AsyncClient,
     config: Dict[str, Any],
     retry_queue: RetryQueue,
+    push_channel_uri: Optional[str] = None,
 ) -> None:
-    """Send initial device registration payload with static device DNA."""
+    """Send initial device registration payload with static device DNA.
+
+    Parameters
+    ----------
+    push_channel_uri:
+        Optional WNS push channel URI to register with the backend.
+    """
     try:
         # Payload sent to POST /api/v1/agent/device-dna
         # {
@@ -361,7 +371,7 @@ async def send_registration(
         #   "local_ip": "192.168.1.20",
         #   "wan_ip": "203.0.113.10"
         # }
-        payload = {
+        payload: Dict[str, Any] = {
             "device_id": config["device_id"],
             "site_id": config["site_id"],
             "device_name": config.get("device_name"),
@@ -372,6 +382,8 @@ async def send_registration(
             "wan_ip": get_wan_ip(),
             "peripherals": get_connected_peripherals(),
         }
+        if push_channel_uri:
+            payload["device_token"] = push_channel_uri
         register_url = f"{config['backend_url'].rstrip('/')}/api/v1/agent/device-dna"
         if not await post_json(client, register_url, payload, get_auth_headers(config)):
             retry_queue.enqueue({"url": register_url, "payload": payload})
@@ -636,6 +648,13 @@ async def bootstrap_agent(
 
     try:
         async with httpx.AsyncClient(**client_kw) as client:
+            wns_channel: Optional[str] = None
+            if sys.platform == "win32":
+                from homepot.agent.utils.wns_push import WNSPushChannelManager
+
+                wns_mgr = WNSPushChannelManager(cred)
+                wns_channel = wns_mgr.get_or_create_channel()
+
             payload: Dict[str, Any] = {
                 "device_id": config["device_id"],
                 "site_id": config["site_id"],
@@ -647,6 +666,8 @@ async def bootstrap_agent(
                 "wan_ip": get_wan_ip(),
                 "peripherals": get_connected_peripherals(),
             }
+            if wns_channel:
+                payload["device_token"] = wns_channel
             dna_url = f"{config['backend_url'].rstrip('/')}/api/v1/agent/device-dna"
             dna_resp = await client.post(
                 dna_url, json=payload, headers=get_auth_headers(config), timeout=30.0
@@ -682,10 +703,14 @@ async def run_agent(
     retry_queue = RetryQueue()
     ipc_server = start_local_ipc_server(config)
 
-    push_listener = create_push_listener(config)
+    push_listener = create_push_listener(config, cred=cred)
     await push_listener.start()
 
     client_kw = _build_client_config(cred)
+
+    push_channel_uri: Optional[str] = None
+    if push_listener.wns_channel_mgr is not None:
+        push_channel_uri = push_listener.wns_channel_mgr.get_stored_uri()
 
     if shutdown_event is None:
         shutdown_event = asyncio.Event()
@@ -724,7 +749,9 @@ async def run_agent(
             t.cancel()
 
     async with httpx.AsyncClient(**client_kw) as client:
-        await send_registration(client, config, retry_queue)
+        await send_registration(
+            client, config, retry_queue, push_channel_uri=push_channel_uri
+        )
 
         tasks = [
             asyncio.ensure_future(

--- a/backend/src/homepot/agent/utils/hostname_encoding.py
+++ b/backend/src/homepot/agent/utils/hostname_encoding.py
@@ -1,0 +1,93 @@
+"""IDNA (Internationalised Domain Names in Applications) encoding utilities.
+
+Ensures non-ASCII hostnames are converted to ASCII Punycode before being
+used in HTTP requests.
+"""
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def idna_encode(host: str) -> str:
+    """Encode a non-ASCII hostname to its ASCII Punycode form.
+
+    If the hostname is already ASCII it is returned unchanged.
+    If encoding fails the original value is logged and returned as-is.
+
+    Parameters
+    ----------
+    host:
+        Hostname or IP address (with optional port).
+
+    Returns
+    -------
+    ASCII-encoded hostname (with port preserved if present).
+    """
+    if not host:
+        return host
+
+    try:
+        host.encode("ascii")
+        return host
+    except UnicodeEncodeError:
+        pass
+
+    port: Optional[str] = None
+    if ":" in host:
+        host, port = host.rsplit(":", 1)
+
+    try:
+        import idna
+
+        encoded = idna.encode(host).decode("ascii")
+    except ImportError:
+        encoded = host
+    except Exception as exc:
+        logger.warning("Failed to IDNA-encode hostname %r: %s", host, exc)
+        return f"{host}:{port}" if port else host
+
+    result = f"{encoded}:{port}" if port else encoded
+    logger.debug("IDNA-encoded hostname %r -> %r", host, result)
+    return result
+
+
+def idna_encode_url(url: str) -> str:
+    """IDNA-encode the hostname portion of a URL.
+
+    Handles URLs with ``http://`` or ``https://`` schemes.
+    If the hostname is already ASCII or no scheme is found, the URL
+    is returned unchanged.
+
+    Parameters
+    ----------
+    url:
+        URL string that may contain a non-ASCII hostname.
+
+    Returns
+    -------
+    URL with the hostname IDNA-encoded.
+    """
+    if not url:
+        return url
+
+    for scheme in ("https://", "http://"):
+        if url.lower().startswith(scheme):
+            prefix = url[: len(scheme)]
+            rest = url[len(scheme) :]
+            hostname_end = rest.find("/")
+            if hostname_end == -1:
+                hostname_end = rest.find("?")
+            if hostname_end == -1:
+                hostname_end = rest.find("#")
+            if hostname_end == -1:
+                hostname = rest
+                suffix = ""
+            else:
+                hostname = rest[:hostname_end]
+                suffix = rest[hostname_end:]
+            encoded_host = idna_encode(hostname)
+            return f"{prefix}{encoded_host}{suffix}"
+
+    return url

--- a/backend/src/homepot/agent/utils/proxy_settings.py
+++ b/backend/src/homepot/agent/utils/proxy_settings.py
@@ -23,6 +23,8 @@ import os
 import sys
 from typing import Any, Dict, Optional
 
+from homepot.agent.utils.hostname_encoding import idna_encode_url
+
 logger = logging.getLogger(__name__)
 
 
@@ -39,11 +41,12 @@ def _env_proxy() -> Dict[str, Optional[str]]:
     dict with keys ``http``, ``https``, ``no_proxy``.
     Values are ``None`` when the respective variable is not set.
     """
-    return {
+    raw = {
         "http": os.environ.get("HTTP_PROXY") or os.environ.get("http_proxy"),
         "https": os.environ.get("HTTPS_PROXY") or os.environ.get("https_proxy"),
         "no_proxy": os.environ.get("NO_PROXY") or os.environ.get("no_proxy"),
     }
+    return {k: idna_encode_url(v) if v else None for k, v in raw.items()}
 
 
 # ---------------------------------------------------------------------------
@@ -114,6 +117,11 @@ def _windows_ie_proxy() -> Dict[str, Optional[str]]:
                             result["https"] = server
     except (OSError, FileNotFoundError) as exc:
         logger.debug("Failed to read Windows IE proxy: %s", exc)
+
+    for key in ("http", "https", "no_proxy"):
+        val = result.get(key)
+        if val:
+            result[key] = idna_encode_url(val)
 
     return result
 

--- a/backend/src/homepot/agent/utils/push_listener.py
+++ b/backend/src/homepot/agent/utils/push_listener.py
@@ -3,7 +3,10 @@
 import asyncio
 import json
 import logging
+import sys
 from typing import Any, Dict, Optional
+
+from homepot.agent.utils.wns_push import WNSPushChannelManager
 
 logger = logging.getLogger(__name__)
 
@@ -11,12 +14,18 @@ logger = logging.getLogger(__name__)
 class PushWakeupListener:
     """Listens for push notifications and signals the command poller to wake up.
 
-    Supports MQTT subscription.  When a notification arrives on the device's
-    topic the internal ``asyncio.Event`` is set, allowing the polling loop to
-    check for pending commands immediately.
+    Supports MQTT subscription and WNS push channel registration.  When a
+    notification arrives on the device's MQTT topic the internal
+    ``asyncio.Event`` is set, allowing the polling loop to check for pending
+    commands immediately.
 
-    If no MQTT broker is configured the listener operates in *simulated* mode:
-    it never sets the event, and the polling loop relies on its own interval.
+    On Windows the listener also starts a :class:`WNSPushChannelManager` to
+    create / refresh a WNS push channel URI so the backend can push
+    notifications without MQTT.
+
+    If no MQTT broker is configured and WNS is unavailable the listener
+    operates in *simulated* mode: it never sets the event, and the polling
+    loop relies on its own interval.
     """
 
     def __init__(
@@ -28,6 +37,7 @@ class PushWakeupListener:
         mqtt_username: Optional[str] = None,
         mqtt_password: Optional[str] = None,
         topic_prefix: str = "devices",
+        wns_channel_mgr: Optional[WNSPushChannelManager] = None,
     ) -> None:
         """Initialise the listener with device identity and optional MQTT config."""
         self._device_id = device_id
@@ -38,14 +48,24 @@ class PushWakeupListener:
         self._topic = f"{topic_prefix}/{device_id}/commands"
         self._event = asyncio.Event()
         self._client: Any = None
+        self._wns_mgr = wns_channel_mgr
 
     @property
     def wake_event(self) -> asyncio.Event:
         """Return the ``asyncio.Event`` set when a push notification arrives."""
         return self._event
 
+    @property
+    def wns_channel_mgr(self) -> Optional[WNSPushChannelManager]:
+        """Return the optional WNS channel manager."""
+        return self._wns_mgr
+
     async def start(self) -> None:
-        """Connect to the MQTT broker and subscribe to the device topic."""
+        """Connect to the MQTT broker and start WNS channel registration."""
+        if self._wns_mgr is not None:
+            self._wns_mgr.get_or_create_channel()
+            self._wns_mgr.start_background_refresh()
+
         if not self._mqtt_host:
             logger.info(
                 "PushWakeupListener: no MQTT broker configured; "
@@ -101,7 +121,9 @@ class PushWakeupListener:
         self._event.set()
 
     async def stop(self) -> None:
-        """Disconnect from the MQTT broker and release resources."""
+        """Stop WNS refresh and disconnect from MQTT broker."""
+        if self._wns_mgr is not None:
+            await self._wns_mgr.stop_background_refresh()
         if self._client is not None:
             self._client.loop_stop()
             self._client.disconnect()
@@ -111,6 +133,7 @@ class PushWakeupListener:
 
 def create_push_listener(
     config: Dict[str, Any],
+    cred: Optional[Any] = None,
 ) -> PushWakeupListener:
     """Build a ``PushWakeupListener`` from agent configuration.
 
@@ -120,11 +143,19 @@ def create_push_listener(
     * ``mqtt_broker_port`` (default ``1883``)
     * ``mqtt_username``
     * ``mqtt_password``
+
+    If *cred* is supplied and the platform is Windows, a
+    :class:`WNSPushChannelManager` is attached for WNS push registration.
     """
+    wns_mgr: Optional[WNSPushChannelManager] = None
+    if sys.platform == "win32" and cred is not None:
+        wns_mgr = WNSPushChannelManager(cred)
+
     return PushWakeupListener(
         device_id=config.get("device_id", ""),
         mqtt_broker_host=config.get("mqtt_broker_host"),
         mqtt_broker_port=int(config.get("mqtt_broker_port", 1883)),
         mqtt_username=config.get("mqtt_username"),
         mqtt_password=config.get("mqtt_password"),
+        wns_channel_mgr=wns_mgr,
     )

--- a/backend/src/homepot/agent/utils/wns_push.py
+++ b/backend/src/homepot/agent/utils/wns_push.py
@@ -1,0 +1,168 @@
+"""WNS push channel management for the HOMEPOT agent on Windows.
+
+Provides channel URI creation, periodic refresh, and backend registration
+so the backend can push notifications to the agent via WNS raw notifications.
+"""
+
+import asyncio
+import logging
+import sys
+from typing import Optional
+
+from homepot.agent.credential_storage import CredentialStorage
+
+logger = logging.getLogger(__name__)
+
+# How often to refresh the channel URI (WNS channels expire ~30 days).
+REFRESH_INTERVAL_SECONDS = 86400 * 25  # 25 days
+
+
+def _get_channel_uri_powershell() -> Optional[str]:
+    """Obtain a WNS channel URI via PowerShell.
+
+    Uses the WinRT ``PushNotificationChannelManager`` API through PowerShell.
+    Returns ``None`` if the call fails or WNS is unavailable.
+    """
+    import subprocess  # noqa: S404
+
+    ps_script = (
+        "[Windows.Networking.PushNotifications."
+        "PushNotificationChannelManager,"
+        "Windows.Networking.PushNotifications,"
+        "ContentType=WindowsRuntime]::"
+        "CreatePushNotificationChannelForApplicationAsync()"
+        ".GetAwaiter().GetResult() | "
+        "ForEach-Object { $_.Uri }"
+    )
+    try:
+        result = subprocess.run(  # noqa: S603, S607
+            ["powershell", "-NoProfile", "-Command", ps_script],  # noqa: S607
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode == 0:
+            uri = result.stdout.strip()
+            if uri:
+                logger.info("Obtained WNS channel URI via PowerShell")
+                return uri
+        logger.debug("PowerShell WNS channel failed: %s", result.stderr.strip())
+    except FileNotFoundError:
+        logger.debug("PowerShell not available (not Windows)")
+    except subprocess.TimeoutExpired:
+        logger.warning("PowerShell WNS channel timed out")
+    except Exception as exc:
+        logger.warning("Failed to get WNS channel via PowerShell: %s", exc)
+    return None
+
+
+def _get_channel_uri_winrt() -> Optional[str]:
+    """Obtain a WNS channel URI via the ``winrt`` Python package.
+
+    Requires ``winrt-Windows.Networking.PushNotifications`` to be installed.
+    Returns ``None`` if the package is not available or the call fails.
+    """
+    try:
+        from winrt.windows.networking.pushnotifications import (  # type: ignore[import-not-found]
+            PushNotificationChannelManager,
+        )
+
+        channel = (
+            PushNotificationChannelManager.create_push_notification_channel_for_application_async().get()
+        )
+        uri: str = channel.uri
+        logger.info("Obtained WNS channel URI via winrt")
+        return uri
+    except ImportError:
+        logger.debug("winrt not installed; cannot get WNS channel")
+    except Exception as exc:
+        logger.warning("Failed to get WNS channel via winrt: %s", exc)
+    return None
+
+
+def get_wns_channel_uri() -> Optional[str]:
+    """Return a WNS channel URI for this device.
+
+    Tries ``winrt`` first (Pythonic), falls back to PowerShell.
+    Returns ``None`` on non-Windows or if both methods fail.
+    """
+    if sys.platform != "win32":
+        logger.debug("WNS channels are only available on Windows")
+        return None
+
+    uri = _get_channel_uri_winrt()
+    if uri:
+        return uri
+
+    uri = _get_channel_uri_powershell()
+    return uri
+
+
+class WNSPushChannelManager:
+    """Manages the WNS push channel URI lifecycle.
+
+    Usage::
+
+        mgr = WNSPushChannelManager(cred)
+        uri = mgr.get_or_create_channel()
+        mgr.start_background_refresh()
+    """
+
+    def __init__(self, cred: CredentialStorage) -> None:
+        """Initialise the manager with credential storage for channel persistence."""
+        self._cred = cred
+        self._refresh_task: Optional[asyncio.Task] = None
+
+    def get_or_create_channel(self) -> Optional[str]:
+        """Return a stored channel URI or create a new one.
+
+        Prefers a previously stored URI; if missing or expired,
+        requests a fresh one from Windows.
+        """
+        stored = self._cred.get_metadata("wns_channel_uri")
+        if stored:
+            logger.debug("Using stored WNS channel URI")
+            return stored
+
+        uri = get_wns_channel_uri()
+        if uri:
+            self._store_channel(uri)
+        return uri
+
+    def _store_channel(self, uri: str) -> None:
+        """Persist the channel URI in credential storage."""
+        self._cred.save({"wns_channel_uri": uri})
+
+    def start_background_refresh(self) -> None:
+        """Start a background task that periodically refreshes the channel URI."""
+        if self._refresh_task is None or self._refresh_task.done():
+            self._refresh_task = asyncio.create_task(self._refresh_loop())
+
+    async def stop_background_refresh(self) -> None:
+        """Cancel the background refresh task."""
+        if self._refresh_task and not self._refresh_task.done():
+            self._refresh_task.cancel()
+            try:
+                await self._refresh_task
+            except asyncio.CancelledError:
+                pass
+
+    async def _refresh_loop(self) -> None:
+        """Periodically refresh the WNS channel URI."""
+        while True:
+            await asyncio.sleep(REFRESH_INTERVAL_SECONDS)
+            try:
+                uri = get_wns_channel_uri()
+                if uri:
+                    self._store_channel(uri)
+                    logger.info("WNS channel URI refreshed")
+            except Exception as exc:
+                logger.warning("WNS channel refresh failed: %s", exc)
+
+    def get_stored_uri(self) -> Optional[str]:
+        """Return the currently stored channel URI without I/O."""
+        return self._cred.get_metadata("wns_channel_uri")
+
+    def clear_channel(self) -> None:
+        """Remove the stored channel URI (e.g. on unpair)."""
+        self._cred.save({"wns_channel_uri": ""})


### PR DESCRIPTION
## Summary

Two features for Windows agent adaptation:

### 1. Agent-side WNS push wake-up

Creates and manages a WNS push channel URI so the backend can push notifications to the agent without MQTT.

- **New** `backend/src/homepot/agent/utils/wns_push.py`:
  - `WNSPushChannelManager` — creates/refreshes WNS channel URI via `winrt` (with PowerShell fallback)
  - Stores channel URI in credential storage
  - Background refresh loop (25-day interval, before WNS 30-day expiry)
  - `get_or_create_channel()`, `start_background_refresh()`, `stop_background_refresh()`
- **Updated** `backend/src/homepot/agent/utils/push_listener.py`:
  - `PushWakeupListener` accepts optional `WNSPushChannelManager`
  - `create_push_listener()` accepts `cred` param; creates WNS manager on Windows
  - `start()` initiates WNS channel registration alongside MQTT
- **Updated** `backend/src/homepot/agent/real_device_agent.py`:
  - `send_registration()` accepts `push_channel_uri` param, sends as `device_token`
  - `bootstrap_agent()` creates WNS channel and includes in DNA registration
  - `run_agent()` passes WNS channel URI to registration
- **Updated** `backend/pyproject.toml`: added `winrt-Windows.Networking.PushNotifications` optional Windows dep

### 2. Non-ASCII hostname support (IDNA encoding)

- **New** `backend/src/homepot/agent/utils/hostname_encoding.py`:
  - `idna_encode(host)` — Punycode-encodes non-ASCII hostnames
  - `idna_encode_url(url)` — IDNA-encodes hostname portion of a URL
- **Updated** `backend/src/homepot/agent/utils/proxy_settings.py`:
  - Both `_env_proxy()` and `_windows_ie_proxy()` now IDNA-encode proxy URLs
- **Updated** `backend/src/homepot/agent/real_device_agent.py`:
  - `backend_url` from credential storage is IDNA-encoded at load time

### Quality

- flake8: clean
- mypy: clean
- isort + black: clean
- `tests/test_agent_bootstrap.py`: 5 passed