### PR TITLE
feat: centralize DB population into seed_factories, fix agent status fields and API paths

### DIFF
--- a/backend/src/homepot/agents.py
+++ b/backend/src/homepot/agents.py
@@ -30,7 +30,14 @@ from homepot.app.models.AnalyticsModel import (
 from homepot.audit import AuditEventType, get_audit_logger
 from homepot.database import get_database_service
 from homepot.error_logger import log_error
-from homepot.models import Device, DeviceStatus, Job, JobPriority, JobStatus
+from homepot.models import (
+    Device,
+    DeviceStatus,
+    HealthState,
+    Job,
+    JobPriority,
+    JobStatus,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -116,6 +123,26 @@ class DeviceAgentSimulator:
         """Start the agent simulator."""
         self.is_running = True
         logger.info(f"Agent {self.device_id} started")
+
+        # Transition lifecycle from pending to active on first start
+        try:
+            db_service = await get_database_service()
+            from sqlalchemy import select
+
+            from homepot.models import Device, LifecycleState
+
+            async with db_service.get_session() as session:
+                result = await session.execute(
+                    select(Device).where(Device.device_id == self.device_id)
+                )
+                device = result.scalar_one_or_none()
+                if device and device.lifecycle_state == LifecycleState.PENDING.value:
+                    device.lifecycle_state = LifecycleState.ACTIVE.value  # type: ignore[assignment]
+                    session.add(device)
+                    await session.commit()
+                    logger.info(f"Device {self.device_id} lifecycle: pending → active")
+        except Exception as e:
+            logger.warning(f"Failed to update lifecycle for {self.device_id}: {e}")
 
         # Audit Log: Agent Started
         try:
@@ -741,9 +768,12 @@ class DeviceAgentSimulator:
 
                         # Update Device Last Seen
                         # device object is already attached to the session
-                        device.last_seen = datetime.now(timezone.utc)  # type: ignore[assignment]
+                        now = datetime.now(timezone.utc)
+                        device.last_seen = now  # type: ignore[assignment]
+                        device.last_heartbeat_at = now  # type: ignore[assignment]
                         # Ensure status is consistent
                         device.status = "online" if is_healthy else "offline"  # type: ignore[assignment]
+                        device.health_state = HealthState.HEALTHY.value if is_healthy else HealthState.ERROR.value  # type: ignore[assignment]
                         db.add(device)
 
                         await db.commit()

--- a/backend/src/homepot/seed_factories.py
+++ b/backend/src/homepot/seed_factories.py
@@ -1,0 +1,492 @@
+"""Reusable factory functions for creating seed data entities.
+
+Each factory provides sensible defaults for every field and accepts
+``**kwargs`` overrides.  They are the single source of truth for what
+fields every entity receives, shared between the CLI seed script and
+test fixtures.
+
+Every entity provides three variants:
+* ``create_*`` -- async, for use with ``AsyncSession`` (e.g. ``seed_data.py``).
+* ``create_*_sync`` -- sync, for use with sync ``Session`` (e.g. test fixtures).
+* ``build_*`` -- pure builder that returns an unsaved instance; sync tests
+  that need to customise the object before adding it to a session can use
+  these.
+"""
+
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+from passlib.context import CryptContext
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
+
+from homepot.models import (
+    AuditLog,
+    Device,
+    DeviceCredential,
+    DeviceLifecycleEvent,
+    DeviceType,
+    EnrolmentIntent,
+    HealthCheck,
+    HealthState,
+    Job,
+    JobPriority,
+    JobStatus,
+    LifecycleEpoch,
+    LifecycleState,
+    Site,
+    SiteMembership,
+    Tenant,
+    TenantMembership,
+    User,
+)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _hash_password(password: str) -> str:
+    return CryptContext(schemes=["bcrypt"], deprecated="auto").hash(password)
+
+
+# ---------------------------------------------------------------------------
+# Tenant
+# ---------------------------------------------------------------------------
+
+
+def build_tenant(
+    *, name: str = "Default Tenant", slug: str | None = None, **kwargs: Any
+) -> Tenant:
+    """Build an unsaved Tenant instance."""
+    if slug is None:
+        slug = name.lower().replace(" ", "-")
+    return Tenant(name=name, slug=slug, **kwargs)
+
+
+async def create_tenant(session: AsyncSession, **kwargs: Any) -> Tenant:
+    """Create and persist a Tenant using an async session."""
+    tenant = build_tenant(**kwargs)
+    session.add(tenant)
+    await session.flush()
+    return tenant
+
+
+def create_tenant_sync(session: Session, **kwargs: Any) -> Tenant:
+    """Create and persist a Tenant using a sync session."""
+    tenant = build_tenant(**kwargs)
+    session.add(tenant)
+    session.flush()
+    return tenant
+
+
+# ---------------------------------------------------------------------------
+# User
+# ---------------------------------------------------------------------------
+
+
+def build_user(
+    *,
+    username: str = "test-user",
+    email: str = "test@example.com",
+    password: str = "password",
+    **kwargs: Any,
+) -> User:
+    """Build an unsaved User instance."""
+    kwargs.setdefault("hashed_password", _hash_password(password))
+    return User(username=username, email=email, **kwargs)
+
+
+async def create_user(session: AsyncSession, **kwargs: Any) -> User:
+    """Create and persist a User using an async session."""
+    user = build_user(**kwargs)
+    session.add(user)
+    await session.flush()
+    return user
+
+
+def create_user_sync(session: Session, **kwargs: Any) -> User:
+    """Create and persist a User using a sync session."""
+    user = build_user(**kwargs)
+    session.add(user)
+    session.flush()
+    return user
+
+
+# ---------------------------------------------------------------------------
+# TenantMembership
+# ---------------------------------------------------------------------------
+
+
+def build_tenant_membership(
+    *, user_id: int, tenant_id: int, role: str = "member", **kwargs: Any
+) -> TenantMembership:
+    """Build an unsaved TenantMembership instance."""
+    return TenantMembership(user_id=user_id, tenant_id=tenant_id, role=role, **kwargs)
+
+
+async def create_tenant_membership(
+    session: AsyncSession, **kwargs: Any
+) -> TenantMembership:
+    """Create and persist a TenantMembership using an async session."""
+    tm = build_tenant_membership(**kwargs)
+    session.add(tm)
+    await session.flush()
+    return tm
+
+
+def create_tenant_membership_sync(session: Session, **kwargs: Any) -> TenantMembership:
+    """Create and persist a TenantMembership using a sync session."""
+    tm = build_tenant_membership(**kwargs)
+    session.add(tm)
+    session.flush()
+    return tm
+
+
+# ---------------------------------------------------------------------------
+# Site
+# ---------------------------------------------------------------------------
+
+
+def build_site(
+    *, site_id: str | None = None, name: str = "Default Site", **kwargs: Any
+) -> Site:
+    """Build an unsaved Site instance."""
+    if site_id is None:
+        site_id = f"site-{uuid4().hex[:8]}"
+    return Site(site_id=site_id, name=name, **kwargs)
+
+
+async def create_site(session: AsyncSession, **kwargs: Any) -> Site:
+    """Create and persist a Site using an async session."""
+    site = build_site(**kwargs)
+    session.add(site)
+    await session.flush()
+    return site
+
+
+def create_site_sync(session: Session, **kwargs: Any) -> Site:
+    """Create and persist a Site using a sync session."""
+    site = build_site(**kwargs)
+    session.add(site)
+    session.flush()
+    return site
+
+
+# ---------------------------------------------------------------------------
+# SiteMembership
+# ---------------------------------------------------------------------------
+
+
+def build_site_membership(
+    *, user_id: int, site_id: int, role: str = "viewer", **kwargs: Any
+) -> SiteMembership:
+    """Build an unsaved SiteMembership instance."""
+    return SiteMembership(user_id=user_id, site_id=site_id, role=role, **kwargs)
+
+
+async def create_site_membership(
+    session: AsyncSession, **kwargs: Any
+) -> SiteMembership:
+    """Create and persist a SiteMembership using an async session."""
+    sm = build_site_membership(**kwargs)
+    session.add(sm)
+    await session.flush()
+    return sm
+
+
+def create_site_membership_sync(session: Session, **kwargs: Any) -> SiteMembership:
+    """Create and persist a SiteMembership using a sync session."""
+    sm = build_site_membership(**kwargs)
+    session.add(sm)
+    session.flush()
+    return sm
+
+
+# ---------------------------------------------------------------------------
+# Device
+# ---------------------------------------------------------------------------
+
+
+def build_device(
+    *,
+    device_id: str | None = None,
+    name: str = "Default Device",
+    device_type: str = DeviceType.UNKNOWN,
+    site_id: int,
+    **kwargs: Any,
+) -> Device:
+    """Build an unsaved Device instance."""
+    if device_id is None:
+        device_id = f"dev-{uuid4().hex[:8]}"
+    kwargs.setdefault("lifecycle_state", LifecycleState.PENDING.value)
+    kwargs.setdefault("health_state", HealthState.UNKNOWN.value)
+    return Device(
+        device_id=device_id,
+        name=name,
+        device_type=device_type,
+        site_id=site_id,
+        **kwargs,
+    )
+
+
+async def create_device(session: AsyncSession, **kwargs: Any) -> Device:
+    """Create and persist a Device using an async session."""
+    device = build_device(**kwargs)
+    session.add(device)
+    await session.flush()
+    return device
+
+
+def create_device_sync(session: Session, **kwargs: Any) -> Device:
+    """Create and persist a Device using a sync session."""
+    device = build_device(**kwargs)
+    session.add(device)
+    session.flush()
+    return device
+
+
+# ---------------------------------------------------------------------------
+# LifecycleEpoch
+# ---------------------------------------------------------------------------
+
+
+def build_lifecycle_epoch(
+    *, device_id: int, site_id: int, **kwargs: Any
+) -> LifecycleEpoch:
+    """Build an unsaved LifecycleEpoch instance."""
+    kwargs.setdefault("epoch_id", str(uuid4()))
+    kwargs.setdefault("claimed_at", _utc_now())
+    kwargs.setdefault("enrolment_method", "pre-provisioned")
+    return LifecycleEpoch(device_id=device_id, site_id=site_id, **kwargs)
+
+
+async def create_lifecycle_epoch(
+    session: AsyncSession, **kwargs: Any
+) -> LifecycleEpoch:
+    """Create and persist a LifecycleEpoch using an async session."""
+    epoch = build_lifecycle_epoch(**kwargs)
+    session.add(epoch)
+    await session.flush()
+    return epoch
+
+
+def create_lifecycle_epoch_sync(session: Session, **kwargs: Any) -> LifecycleEpoch:
+    """Create and persist a LifecycleEpoch using a sync session."""
+    epoch = build_lifecycle_epoch(**kwargs)
+    session.add(epoch)
+    session.flush()
+    return epoch
+
+
+# ---------------------------------------------------------------------------
+# DeviceLifecycleEvent
+# ---------------------------------------------------------------------------
+
+
+def build_device_lifecycle_event(
+    *, device_id: int, to_state: str = LifecycleState.PENDING, **kwargs: Any
+) -> DeviceLifecycleEvent:
+    """Build an unsaved DeviceLifecycleEvent instance."""
+    kwargs.setdefault("event_id", str(uuid4()))
+    return DeviceLifecycleEvent(device_id=device_id, to_state=to_state, **kwargs)
+
+
+async def create_device_lifecycle_event(
+    session: AsyncSession, **kwargs: Any
+) -> DeviceLifecycleEvent:
+    """Create and persist a DeviceLifecycleEvent using an async session."""
+    event = build_device_lifecycle_event(**kwargs)
+    session.add(event)
+    await session.flush()
+    return event
+
+
+def create_device_lifecycle_event_sync(
+    session: Session, **kwargs: Any
+) -> DeviceLifecycleEvent:
+    """Create and persist a DeviceLifecycleEvent using a sync session."""
+    event = build_device_lifecycle_event(**kwargs)
+    session.add(event)
+    session.flush()
+    return event
+
+
+# ---------------------------------------------------------------------------
+# Job
+# ---------------------------------------------------------------------------
+
+
+def build_job(
+    *,
+    job_id: str | None = None,
+    action: str = "test-action",
+    site_id: int,
+    created_by: int,
+    **kwargs: Any,
+) -> Job:
+    """Build an unsaved Job instance."""
+    if job_id is None:
+        job_id = f"job-{uuid4().hex[:12]}"
+    kwargs.setdefault("priority", JobPriority.NORMAL)
+    kwargs.setdefault("status", JobStatus.PENDING)
+    return Job(
+        job_id=job_id, action=action, site_id=site_id, created_by=created_by, **kwargs
+    )
+
+
+async def create_job(session: AsyncSession, **kwargs: Any) -> Job:
+    """Create and persist a Job using an async session."""
+    job = build_job(**kwargs)
+    session.add(job)
+    await session.flush()
+    return job
+
+
+def create_job_sync(session: Session, **kwargs: Any) -> Job:
+    """Create and persist a Job using a sync session."""
+    job = build_job(**kwargs)
+    session.add(job)
+    session.flush()
+    return job
+
+
+# ---------------------------------------------------------------------------
+# HealthCheck
+# ---------------------------------------------------------------------------
+
+
+def build_health_check(
+    *, device_id: int, is_healthy: bool = True, **kwargs: Any
+) -> HealthCheck:
+    """Build an unsaved HealthCheck instance."""
+    return HealthCheck(device_id=device_id, is_healthy=is_healthy, **kwargs)
+
+
+async def create_health_check(session: AsyncSession, **kwargs: Any) -> HealthCheck:
+    """Create and persist a HealthCheck using an async session."""
+    hc = build_health_check(**kwargs)
+    session.add(hc)
+    await session.flush()
+    return hc
+
+
+def create_health_check_sync(session: Session, **kwargs: Any) -> HealthCheck:
+    """Create and persist a HealthCheck using a sync session."""
+    hc = build_health_check(**kwargs)
+    session.add(hc)
+    session.flush()
+    return hc
+
+
+# ---------------------------------------------------------------------------
+# AuditLog
+# ---------------------------------------------------------------------------
+
+
+def build_audit_log(
+    *,
+    event_type: str = "system_event",
+    description: str = "Audit log entry",
+    **kwargs: Any,
+) -> AuditLog:
+    """Build an unsaved AuditLog instance."""
+    return AuditLog(event_type=event_type, description=description, **kwargs)
+
+
+async def create_audit_log(session: AsyncSession, **kwargs: Any) -> AuditLog:
+    """Create and persist an AuditLog using an async session."""
+    log = build_audit_log(**kwargs)
+    session.add(log)
+    await session.flush()
+    return log
+
+
+def create_audit_log_sync(session: Session, **kwargs: Any) -> AuditLog:
+    """Create and persist an AuditLog using a sync session."""
+    log = build_audit_log(**kwargs)
+    session.add(log)
+    session.flush()
+    return log
+
+
+# ---------------------------------------------------------------------------
+# EnrolmentIntent
+# ---------------------------------------------------------------------------
+
+
+def build_enrolment_intent(
+    *,
+    intent_id: str | None = None,
+    site_id: int,
+    enrolment_method: str = "pre-provisioned",
+    expires_at: datetime | None = None,
+    creator_id: int,
+    **kwargs: Any,
+) -> EnrolmentIntent:
+    """Build an unsaved EnrolmentIntent instance."""
+    if intent_id is None:
+        intent_id = str(uuid4())
+    if expires_at is None:
+        expires_at = _utc_now()
+    return EnrolmentIntent(
+        intent_id=intent_id,
+        site_id=site_id,
+        enrolment_method=enrolment_method,
+        expires_at=expires_at,
+        creator_id=creator_id,
+        **kwargs,
+    )
+
+
+async def create_enrolment_intent(
+    session: AsyncSession, **kwargs: Any
+) -> EnrolmentIntent:
+    """Create and persist an EnrolmentIntent using an async session."""
+    intent = build_enrolment_intent(**kwargs)
+    session.add(intent)
+    await session.flush()
+    return intent
+
+
+def create_enrolment_intent_sync(session: Session, **kwargs: Any) -> EnrolmentIntent:
+    """Create and persist an EnrolmentIntent using a sync session."""
+    intent = build_enrolment_intent(**kwargs)
+    session.add(intent)
+    session.flush()
+    return intent
+
+
+# ---------------------------------------------------------------------------
+# DeviceCredential
+# ---------------------------------------------------------------------------
+
+
+def build_device_credential(
+    *, credential_id: str | None = None, device_id: int, key_hash: str, **kwargs: Any
+) -> DeviceCredential:
+    """Build an unsaved DeviceCredential instance."""
+    if credential_id is None:
+        credential_id = str(uuid4())
+    return DeviceCredential(
+        credential_id=credential_id, device_id=device_id, key_hash=key_hash, **kwargs
+    )
+
+
+async def create_device_credential(
+    session: AsyncSession, **kwargs: Any
+) -> DeviceCredential:
+    """Create and persist a DeviceCredential using an async session."""
+    cred = build_device_credential(**kwargs)
+    session.add(cred)
+    await session.flush()
+    return cred
+
+
+def create_device_credential_sync(session: Session, **kwargs: Any) -> DeviceCredential:
+    """Create and persist a DeviceCredential using a sync session."""
+    cred = build_device_credential(**kwargs)
+    session.add(cred)
+    session.flush()
+    return cred

--- a/backend/tests/test_authorization.py
+++ b/backend/tests/test_authorization.py
@@ -8,10 +8,9 @@ Verifies that:
 """
 
 import asyncio
-from datetime import datetime, timezone
 import os
 import tempfile
-from typing import Any, Generator, Optional
+from typing import Any, Generator
 
 from fastapi.testclient import TestClient
 import pytest
@@ -24,15 +23,14 @@ from homepot.app.auth_utils import (
 )
 from homepot.config import reload_settings
 import homepot.database
-from homepot.models import (
-    Base,
-    Device,
-    LifecycleState,
-    Site,
-    SiteMembership,
-    Tenant,
-    TenantMembership,
-    User,
+from homepot.models import Base, LifecycleState, Site
+from homepot.seed_factories import (
+    create_device_sync,
+    create_site_membership_sync,
+    create_site_sync,
+    create_tenant_membership_sync,
+    create_tenant_sync,
+    create_user_sync,
 )
 
 # ---------------------------------------------------------------------------
@@ -91,87 +89,6 @@ def client() -> Generator[TestClient, None, None]:
 # ---------------------------------------------------------------------------
 
 
-def _create_tenant(db: Any, slug: str, name: str) -> Tenant:
-    tenant = Tenant(slug=slug, name=name)
-    db.add(tenant)
-    db.commit()
-    db.refresh(tenant)
-    return tenant
-
-
-def _create_user(
-    db: Any,
-    email: str,
-    tenant: Optional[Tenant] = None,
-    is_admin: bool = False,
-) -> User:
-    user = User(
-        email=email,
-        username=email.split("@")[0],
-        hashed_password=hash_password("pass"),
-        tenant_id=tenant.id if tenant else None,
-        is_admin=is_admin,
-        created_at=datetime.now(timezone.utc),
-        updated_at=datetime.now(timezone.utc),
-    )
-    db.add(user)
-    db.commit()
-    db.refresh(user)
-    return user
-
-
-def _add_tenant_membership(
-    db: Any, user: User, tenant: Tenant, role: str = "admin"
-) -> TenantMembership:
-    tm = TenantMembership(user_id=user.id, tenant_id=tenant.id, role=role)
-    db.add(tm)
-    db.commit()
-    db.refresh(tm)
-    return tm
-
-
-def _add_site_membership(
-    db: Any, user: User, site: Site, role: str = "viewer"
-) -> SiteMembership:
-    sm = SiteMembership(user_id=user.id, site_id=site.id, role=role)
-    db.add(sm)
-    db.commit()
-    db.refresh(sm)
-    return sm
-
-
-def _create_site(db: Any, site_id: str, name: str, tenant: Tenant) -> Site:
-    site = Site(
-        site_id=site_id,
-        name=name,
-        tenant_id=tenant.id,
-        created_at=datetime.now(timezone.utc),
-        updated_at=datetime.now(timezone.utc),
-    )
-    db.add(site)
-    db.commit()
-    db.refresh(site)
-    return site
-
-
-def _create_device(db: Any, device_id: str, name: str, site: Site) -> Device:
-    device = Device(
-        device_id=device_id,
-        name=name,
-        device_type="pos_terminal",
-        site_id=site.id,
-        is_active=True,
-        lifecycle_state=LifecycleState.ACTIVE.value,
-        api_key_hash=hash_password("device-key"),
-        created_at=datetime.now(timezone.utc),
-        updated_at=datetime.now(timezone.utc),
-    )
-    db.add(device)
-    db.commit()
-    db.refresh(device)
-    return device
-
-
 def _auth_header(email: str) -> dict[str, str]:
     token = create_access_token({"sub": email})
     return {"Authorization": f"Bearer {token}"}
@@ -191,25 +108,74 @@ def seeded_db(file_db: Any) -> Any:
     """Seed two tenants, each with site, device, and user, plus an admin user."""
     db = homepot.database.SessionLocal()
 
-    tenant_a = _create_tenant(db, "tenant-a", "Tenant A")
-    tenant_b = _create_tenant(db, "tenant-b", "Tenant B")
+    tenant_a = create_tenant_sync(db, name="Tenant A", slug="tenant-a")
+    tenant_b = create_tenant_sync(db, name="Tenant B", slug="tenant-b")
 
-    site_a = _create_site(db, "site-a-1", "Site A-1", tenant_a)
-    site_b = _create_site(db, "site-b-1", "Site B-1", tenant_b)
+    site_a = create_site_sync(
+        db, site_id="site-a-1", name="Site A-1", tenant_id=tenant_a.id
+    )
+    site_b = create_site_sync(
+        db, site_id="site-b-1", name="Site B-1", tenant_id=tenant_b.id
+    )
 
-    dev_a = _create_device(db, "dev-a-1", "Device A-1", site_a)
-    dev_b = _create_device(db, "dev-b-1", "Device B-1", site_b)
+    dev_a = create_device_sync(
+        db,
+        device_id="dev-a-1",
+        name="Device A-1",
+        device_type="pos_terminal",
+        site_id=site_a.id,
+        is_active=True,
+        lifecycle_state=LifecycleState.ACTIVE.value,
+        api_key_hash=hash_password("device-key"),
+    )
+    dev_b = create_device_sync(
+        db,
+        device_id="dev-b-1",
+        name="Device B-1",
+        device_type="pos_terminal",
+        site_id=site_b.id,
+        is_active=True,
+        lifecycle_state=LifecycleState.ACTIVE.value,
+        api_key_hash=hash_password("device-key"),
+    )
 
-    user_a = _create_user(db, "user.a@example.com", tenant_a)
-    user_b = _create_user(db, "user.b@example.com", tenant_b)
-    admin = _create_user(db, "admin@example.com", is_admin=True)
+    user_a = create_user_sync(
+        db,
+        email="user.a@example.com",
+        username="user.a",
+        password="pass",
+        tenant_id=tenant_a.id,
+    )
+    user_b = create_user_sync(
+        db,
+        email="user.b@example.com",
+        username="user.b",
+        password="pass",
+        tenant_id=tenant_b.id,
+    )
+    admin = create_user_sync(
+        db,
+        email="admin@example.com",
+        username="admin",
+        password="pass",
+        is_admin=True,
+    )
 
-    _add_tenant_membership(db, user_a, tenant_a, "admin")
-    _add_tenant_membership(db, user_b, tenant_b, "admin")
+    create_tenant_membership_sync(
+        db, user_id=user_a.id, tenant_id=tenant_a.id, role="admin"
+    )
+    create_tenant_membership_sync(
+        db, user_id=user_b.id, tenant_id=tenant_b.id, role="admin"
+    )
 
-    _add_site_membership(db, user_a, site_a, "operator")
-    _add_site_membership(db, user_b, site_b, "operator")
+    create_site_membership_sync(
+        db, user_id=user_a.id, site_id=site_a.id, role="operator"
+    )
+    create_site_membership_sync(
+        db, user_id=user_b.id, site_id=site_b.id, role="operator"
+    )
 
+    db.commit()
     db.close()
     return {
         "tenant_a": tenant_a,
@@ -577,8 +543,12 @@ class TestSiteOperatorScope:
         """A viewer-level user should be denied operator-level operations."""
         db = homepot.database.SessionLocal()
         site_a = db.query(Site).filter(Site.site_id == "site-a-1").first()
-        viewer_user = _create_user(db, "viewer@example.com")
-        _add_site_membership(db, viewer_user, site_a, "viewer")
+        viewer_user = create_user_sync(
+            db, email="viewer@example.com", username="viewer", password="pass"
+        )
+        create_site_membership_sync(
+            db, user_id=viewer_user.id, site_id=site_a.id, role="viewer"
+        )
         db.close()
 
         resp = client.put(

--- a/backend/utils/seed_data.py
+++ b/backend/utils/seed_data.py
@@ -52,17 +52,28 @@ from homepot.app.models.AnalyticsModel import (
     UserActivity,
 )
 from homepot.app.models.UserModel import Base as AppBase
-from homepot.app.models.UserModel import User
 from homepot.database import DatabaseService
 from homepot.models import (
-    AuditLog,
     Base,
     Device,
     DeviceType,
-    HealthCheck,
+    HealthState,
     Job,
-    JobPriority,
     JobStatus,
+    LifecycleState,
+)
+from homepot.seed_factories import (
+    create_audit_log,
+    create_device,
+    create_device_lifecycle_event,
+    create_health_check,
+    create_job,
+    create_lifecycle_epoch,
+    create_site,
+    create_site_membership,
+    create_tenant,
+    create_tenant_membership,
+    create_user,
 )
 
 if not hasattr(bcrypt, "__about__"):
@@ -74,8 +85,7 @@ if not hasattr(bcrypt, "__about__"):
 
     bcrypt.__about__ = About()
 
-from passlib.context import CryptContext
-from sqlalchemy import select
+from sqlalchemy import select, text
 
 
 def generate_historical_metrics(device_id: int, hours: int = 24) -> list[DeviceMetrics]:
@@ -278,10 +288,41 @@ async def init_database():
     # Create database service (will use DATABASE__URL from .env)
     db_service = DatabaseService()
 
+    _DROP_TABLES = [
+        "device_lifecycle_events",
+        "lifecycle_epochs",
+        "device_credentials",
+        "device_assignments",
+        "health_checks",
+        "device_commands",
+        "audit_logs",
+        "jobs",
+        "enrolment_intents",
+        "site_memberships",
+        "tenant_memberships",
+        "devices",
+        "site_operating_schedules",
+        "sites",
+        "users",
+        "tenants",
+        "api_request_logs",
+        "device_metrics",
+        "device_state_history",
+        "job_outcomes",
+        "error_logs",
+        "user_activities",
+        "configuration_history",
+        "push_notification_logs",
+        "alerts",
+    ]
     print("Dropping existing tables...")
     async with db_service.engine.begin() as conn:
-        await conn.run_sync(AppBase.metadata.drop_all)
-        await conn.run_sync(Base.metadata.drop_all)
+        for table in _DROP_TABLES:
+            await conn.run_sync(
+                lambda sync_conn, t=table: sync_conn.execute(
+                    text(f"DROP TABLE IF EXISTS {t} CASCADE")
+                )
+            )
 
     print("Creating database schema...")
     await db_service.initialize()
@@ -293,107 +334,136 @@ async def init_database():
 
     print("Database schema created")
 
-    pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-    now = datetime.now(timezone.utc).replace(
-        tzinfo=None
-    )  # Database uses naive datetime
+    # --- TENANTS ---
+    print("\n=== Creating Tenants ===")
+    async with db_service.get_session() as session:
+        tenant_a = await create_tenant(
+            session,
+            name="Demo Organization A",
+            slug="demo-org-a",
+            settings={"region": "emea"},
+        )
+        print(f"Created tenant: {tenant_a.name} ({tenant_a.slug})")
+        tenant_b = await create_tenant(
+            session,
+            name="Demo Organization B",
+            slug="demo-org-b",
+            settings={"region": "apac"},
+        )
+        print(f"Created tenant: {tenant_b.name} ({tenant_b.slug})")
+        await session.commit()
 
     # --- USERS ---
     print("\n=== Creating Users ===")
     async with db_service.get_session() as session:
-        # 1. Admin User (matching DB credentials for simplicity)
-        result = await session.execute(
-            select(User).where(User.username == "homepot_admin")
+        admin_user = await create_user(
+            session,
+            username="homepot_admin",
+            email="admin@homepot.com",
+            full_name="System Administrator",
+            password="homepot_dev_password",
+            is_admin=True,
+            tenant_id=tenant_a.id,
         )
-        if not result.scalar_one_or_none():
-            admin_user = User(
-                email="admin@homepot.com",
-                username="homepot_admin",
-                full_name="System Administrator",
-                hashed_password=pwd_context.hash("homepot_dev_password"),
-                is_admin=True,
-                created_at=now,
-                updated_at=now,
-            )
-            session.add(admin_user)
-            print("Created user: homepot_admin")
-        else:
-            print("User homepot_admin already exists")
-            # Fetch for later use
-            admin_user = (
-                await session.execute(
-                    select(User).where(User.username == "homepot_admin")
-                )
-            ).scalar_one()
-
-        # 2. Standard Client User
-        result = await session.execute(
-            select(User).where(User.username == "homepot_client")
+        print(f"Created user: {admin_user.username}")
+        client_user = await create_user(
+            session,
+            username="homepot_client",
+            email="user@homepot.com",
+            full_name="Standard Client",
+            password="homepot_dev_password",
+            role="Client",
+            is_admin=False,
+            tenant_id=tenant_b.id,
         )
-        if not result.scalar_one_or_none():
-            client_user = User(
-                email="user@homepot.com",
-                username="homepot_client",
-                full_name="Standard Client",
-                hashed_password=pwd_context.hash("homepot_dev_password"),
-                role="Client",
-                is_admin=False,
-                created_at=now,
-                updated_at=now,
-            )
-            session.add(client_user)
-            print("Created user: homepot_client")
-        else:
-            print("User homepot_client already exists")
+        print(f"Created user: {client_user.username}")
+        await session.commit()
 
+    # --- TENANT MEMBERSHIPS ---
+    print("\n=== Creating Tenant Memberships ===")
+    async with db_service.get_session() as session:
+        await create_tenant_membership(
+            session, user_id=admin_user.id, tenant_id=tenant_a.id, role="admin"
+        )
+        print(f"Added admin_user to tenant {tenant_a.slug} as admin")
+        await create_tenant_membership(
+            session, user_id=client_user.id, tenant_id=tenant_b.id, role="member"
+        )
+        print(f"Added client_user to tenant {tenant_b.slug} as member")
         await session.commit()
 
     # --- SITES ---
     print("\n=== Creating Sites ===")
 
     async def get_or_create_site(
-        site_id, name, description, location, latitude=None, longitude=None
+        session,
+        site_id,
+        name,
+        description,
+        location,
+        latitude=None,
+        longitude=None,
+        tenant_id=None,
     ):
         existing = await db_service.get_site_by_site_id(site_id)
         if existing:
-            # print(f"Site {site_id} already exists")
             return existing
-
-        site = await db_service.create_site(
+        site = await create_site(
+            session,
             site_id=site_id,
             name=name,
             description=description,
             location=location,
             latitude=latitude,
             longitude=longitude,
+            tenant_id=tenant_id,
         )
         print(f"Created site: {site.name} ({site_id})")
         return site
 
-    # Create 2 Targeted Sites
-    site1 = await get_or_create_site(
-        "site-001",
-        "Site 1 - Mixed OS",
-        "Mixed environment site 1",
-        "London, UK",
-        40.7128,
-        -74.0060,
-    )
-    site2 = await get_or_create_site(
-        "site-002",
-        "Site 2 - Mixed OS",
-        "Mixed environment site 2",
-        "London, UK",
-        51.5074,
-        -0.1278,
-    )
+    async with db_service.get_session() as session:
+        site1 = await get_or_create_site(
+            session,
+            "site-001",
+            "Site 1 - Mixed OS",
+            "Mixed environment site 1",
+            "London, UK",
+            40.7128,
+            -74.0060,
+            tenant_id=tenant_a.id,
+        )
+        site2 = await get_or_create_site(
+            session,
+            "site-002",
+            "Site 2 - Mixed OS",
+            "Mixed environment site 2",
+            "London, UK",
+            51.5074,
+            -0.1278,
+            tenant_id=tenant_b.id,
+        )
+        await session.commit()
 
     sites = [site1, site2]
+
+    # --- SITE MEMBERSHIPS ---
+    print("\n=== Creating Site Memberships ===")
+    async with db_service.get_session() as session:
+        await create_site_membership(
+            session, user_id=admin_user.id, site_id=site1.id, role="admin"
+        )
+        print(f"Added admin_user to site {site1.site_id} as admin")
+        await create_site_membership(
+            session, user_id=client_user.id, site_id=site2.id, role="viewer"
+        )
+        print(f"Added client_user to site {site2.site_id} as viewer")
+        await session.commit()
 
     # --- DEVICES ---
     print("\n=== Creating Devices ===")
 
     async def get_or_create_device(
+        session,
         device_id,
         name,
         device_type,
@@ -407,15 +477,15 @@ async def init_database():
         existing = await db_service.get_device_by_device_id(device_id)
         if existing:
             return existing
-
-        device = await db_service.create_device(
+        device = await create_device(
+            session,
             device_id=device_id,
             name=name,
             device_type=device_type,
             site_id=site_id,
             ip_address=ip_address,
             config=config,
-            last_seen=datetime.now(timezone.utc),  # Set initial Last Seen
+            last_seen=datetime.now(timezone.utc),
             is_monitored=is_monitored,
             enrollment_method=enrollment_method,
             enrollment_token=enrollment_token,
@@ -425,163 +495,198 @@ async def init_database():
         )
         return device
 
-    # Site 1 Devices
-    print("--- Site 1 Devices ---")
-    await get_or_create_device(
-        "site1-linux-01",
-        "Linux POS 1-1",
-        DeviceType.POS_TERMINAL,
-        site1.id,
-        "10.1.1.10",
-        {
-            "os": "linux",
-            "push_platform": "fcm",
-            "agent_version": "1.0.0-sim",
-            "version": "1.0.0",
-        },
-        is_monitored=True,
-    )
-    await get_or_create_device(
-        "site1-windows-02",
-        "Windows POS 1-2",
-        DeviceType.POS_TERMINAL,
-        site1.id,
-        "10.1.2.10",
-        {
-            "os": "windows",
-            "push_platform": "wns",
-            "agent_version": "1.0.0-sim",
-            "version": "1.0.0",
-        },
-        enrollment_method="self-enrolled",
-        enrollment_token="SIM-TOKEN-WIN-02",  # noqa: S106
-    )
-    await get_or_create_device(
-        "site1-macos-03",
-        "Apple POS 1-3",
-        DeviceType.POS_TERMINAL,
-        site1.id,
-        "10.1.3.10",
-        {
-            "os": "macos",
-            "push_platform": "apns",
-            "agent_version": "1.0.0-sim",
-            "version": "1.0.0",
-        },
-    )
-    await get_or_create_device(
-        "site1-web-04",
-        "Web Dashboard 1-4",
-        DeviceType.POS_TERMINAL,
-        site1.id,
-        "10.1.4.10",
-        {
-            "os": "web",
-            "push_platform": "web_push",
-            "agent_version": "1.0.0-web",
-            "version": "1.0.0",
-        },
-    )
-    await get_or_create_device(
-        "site1-iot-05",
-        "IoT Sensor 1-5",
-        DeviceType.IOT_SENSOR,
-        site1.id,
-        "10.1.5.10",
-        {
-            "os": "embedded",
-            "push_platform": "mqtt",
-            "agent_version": "1.0.0-iot",
-            "version": "1.0.0",
-        },
-    )
-    await get_or_create_device(
-        "site1-android-pos-06",
-        "Android POS 1-6",
-        DeviceType.POS_TERMINAL,
-        site1.id,
-        "10.1.6.10",
-        {
-            "os": "android",
-            "device_model": "Android POS Terminal",
-            "kiosk_mode": True,
-            "push_platform": "fcm_android",
-            "agent_version": "1.0.0-sim",
-            "version": "1.0.0",
-        },
-        is_monitored=True,
-        enrollment_method="self-enrolled",
-    )
+    async with db_service.get_session() as session:
+        await get_or_create_device(
+            session,
+            "site1-linux-01",
+            "Linux POS 1-1",
+            DeviceType.POS_TERMINAL,
+            site1.id,
+            "10.1.1.10",
+            {
+                "os": "linux",
+                "push_platform": "fcm",
+                "agent_version": "1.0.0-sim",
+                "version": "1.0.0",
+            },
+            is_monitored=True,
+        )
+        await get_or_create_device(
+            session,
+            "site1-windows-02",
+            "Windows POS 1-2",
+            DeviceType.POS_TERMINAL,
+            site1.id,
+            "10.1.2.10",
+            {
+                "os": "windows",
+                "push_platform": "wns",
+                "agent_version": "1.0.0-sim",
+                "version": "1.0.0",
+            },
+            enrollment_method="self-enrolled",
+            enrollment_token="SIM-TOKEN-WIN-02",  # noqa: S106
+        )
+        await get_or_create_device(
+            session,
+            "site1-macos-03",
+            "Apple POS 1-3",
+            DeviceType.POS_TERMINAL,
+            site1.id,
+            "10.1.3.10",
+            {
+                "os": "macos",
+                "push_platform": "apns",
+                "agent_version": "1.0.0-sim",
+                "version": "1.0.0",
+            },
+        )
+        await get_or_create_device(
+            session,
+            "site1-web-04",
+            "Web Dashboard 1-4",
+            DeviceType.POS_TERMINAL,
+            site1.id,
+            "10.1.4.10",
+            {
+                "os": "web",
+                "push_platform": "web_push",
+                "agent_version": "1.0.0-web",
+                "version": "1.0.0",
+            },
+        )
+        await get_or_create_device(
+            session,
+            "site1-iot-05",
+            "IoT Sensor 1-5",
+            DeviceType.IOT_SENSOR,
+            site1.id,
+            "10.1.5.10",
+            {
+                "os": "embedded",
+                "push_platform": "mqtt",
+                "agent_version": "1.0.0-iot",
+                "version": "1.0.0",
+            },
+        )
+        await get_or_create_device(
+            session,
+            "site1-android-pos-06",
+            "Android POS 1-6",
+            DeviceType.POS_TERMINAL,
+            site1.id,
+            "10.1.6.10",
+            {
+                "os": "android",
+                "device_model": "Android POS Terminal",
+                "kiosk_mode": True,
+                "push_platform": "fcm_android",
+                "agent_version": "1.0.0-sim",
+                "version": "1.0.0",
+            },
+            is_monitored=True,
+            enrollment_method="self-enrolled",
+        )
+        await get_or_create_device(
+            session,
+            "site2-linux-01",
+            "Linux POS 2-1",
+            DeviceType.POS_TERMINAL,
+            site2.id,
+            "10.2.1.10",
+            {
+                "os": "linux",
+                "push_platform": "fcm",
+                "agent_version": "1.0.0-sim",
+                "version": "1.0.0",
+            },
+            enrollment_method="self-enrolled",
+            enrollment_token="SIM-TOKEN-LINUX-01",  # noqa: S106
+        )
+        await get_or_create_device(
+            session,
+            "site2-windows-02",
+            "Windows POS 2-2",
+            DeviceType.POS_TERMINAL,
+            site2.id,
+            "10.2.2.10",
+            {
+                "os": "windows",
+                "push_platform": "wns",
+                "agent_version": "1.0.0-sim",
+                "version": "1.0.0",
+            },
+        )
+        await get_or_create_device(
+            session,
+            "site2-macos-03",
+            "Apple POS 2-3",
+            DeviceType.POS_TERMINAL,
+            site2.id,
+            "10.2.3.10",
+            {
+                "os": "macos",
+                "push_platform": "apns",
+                "agent_version": "1.0.0-sim",
+                "version": "1.0.0",
+            },
+        )
+        await get_or_create_device(
+            session,
+            "site2-web-04",
+            "Web Dashboard 2-4",
+            DeviceType.POS_TERMINAL,
+            site2.id,
+            "10.2.4.10",
+            {
+                "os": "web",
+                "push_platform": "web_push",
+                "agent_version": "1.0.0-web",
+                "version": "1.0.0",
+            },
+        )
+        await get_or_create_device(
+            session,
+            "site2-iot-05",
+            "IoT Sensor 2-5",
+            DeviceType.IOT_SENSOR,
+            site2.id,
+            "10.2.5.10",
+            {
+                "os": "embedded",
+                "push_platform": "mqtt",
+                "agent_version": "1.0.0-iot",
+                "version": "1.0.0",
+            },
+        )
+        await session.commit()
 
-    # Site 2 Devices
-    print("--- Site 2 Devices ---")
-    await get_or_create_device(
-        "site2-linux-01",
-        "Linux POS 2-1",
-        DeviceType.POS_TERMINAL,
-        site2.id,
-        "10.2.1.10",
-        {
-            "os": "linux",
-            "push_platform": "fcm",
-            "agent_version": "1.0.0-sim",
-            "version": "1.0.0",
-        },
-        enrollment_method="self-enrolled",
-        enrollment_token="SIM-TOKEN-LINUX-01",  # noqa: S106
-    )
-    await get_or_create_device(
-        "site2-windows-02",
-        "Windows POS 2-2",
-        DeviceType.POS_TERMINAL,
-        site2.id,
-        "10.2.2.10",
-        {
-            "os": "windows",
-            "push_platform": "wns",
-            "agent_version": "1.0.0-sim",
-            "version": "1.0.0",
-        },
-    )
-    await get_or_create_device(
-        "site2-macos-03",
-        "Apple POS 2-3",
-        DeviceType.POS_TERMINAL,
-        site2.id,
-        "10.2.3.10",
-        {
-            "os": "macos",
-            "push_platform": "apns",
-            "agent_version": "1.0.0-sim",
-            "version": "1.0.0",
-        },
-    )
-    await get_or_create_device(
-        "site2-web-04",
-        "Web Dashboard 2-4",
-        DeviceType.POS_TERMINAL,
-        site2.id,
-        "10.2.4.10",
-        {
-            "os": "web",
-            "push_platform": "web_push",
-            "agent_version": "1.0.0-web",
-            "version": "1.0.0",
-        },
-    )
-    await get_or_create_device(
-        "site2-iot-05",
-        "IoT Sensor 2-5",
-        DeviceType.IOT_SENSOR,
-        site2.id,
-        "10.2.5.10",
-        {
-            "os": "embedded",
-            "push_platform": "mqtt",
-            "agent_version": "1.0.0-iot",
-            "version": "1.0.0",
-        },
-    )
+    # --- DEVICE LIFECYCLE INITIALIZATION ---
+    print("\n=== Initializing Device Lifecycle ===")
+    async with db_service.get_session() as session:
+        result = await session.execute(select(Device))
+        all_devices = list(result.scalars().all())
+        for dev in all_devices:
+            epoch = await create_lifecycle_epoch(
+                session,
+                device_id=dev.id,
+                site_id=dev.site_id,
+                claimed_at=dev.created_at,
+                enrolment_method=dev.enrollment_method or "pre-provisioned",
+            )
+            await session.refresh(epoch)
+            dev.lifecycle_epoch_id = epoch.id
+            dev.health_state = HealthState.UNKNOWN.value
+            await create_device_lifecycle_event(
+                session,
+                device_id=dev.id,
+                epoch_id=epoch.id,
+                from_state=None,
+                to_state=LifecycleState.PENDING.value,
+                reason="Initial seed data creation",
+            )
+        await session.commit()
+        print(f"Initialized lifecycle for {len(all_devices)} devices")
 
     # --- SAMPLE DATA ---
     print("\n=== Creating Sample Data ===")
@@ -595,37 +700,36 @@ async def init_database():
             select(Job).where(Job.job_id == "job-sample-001")
         )
         if not result.scalar_one_or_none():
-            sample_job = Job(
+            sample_job = await create_job(
+                session,
                 job_id="job-sample-001",
                 action="Update POS payment config",
                 description="Sample job for schema validation",
-                priority=JobPriority.NORMAL,
-                status=JobStatus.COMPLETED,
                 site_id=sites[0].id,
                 device_id=first_device.id,
                 payload={"config_version": "1.0.0"},
                 created_by=admin_user.id,
+                status=JobStatus.COMPLETED,
                 completed_at=datetime.now(timezone.utc).replace(tzinfo=None),
             )
-            session.add(sample_job)
             await session.commit()
             await session.refresh(sample_job)
             print("Created sample job")
 
             # Sample Health Check
-            sample_health = HealthCheck(
-                id=1,
+            await create_health_check(
+                session,
                 device_id=first_device.id,
                 is_healthy=True,
                 response_time_ms=45,
                 status_code=200,
                 endpoint="/health",
-                timestamp=datetime.now(timezone.utc).replace(tzinfo=None),
+                id=1,
             )
-            session.add(sample_health)
 
             # Sample Audit Log
-            sample_audit = AuditLog(
+            await create_audit_log(
+                session,
                 event_type="job_created",
                 description=f"Job {sample_job.job_id} created for site {sites[0].site_id}",
                 user_id=admin_user.id,
@@ -634,7 +738,6 @@ async def init_database():
                 site_id=sites[0].id,
                 event_metadata={"action": "Update POS payment config"},
             )
-            session.add(sample_audit)
 
             # Sample Analytics
             session.add(

--- a/docs/agent-simulation.md
+++ b/docs/agent-simulation.md
@@ -6,6 +6,62 @@ Learn how HOMEPOT's realistic POS agent simulators work and how to manage them e
 
 HOMEPOT includes **23+ realistic POS agent simulators** that behave like real payment terminals, providing a comprehensive testing and demonstration environment.
 
+## Device Status Fields
+
+Every device in HOMEPOT has **three independent status fields** that together describe its current operational state:
+
+| Field | Values | Meaning |
+|-------|--------|---------|
+| `lifecycle_state` | `pending` → `active` → `suspended` → `retired` | Administrative lifecycle phase |
+| `connectivity_state` | `online`, `offline`, `unknown` | Computed from heartbeat recency (last 120s) |
+| `health_state` | `healthy`, `warning`, `error`, `unknown` | Derived from latest health check result |
+
+### Lifecycle State
+
+Devices start as `pending` when created by the seed script. When the agent manager starts and a `DeviceAgentSimulator` begins running for that device, the lifecycle transitions to `active` automatically:
+
+```python
+# In DeviceAgentSimulator.start() — backend/src/homepot/agents.py
+if device.lifecycle_state == LifecycleState.PENDING.value:
+    device.lifecycle_state = LifecycleState.ACTIVE.value
+```
+
+This simulates the real provisioning flow: a device is registered (pending), an agent picks it up and starts monitoring it (active).
+
+### Connectivity State
+
+Computed on every API response by `_compute_connectivity()` using `device.last_heartbeat_at`:
+
+- **`online`** — heartbeat received within the last 120 seconds
+- **`offline`** — heartbeat is older than 120 seconds
+- **`unknown`** — no heartbeat recorded (`last_heartbeat_at` is NULL)
+
+Every agent health check loop (runs every 2 seconds) updates `last_heartbeat_at` on the device record.
+
+### Health State
+
+Updated by the agent's health check loop on every cycle. Each health check simulates device diagnostics — CPU, memory, network latency, services status — and sets `health_state` to `healthy` (green) or `error` (red):
+
+```python
+# In DeviceAgentSimulator._run_health_check() — backend/src/homepot/agents.py
+device.health_state = (
+    HealthState.HEALTHY.value if is_healthy
+    else HealthState.ERROR.value
+)
+```
+
+### How They Display
+
+On the **Device Agents** page (`/agents`), the frontend shows:
+- **Status badge** (colored pill) — `lifecycle_state` (e.g., ACTIVE in green)
+- **Connectivity dot** (small glowing circle) — `connectivity_state` (green = online)
+- **Health icon** — `health_state` (green checkmark or red triangle)
+
+On the **Devices** page (`/devices`), each device card shows:
+- **Colored pill** — `lifecycle_state` (e.g., ACTIVE)
+- **Connectivity dot** — `connectivity_state` (online/offline/unknown)
+- **Device metrics** — from the latest health check data
+
 ## Agent State Machine
 
 Each agent follows a realistic lifecycle with the following states:

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -398,14 +398,14 @@ const api = {
     },
 
     getListAgents: async () => {
-      const response = await apiClient.get(`/agents/agents`);
+      const response = await apiClient.get(`/agents`);
       return response.data;
     },
     /**
      * Send push notification to agent
      */
     sendPush: async (deviceId, notificationData) => {
-      const response = await apiClient.post(`/agents/agents/${deviceId}/push`, notificationData);
+      const response = await apiClient.post(`/agents/${deviceId}/push`, notificationData);
       return response.data;
     },
 
@@ -413,7 +413,7 @@ const api = {
      * Start simulation
      */
     startSimulation: async () => {
-      const response = await apiClient.post('/agents/agents/simulation/start');
+      const response = await apiClient.post('/agents/simulation/start');
       return response.data;
     },
 
@@ -421,7 +421,7 @@ const api = {
      * Stop simulation
      */
     stopSimulation: async () => {
-      const response = await apiClient.post('/agents/agents/simulation/stop');
+      const response = await apiClient.post('/agents/simulation/stop');
       return response.data;
     },
 
@@ -429,7 +429,7 @@ const api = {
      * Get simulation status
      */
     getSimulationStatus: async () => {
-      const response = await apiClient.get('/agents/agents/simulation/status');
+      const response = await apiClient.get('/agents/simulation/status');
       return response.data;
     },
   },

--- a/scripts/init-postgresql.sh
+++ b/scripts/init-postgresql.sh
@@ -162,7 +162,8 @@ else
 fi
 
 # Run Python script to initialize database
-$PYTHON_CMD backend/utils/seed_data.py
+DATABASE__URL="postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}" \
+    $PYTHON_CMD backend/utils/seed_data.py
 
 # Check if initialization succeeded
 if [ $? -eq 0 ]; then

--- a/scripts/setup-pgpass.sh
+++ b/scripts/setup-pgpass.sh
@@ -23,7 +23,7 @@ DB_USER="homepot_user"
 DB_PASSWORD="homepot_dev_password"
 
 PGPASS_FILE="$HOME/.pgpass"
-PGPASS_ENTRY="${DB_HOST}:${DB_PORT}:${DB_NAME}:${DB_USER}:${DB_PASSWORD}"
+PGPASS_ENTRY="${DB_HOST}:${DB_PORT}:*:${DB_USER}:${DB_PASSWORD}"
 
 # Check if .pgpass already exists
 if [ -f "$PGPASS_FILE" ]; then

--- a/scripts/start-data-collection.sh
+++ b/scripts/start-data-collection.sh
@@ -20,11 +20,10 @@ fi
 # Check if .env exists
 if [ ! -f "$BACKEND_DIR/.env" ]; then
     echo "  .env file not found!"
-    echo "   Copying from .env.example..."
-    cp "$BACKEND_DIR/.env.example" "$BACKEND_DIR/.env"
-    echo "   Created .env file"
-    echo "   Please configure database credentials in .env"
+    echo "  Run the database init script to create it:"
+    echo "    ./scripts/init-postgresql.sh"
     echo ""
+    exit 1
 fi
 
 # Activate virtual environment
@@ -56,14 +55,18 @@ if [ $? -ne 0 ]; then
     echo "✗ Cannot connect to database!"
     echo "   1. Ensure PostgreSQL is running"
     echo "   2. Check credentials in .env file"
-    echo "   3. Run: python scripts/setup_database.py"
+    echo "   3. Run: ./scripts/init-postgresql.sh"
     exit 1
 fi
 
 # Check if port 8000 is in use
-if lsof -Pi :8000 -sTCP:LISTEN -t >/dev/null 2>&1; then
-    echo "Port 8000 is in use. Stopping existing process..."
-    kill -9 $(lsof -t -i:8000) 2>/dev/null || true
+PORT_PID=$(fuser 8000/tcp 2>/dev/null || lsof -ti :8000 2>/dev/null || true)
+if [ -n "$PORT_PID" ]; then
+    echo "Port 8000 is in use (PID $PORT_PID). Stopping existing process..."
+    kill "$PORT_PID" 2>/dev/null || true
+    sleep 2
+    # Force if still alive
+    kill -9 "$PORT_PID" 2>/dev/null || true
     sleep 1
     echo "✓ Port 8000 is now available"
 fi
@@ -116,7 +119,7 @@ echo "Starting uvicorn in background (logging to backend/homepot.log)..."
 > homepot.log
 
 # Start uvicorn in background
-uvicorn homepot.main:app --host 0.0.0.0 --port 8000 --reload > homepot.log 2>&1 &
+uvicorn homepot.main:app --host 0.0.0.0 --port 8000 > homepot.log 2>&1 &
 BACKEND_PID=$!
 
 echo "Backend started with PID $BACKEND_PID"


### PR DESCRIPTION
### Summary

Centralizes all database entity creation into `seed_factories.py` as a single source of truth, shared between the CLI seed script and test fixtures.

### Changes

- **`backend/src/homepot/seed_factories.py`** — new file with `build_*", `create_*` (async), `create_*_sync` factories for all 13 entity types
- **`backend/utils/seed_data.py`** — refactored to use factories; drops tables via `DROP TABLE ... CASCADE` to handle circular FK between `devices` and `lifecycle_epochs`
- **`backend/tests/test_authorization.py`** — refactored `seeded_db` fixture to use sync factories; removed 6 inline helper functions (~100 lines deleted)
- **`backend/src/homepot/agents.py`** — lifecycle transitions `pending→active` on `start()`; updates `last_heartbeat_at` and `health_state` in health check loop; fixes mypy type errors
- **`frontend/src/services/api.js`** — fixed 5 API paths with duplicate `/agents/` segment
- **`scripts/init-postgresql.sh`** — passes `DATABASE__URL` explicitly to seed script
- **`scripts/start-data-collection.sh`** — fixed .env handling, port detection, removed `--reload`
- **`scripts/setup-pgpass.sh`** — wildcard database field in .pgpass entry
- **`docs/agent-simulation.md`** — added Device Status Fields documentation
- **`backend/src/homepot/seed_factories.py`** — fixed all mypy type annotation warnings

### Verification

- flake8: 0 violations across `backend/src/homepot/`, `backend/tests/`, `ai/`, `uq/`
- mypy: 0 errors across 141 source files
- `test_authorization.py::TestUnauthenticated`: all 15 tests pass