### PR TITLE
fix: resolve AI database connection conflict (port 5432/15432)

### DIFF
--- a/ai/config.yaml
+++ b/ai/config.yaml
@@ -17,7 +17,7 @@ memory:
 
 database:
   # Use PostgreSQL from docker-compose
-  url: "postgresql://homepot_user:homepot_dev_password@localhost:5432/homepot_db"
+  url: "postgresql://homepot_user:homepot_dev_password@localhost:15432/homepot_db"
   # url: "sqlite:///homepot.db"
 
 anomaly_detection:

--- a/backend/src/homepot/config.py
+++ b/backend/src/homepot/config.py
@@ -14,11 +14,7 @@ class DatabaseSettings(BaseSettings):
     """Database configuration settings."""
 
     url: str = Field(
-        default=(
-            # "postgresql://homepot_user:homepot_dev_password@"
-            # "localhost:5432/homepot_db"
-            "postgresql://postgres:newpassword@localhost:5432/HP"
-        ),
+        default="postgresql://homepot_user:homepot_dev_password@localhost:15432/homepot_db",
         description="Database URL (PostgreSQL)",
     )
     echo_sql: bool = Field(default=False, description="Enable SQL query logging")


### PR DESCRIPTION
## Summary

Fixes the AI service and backend database connection failure caused by port conflict between host and Docker PostgreSQL instances.

## Root Cause

Two PostgreSQL instances were competing for port 5432:
- **Host PostgreSQL** (port 5432) — had no `homepot_db` database
- **Docker TimescaleDB** (port 5432 via Docker) — had `homepot_db` with full schema, but was inaccessible because host PostgreSQL was already bound

The `.env` pointed to `localhost:15432` but nothing was listening there. The hardcoded default in `config.py` pointed to a nonexistent database (`postgres:newpassword@localhost:5432/HP`).

## Changes

1. **`backend/src/homepot/config.py`** — Fixed default DB URL from `postgres:newpassword@localhost:5432/HP` to `homepot_user:homepot_dev_password@localhost:15432/homepot_db`
2. **`ai/config.yaml`** — Updated database URL from `localhost:5432` → `localhost:15432` to match the Docker PostgreSQL proxy
3. **Infrastructure** — Recreated `homepot-postgres` Docker container with host port `15432` (existing stale pg-proxy container removed)

## Verification

- black/isort/flake8/mypy: all clean (131 source files)
- Backend: healthy on `localhost:8000`
- AI service: healthy on `localhost:8001`, LLM connected
- AI query endpoint returns valid responses