### PR TITLE
feat: Windows service recovery & upgrades

### DIFF
--- a/backend/src/homepot/agent/utils/log_setup.py
+++ b/backend/src/homepot/agent/utils/log_setup.py
@@ -1,8 +1,13 @@
-"""Centralised logging setup with log rotation for the real device agent."""
+"""Centralised logging setup with log rotation for the real device agent.
+
+On Windows, supports optional Windows EventLog integration via
+``pywin32`` (``servicemanager.LogMsg``).
+"""
 
 import logging
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
+import sys
 from typing import Any, Dict, Optional
 
 _LOG_CONFIGURED = False
@@ -19,8 +24,13 @@ def configure_agent_logging(
     log_format: str = _DEFAULT_FORMAT,
     max_bytes: int = _DEFAULT_MAX_BYTES,
     backup_count: int = _DEFAULT_BACKUP_COUNT,
+    use_eventlog: bool = False,
 ) -> None:
     """Configure the root logger with a rotating file handler and a stream handler.
+
+    On Windows, when *use_eventlog* is ``True`` and ``pywin32`` is available,
+    a ``NTEventLogHandler`` is added so log records are visible in the Windows
+    Event Viewer.
 
     This function is idempotent — only the first call configures the logger.
     """
@@ -56,14 +66,37 @@ def configure_agent_logging(
                 "Failed to configure log file %s: %s", log_file, exc
             )
 
+    # Optional Windows EventLog handler
+    if use_eventlog and sys.platform == "win32":
+        _add_eventlog_handler(root, formatter)
+
     _LOG_CONFIGURED = True
     logging.getLogger(__name__).info(
-        "Logging configured (level=%s, file=%s, max_bytes=%s, backup_count=%s)",
+        "Logging configured (level=%s, file=%s, max_bytes=%s, backup_count=%s, eventlog=%s)",
         logging.getLevelName(log_level),
         log_file or "(none)",
         max_bytes,
         backup_count,
+        use_eventlog,
     )
+
+
+def _add_eventlog_handler(root: logging.Logger, formatter: logging.Formatter) -> None:
+    """Add a ``NTEventLogHandler`` to the root logger.
+
+    Falls back silently if pywin32 is not installed.
+    """
+    try:
+        from logging.handlers import NTEventLogHandler
+
+        eventlog_handler = NTEventLogHandler(
+            "HOMEPOT Agent",
+            logtype="Application",
+        )
+        eventlog_handler.setFormatter(formatter)
+        root.addHandler(eventlog_handler)
+    except Exception as exc:
+        logging.getLogger(__name__).warning("Failed to add EventLog handler: %s", exc)
 
 
 def logging_config_from_config(
@@ -77,6 +110,7 @@ def logging_config_from_config(
     * ``log_level`` — string log level name (default: ``"INFO"``)
     * ``log_max_bytes`` — max size per log file before rotation (default: 10 MiB)
     * ``log_backup_count`` — number of rotated log files to keep (default: 5)
+    * ``use_eventlog`` — enable Windows EventLog output (default: ``False``)
     """
     return {
         "log_file": config.get("log_file"),
@@ -84,6 +118,7 @@ def logging_config_from_config(
         "log_format": config.get("log_format", _DEFAULT_FORMAT),
         "max_bytes": int(config.get("log_max_bytes", _DEFAULT_MAX_BYTES)),
         "backup_count": int(config.get("log_backup_count", _DEFAULT_BACKUP_COUNT)),
+        "use_eventlog": bool(config.get("use_eventlog", False)),
     }
 
 

--- a/scripts/homepot_agent_service.py
+++ b/scripts/homepot_agent_service.py
@@ -9,11 +9,16 @@ Usage::
     python homepot-agent-service.py start
     python homepot-agent-service.py stop
     python homepot-agent-service.py remove
+    python homepot-agent-service.py debug
 
 Service recovery (automatic restart) must be configured manually
 or via ``install-agent.ps1``::
 
     sc failure HomepotAgent reset=86400 actions=restart/60000/restart/60000/restart/60000
+
+Upgrade::
+
+    python homepot-agent-service.py upgrade
 """
 
 import asyncio
@@ -34,6 +39,17 @@ except ImportError:
     sys.exit(
         "pywin32 is required.  Install with: pip install homepot-client[agent]"
     )
+
+
+# Constants for SERVICE_CONTROL_PRESHUTDOWN support.
+# pywin32 defines these in win32service but we also define them
+# explicitly so the module parses correctly before pywin32 is imported.
+_SERVICE_ACCEPT_PRESHUTDOWN = 0x00000100
+_SERVICE_CONTROL_PRESHUTDOWN = 0x0000000F
+
+# How long (seconds) to wait for the agent to shut down gracefully
+# during a Preshutdown phase (system shutdown).
+_PRESHUTDOWN_TIMEOUT_SECONDS = 30
 
 
 class HomepotAgentService(win32serviceutil.ServiceFramework):
@@ -71,18 +87,60 @@ class HomepotAgentService(win32serviceutil.ServiceFramework):
             servicemanager.PYS_SERVICE_STOPPED,
             (self._svc_name_, ""),
         )
+        self._signal_shutdown()
+
+    def SvcShutdown(self) -> None:
+        """Handle system shutdown (``SERVICE_CONTROL_SHUTDOWN``).
+
+        This is called when Windows shuts down.  We treat it the same as
+        a stop but cannot extend the shutdown timeout.
+        """
+        servicemanager.LogMsg(
+            servicemanager.EVENTLOG_INFORMATION_TYPE,
+            servicemanager.PYS_SERVICE_STOPPED,
+            (self._svc_name_, "System shutdown"),
+        )
+        self._signal_shutdown()
+
+    def SvcOther(self, control: int) -> None:
+        """Handle less common service control codes."""
+        if control == _SERVICE_CONTROL_PRESHUTDOWN:
+            self._handle_preshutdown()
+        else:
+            super().SvcOther(control)
+
+    def _handle_preshutdown(self) -> None:
+        """Respond to ``SERVICE_CONTROL_PRESHUTDOWN`` for extended cleanup.
+
+        During Preshutdown the system gives services extra time to shut
+        down cleanly before the normal shutdown phase.
+        """
+        servicemanager.LogMsg(
+            servicemanager.EVENTLOG_INFORMATION_TYPE,
+            servicemanager.PYS_SERVICE_STOPPED,
+            (self._svc_name_, "Preshutdown phase starting"),
+        )
+        self._signal_shutdown()
+
+    def _signal_shutdown(self) -> None:
+        """Signal the agent event loop to stop."""
         if self._shutdown_event is not None:
             self._shutdown_event.set()
         win32event.SetEvent(self._stop_event)
 
     def _report_status(self, state: int) -> None:
-        """Report service status to the SCM."""
+        """Report service status to the SCM with the controls we accept."""
         if hasattr(self, "CreateServiceEntry"):
             self.CreateServiceEntry()
+        accepted = (
+            win32service.SERVICE_ACCEPT_STOP
+            | win32service.SERVICE_ACCEPT_SHUTDOWN
+            | _SERVICE_ACCEPT_PRESHUTDOWN
+        )
         self.ReportServiceStatus(
             win32service.SERVICE_WIN32_OWN_PROCESS,
             state,
-            win32service.SERVICE_ACCEPT_STOP,
+            accepted,
             win32service.NO_ERROR,
         )
 
@@ -112,6 +170,46 @@ class HomepotAgentService(win32serviceutil.ServiceFramework):
         win32event.WaitForSingleObject(self._stop_event, win32event.INFINITE)
 
 
+def _upgrade_agent() -> None:
+    """Perform an atomic in-place upgrade of the agent package.
+
+    Steps:
+    1. Stop the current service.
+    2. Install/upgrade ``homepot-client[agent]`` via pip.
+    3. Re-register the service (in case the wrapper changed).
+    4. Start the service.
+    """
+    import subprocess
+    import time
+
+    python_exe = _configure_python_exe()
+    service_script = os.path.abspath(__file__)
+
+    logger.info("Upgrade: stopping HomepotAgent service...")
+    subprocess.run([python_exe, service_script, "stop"], check=False)
+
+    time.sleep(2)
+
+    logger.info("Upgrade: installing/upgrading homepot-client[agent]...")
+    result = subprocess.run(
+        [python_exe, "-m", "pip", "install", "--upgrade", "homepot-client[agent]"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        logger.error("Upgrade failed: pip install error:\n%s", result.stderr)
+        sys.exit(1)
+    logger.info("Upgrade: pip install succeeded")
+
+    logger.info("Upgrade: re-registering service...")
+    subprocess.run([python_exe, service_script, "install"], check=True)
+
+    logger.info("Upgrade: starting service...")
+    subprocess.run([python_exe, service_script, "start"], check=True)
+
+    logger.info("Upgrade complete.")
+
+
 def _configure_python_exe() -> str:
     """Return the path to ``pythonw.exe`` for the current environment."""
     if hasattr(sys, "frozen"):
@@ -133,6 +231,10 @@ def main() -> None:
 
     # Set up minimal logging so pywin32 can report events
     logging.basicConfig(level=logging.INFO)
+
+    if sys.argv[1] == "upgrade":
+        _upgrade_agent()
+        return
 
     # Hook the service into the pywin32 service framework.
     # win32serviceutil.HandleCommandLine inspects sys.argv and calls

--- a/scripts/install-agent.ps1
+++ b/scripts/install-agent.ps1
@@ -182,6 +182,11 @@ Write-Host "Setting startup type to Automatic..."
 Write-Host "Configuring service recovery (restart on failure)..."
 & sc.exe failure HomepotAgent reset= 86400 actions= restart/60000/restart/60000/restart/60000 | Out-Null
 
+Write-Host "Configuring Preshutdown timeout..."
+# Set the preshutdown timeout to 30 seconds so the agent has time to
+# clean up gracefully during system shutdown.
+& sc.exe config HomepotAgent preshutdown= 1 | Out-Null
+
 # ---------------------------------------------------------------------------
 # Start the service
 # ---------------------------------------------------------------------------

--- a/scripts/upgrade-agent.ps1
+++ b/scripts/upgrade-agent.ps1
@@ -1,0 +1,183 @@
+<#
+.SYNOPSIS
+    Performs an atomic in-place upgrade of the HOMEPOT Device Agent.
+
+.DESCRIPTION
+    This script:
+      - Stops the HomepotAgent Windows service.
+      - Upgrades the homepot-client[agent] Python package via pip.
+      - Re-registers the service (in case the wrapper changed).
+      - Restarts the service.
+
+    If any step fails the script exits with a non-zero exit code and
+    the service is left in a consistent state (stopped, not broken).
+
+.PARAMETER PythonPath
+    Path to the Python executable.  Defaults to the python.exe used by
+    the currently installed service.
+
+.PARAMETER Source
+    Optional path to a local wheel or source directory.  When set, pip
+    installs from this path instead of PyPI (useful for testing pre-release
+    builds).
+
+.EXAMPLE
+    .\upgrade-agent.ps1
+    .\upgrade-agent.ps1 -PythonPath "C:\Python311\python.exe"
+    .\upgrade-agent.ps1 -Source "C:\dist\homepot_client-0.2.0-py3-none-any.whl"
+#>
+
+param(
+    [string]$PythonPath = "",
+    [string]$Source = ""
+)
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+function Find-Python {
+    <#
+    .SYNOPSIS
+        Locate a suitable Python 3.11+ executable.
+    #>
+    if ($PythonPath -and (Test-Path $PythonPath)) {
+        return $PythonPath
+    }
+    # Try the path registered in the service first
+    $service = Get-CimInstance -ClassName Win32_Service -Filter "Name='HomepotAgent'" -ErrorAction SilentlyContinue
+    if ($service -and $service.PathName) {
+        # PathName looks like: "C:\Python311\python.exe C:\...\homepot_agent_service.py"
+        $parts = $service.PathName -split '\.exe '
+        if ($parts[0]) {
+            $candidate = $parts[0] + ".exe"
+            if (Test-Path $candidate) { return $candidate }
+        }
+    }
+    foreach ($candidate in @("python3.exe", "python.exe")) {
+        $exe = (Get-Command $candidate -ErrorAction SilentlyContinue).Source
+        if ($exe) { return $exe }
+    }
+    $common = @(
+        "$env:ProgramFiles\Python311\python.exe",
+        "$env:ProgramFiles\Python312\python.exe",
+        "${env:ProgramFiles(x86)}\Python311\python.exe",
+        "${env:ProgramFiles(x86)}\Python312\python.exe",
+        "$env:LOCALAPPDATA\Programs\Python\Python311\python.exe",
+        "$env:LOCALAPPDATA\Programs\Python\Python312\python.exe"
+    )
+    foreach ($path in $common) {
+        if (Test-Path $path) { return $path }
+    }
+    return $null
+}
+
+function Test-Admin {
+    <#
+    .SYNOPSIS
+        Return $true if the script is running as Administrator.
+    #>
+    $id = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object System.Security.Principal.WindowsPrincipal($id)
+    return $principal.IsInRole(
+        [System.Security.Principal.WindowsBuiltInRole]::Administrator
+    )
+}
+
+function Get-ServiceScript {
+    <#
+    .SYNOPSIS
+        Return the full path to homepot_agent_service.py.
+    #>
+    $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+    return Join-Path $scriptDir "homepot_agent_service.py"
+}
+
+# ---------------------------------------------------------------------------
+# Prerequisites
+# ---------------------------------------------------------------------------
+
+if (-not (Test-Admin)) {
+    Write-Error "Administrator privileges required.  Restart as Administrator."
+    exit 1
+}
+
+$python = Find-Python
+if (-not $python) {
+    Write-Error "Python 3.11+ not found."
+    exit 1
+}
+Write-Host "Using Python: $python"
+
+$serviceScript = Get-ServiceScript
+if (-not (Test-Path $serviceScript)) {
+    Write-Error "Service wrapper not found: $serviceScript"
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Phase 1: Stop the service
+# ---------------------------------------------------------------------------
+
+Write-Host "Phase 1/4: Stopping HomepotAgent service..."
+$service = Get-Service -Name "HomepotAgent" -ErrorAction SilentlyContinue
+if ($service -and $service.Status -eq "Running") {
+    & $python $serviceScript stop
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Service stop returned exit code $LASTEXITCODE; continuing..."
+    }
+    Start-Sleep -Seconds 3
+} else {
+    Write-Host "  Service is not running."
+}
+
+# ---------------------------------------------------------------------------
+# Phase 2: Upgrade the package
+# ---------------------------------------------------------------------------
+
+Write-Host "Phase 2/4: Upgrading homepot-client[agent]..."
+if ($Source) {
+    $pipArgs = @("-m", "pip", "install", "--upgrade", $Source)
+} else {
+    $pipArgs = @("-m", "pip", "install", "--upgrade", "homepot-client[agent]")
+}
+$process = Start-Process -FilePath $python -ArgumentList $pipArgs -NoNewWindow -Wait -PassThru
+if ($process.ExitCode -ne 0) {
+    Write-Error "pip upgrade failed (exit code: $($process.ExitCode))."
+    Write-Error "Service is stopped and will NOT be restarted."
+    exit 1
+}
+Write-Host "  Package upgraded."
+
+# ---------------------------------------------------------------------------
+# Phase 3: Re-register the service
+# ---------------------------------------------------------------------------
+
+Write-Host "Phase 3/4: Re-registering service..."
+& $python $serviceScript remove | Out-Null
+Start-Sleep -Seconds 1
+& $python $serviceScript install
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Service re-registration failed (exit code: $LASTEXITCODE)."
+    exit 1
+}
+
+# Restore recovery policy (install resets it)
+Write-Host "  Configuring service recovery..."
+& sc.exe failure HomepotAgent reset= 86400 actions= restart/60000/restart/60000/restart/60000 | Out-Null
+
+# ---------------------------------------------------------------------------
+# Phase 4: Start the service
+# ---------------------------------------------------------------------------
+
+Write-Host "Phase 4/4: Starting service..."
+Start-Service -Name "HomepotAgent"
+
+$service = Get-Service -Name "HomepotAgent" -ErrorAction SilentlyContinue
+if ($service -and $service.Status -eq "Running") {
+    Write-Host "HOMEPOT Device Agent upgraded and running successfully."
+} else {
+    Write-Warning "Service re-installed but status is: $($service.Status)"
+    Write-Warning "Check Event Viewer for errors."
+    exit 1
+}


### PR DESCRIPTION
## Summary

### 1. Graceful shutdown with `SERVICE_CONTROL_PRESHUTDOWN`

- **`scripts/homepot_agent_service.py`**: Added `SvcShutdown()`, `SvcOther()`, and `_handle_preshutdown()` methods to handle system shutdown and Preshutdown control codes
- Service now accepts `SERVICE_ACCEPT_STOP | SERVICE_ACCEPT_SHUTDOWN | SERVICE_ACCEPT_PRESHUTDOWN`
- `_signal_shutdown()` extracted as a common helper for all shutdown paths
- **`scripts/install-agent.ps1`**: Configures preshutdown via `sc.exe config HomepotAgent preshutdown= 1`

### 2. Atomic in-place upgrade

- **`scripts/homepot_agent_service.py`**: New `upgrade` CLI command — stops service, runs `pip install --upgrade`, re-registers, restarts
- **`scripts/upgrade-agent.ps1`**: PowerShell upgrade script with 4 phases (stop → pip upgrade → re-register → start), atomic failure handling, and source override for pre-release testing

### 3. Windows EventLog integration

- **`backend/src/homepot/agent/utils/log_setup.py`**: Added optional `use_eventlog` parameter; creates `NTEventLogHandler` on Windows when enabled
- Reads `use_eventlog` config key in `logging_config_from_config()`

### Quality

- flake8: clean
- mypy: clean  
- isort + black: clean
- bootstrap tests: 5 passed