### PR TITLE
feat: enhance Agents and Data Collection pages, add health_state to Site Detail

### DIFF
--- a/docs/device-lifecycle-and-ownership.md
+++ b/docs/device-lifecycle-and-ownership.md
@@ -475,6 +475,49 @@ PR 24: frontend/src/services/api.js — 3 new API methods:
 - devices.getCommands(deviceId) → GET /device/{did}/commands
 frontend/src/pages/Dashboard.jsx — Fetches dashboard.summary() and renders 4 aggregate stat cards (Total Devices, Online, Offline, Active) above the monitored resources.
 
+### Site Detail device table
+
+The Site Detail page (`frontend/src/pages/Sites/SiteDetail.jsx`) displays a table of devices associated with a site. Each row pulls from `GET /sites/{site_id}/devices`.
+
+| Column | Field | Display |
+|---|---|---|
+| **Name** | `device.name` | Clickable link to Device Detail page |
+| **Type** | `device.device_type` | Uppercase, underscores replaced with spaces |
+| **Status** | `lifecycle_state` + `connectivity_state` + `health_state` | Badge + connectivity dot + health pill (see colour reference below) |
+| **Enrollment** | `device.enrollment_method` | Pill: `self-enrolled` (purple) or `Pre-Provisioned` (blue) |
+| **Alerts** | `device.active_alerts` | Count with icon; green checkmark when zero |
+| **Last Seen** | `device.last_seen` + `device.last_heartbeat_at` | Timestamp plus heartbeat timestamp on a second line |
+| **Actions** | — | Edit and Delete icon buttons |
+
+#### Status column colour reference
+
+**Lifecycle badge (background + text):**
+
+| State | Colour |
+|---|---|
+| `active` | green-500 on green-500/10 |
+| `suspended` | orange-500 on orange-500/10 |
+| `unpaired` | gray-500 on gray-500/10 |
+| `pending`, `retired`, or unknown | yellow-500 on yellow-500/10 |
+
+**Connectivity dot (within the lifecycle badge):**
+
+| State | Colour |
+|---|---|
+| `online` | green-500 |
+| `offline` | gray-500 |
+| `unknown` | yellow-500 |
+
+**Health pill (separate pill next to the lifecycle badge):**
+
+| State | Colour |
+|---|---|
+| `healthy` | green-400 on green-500/10 |
+| `warning` | yellow-400 on yellow-500/10 |
+| `error` | red-400 on red-500/10 |
+| `maintenance` | blue-400 on blue-500/10 |
+| `unknown` or absent | gray-400 on gray-500/10 |
+
 ## Windows adaptation
 Only after the Linux real-device contract works:
 - implement stable Windows device identity;

--- a/frontend/src/pages/Agents.jsx
+++ b/frontend/src/pages/Agents.jsx
@@ -58,14 +58,18 @@ export default function AgentList() {
             aValue = a.connectivity_state === 'online' ? 1 : 0;
             bValue = b.connectivity_state === 'online' ? 1 : 0;
             break;
+          case 'lifecycle':
+            aValue = a.lifecycle_state === 'active' ? 2 : a.lifecycle_state === 'suspended' ? 1 : 0;
+            bValue = b.lifecycle_state === 'active' ? 2 : b.lifecycle_state === 'suspended' ? 1 : 0;
+            break;
           case 'health':
             // 1 for Healthy (has check), 0 for Unknown
             aValue = a.health_state === 'healthy' ? 1 : 0;
             bValue = b.health_state === 'healthy' ? 1 : 0;
             break;
           case 'last_seen':
-            aValue = a.last_heartbeat_at || '';
-            bValue = b.last_heartbeat_at || '';
+            aValue = a.last_health_check?.timestamp || '';
+            bValue = b.last_health_check?.timestamp || '';
             break;
           case 'device_id':
             aValue = a.device_id;
@@ -86,6 +90,24 @@ export default function AgentList() {
     }
     return sortableItems;
   }, [agents, sortConfig]);
+
+  const getLifecycleBadge = (state) => {
+    const s = state || 'unknown';
+    const colors = {
+      active: 'bg-green-500/10 text-green-400 border-green-500/20',
+      suspended: 'bg-orange-500/10 text-orange-400 border-orange-500/20',
+      unpaired: 'bg-gray-500/10 text-gray-400 border-gray-500/20',
+      retired: 'bg-gray-500/10 text-gray-400 border-gray-500/20',
+      pending: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+    };
+    return (
+      <span
+        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border ${colors[s] || 'bg-slate-500/10 text-slate-400 border-slate-500/20'}`}
+      >
+        {s}
+      </span>
+    );
+  };
 
   const getStatusBadge = (state) => {
     const isOnline = state === 'online';
@@ -242,6 +264,17 @@ export default function AgentList() {
                   </th>
                   <th
                     className="px-6 py-4 font-medium cursor-pointer hover:text-white transition-colors group"
+                    onClick={() => handleSort('lifecycle')}
+                  >
+                    <div className="flex items-center gap-2">
+                      Lifecycle
+                      <ArrowUpDown
+                        className={`h-3 w-3 ${sortConfig.key === 'lifecycle' ? 'text-teal-400' : 'text-slate-600 group-hover:text-slate-400'}`}
+                      />
+                    </div>
+                  </th>
+                  <th
+                    className="px-6 py-4 font-medium cursor-pointer hover:text-white transition-colors group"
                     onClick={() => handleSort('health')}
                   >
                     <div className="flex items-center gap-2">
@@ -268,7 +301,7 @@ export default function AgentList() {
               <tbody className="divide-y divide-slate-800">
                 {sortedAgents.length === 0 ? (
                   <tr>
-                    <td colSpan={5} className="px-6 py-12 text-center text-slate-500">
+                    <td colSpan={6} className="px-6 py-12 text-center text-slate-500">
                       No agents found. Register a device to get started.
                     </td>
                   </tr>
@@ -281,9 +314,10 @@ export default function AgentList() {
                     >
                       <td className="px-6 py-4 font-medium text-white">{agent.device_id}</td>
                       <td className="px-6 py-4">{getStatusBadge(agent.connectivity_state)}</td>
+                      <td className="px-6 py-4">{getLifecycleBadge(agent.lifecycle_state)}</td>
                       <td className="px-6 py-4">{getHealthIcon(agent.health_state)}</td>
                       <td className="px-6 py-4 text-slate-400 font-mono text-xs">
-                        {formatDate(agent.last_heartbeat_at)}
+                        {formatDate(agent.last_health_check?.timestamp)}
                       </td>
                       <td className="px-6 py-4 text-right">
                         <Button

--- a/frontend/src/pages/DataCollection.jsx
+++ b/frontend/src/pages/DataCollection.jsx
@@ -225,7 +225,7 @@ export default function DataCollection() {
                       v{agent.config_version}
                     </p>
                   </div>
-                  {getStatusBadge(agent.state)}
+                  {getStatusBadge(agent.connectivity_state)}
                 </CardHeader>
                 <CardContent className="p-3 pt-3 space-y-3">
                   <div className="grid grid-cols-2 gap-2 text-xs">

--- a/frontend/src/pages/Sites/SiteDetail.jsx
+++ b/frontend/src/pages/Sites/SiteDetail.jsx
@@ -292,28 +292,45 @@ export default function SiteDetail() {
                           {device.device_type?.replace(/_/g, ' ') || 'Unknown'}
                         </td>
                         <td className="p-4 align-middle">
-                          <span
-                            className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                              device.lifecycle_state === 'active'
-                                ? 'bg-green-500/10 text-green-500'
-                                : device.lifecycle_state === 'suspended'
-                                  ? 'bg-orange-500/10 text-orange-500'
-                                  : device.lifecycle_state === 'unpaired'
-                                    ? 'bg-gray-500/10 text-gray-500'
-                                    : 'bg-yellow-500/10 text-yellow-500'
-                            }`}
-                          >
+                          <div className="flex items-center gap-2">
                             <span
-                              className={`w-1.5 h-1.5 rounded-full ${
-                                device.connectivity_state === 'online'
-                                  ? 'bg-green-500'
-                                  : device.connectivity_state === 'offline'
-                                    ? 'bg-gray-500'
-                                    : 'bg-yellow-500'
+                              className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                                device.lifecycle_state === 'active'
+                                  ? 'bg-green-500/10 text-green-500'
+                                  : device.lifecycle_state === 'suspended'
+                                    ? 'bg-orange-500/10 text-orange-500'
+                                    : device.lifecycle_state === 'unpaired'
+                                      ? 'bg-gray-500/10 text-gray-500'
+                                      : 'bg-yellow-500/10 text-yellow-500'
                               }`}
-                            />
-                            {device.lifecycle_state || 'Unknown'}
-                          </span>
+                            >
+                              <span
+                                className={`w-1.5 h-1.5 rounded-full ${
+                                  device.connectivity_state === 'online'
+                                    ? 'bg-green-500'
+                                    : device.connectivity_state === 'offline'
+                                      ? 'bg-gray-500'
+                                      : 'bg-yellow-500'
+                                }`}
+                              />
+                              {device.lifecycle_state || 'Unknown'}
+                            </span>
+                            <span
+                              className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                                device.health_state === 'healthy'
+                                  ? 'bg-green-500/10 text-green-400'
+                                  : device.health_state === 'warning'
+                                    ? 'bg-yellow-500/10 text-yellow-400'
+                                    : device.health_state === 'error'
+                                      ? 'bg-red-500/10 text-red-400'
+                                      : device.health_state === 'maintenance'
+                                        ? 'bg-blue-500/10 text-blue-400'
+                                        : 'bg-gray-500/10 text-gray-400'
+                              }`}
+                            >
+                              {device.health_state || 'unknown'}
+                            </span>
+                          </div>
                         </td>
                         <td className="p-4 align-middle">
                           <span


### PR DESCRIPTION
## Summary

Three fixes across the Dashboard frontend:

### 1. Data Collection page — fix all agents showing 'Unknown'
`DataCollection.jsx` was reading `agent.state` which the backend `GET /agents` endpoint does not return (it returns `connectivity_state`, `lifecycle_state`, `health_state`). Every card fell through to the default case rendering `"Unknown"`. Changed to `agent.connectivity_state`.

### 2. Agents page — add Lifecycle State column
Added a new sortable **Lifecycle** column between Status and Health Check, showing `lifecycle_state` with colored badges (active=green, suspended=orange, pending=yellow, unpaired/retired=gray).

### 3. Agents page — fix empty Last Seen column
The Last Seen column was reading `agent.last_heartbeat_at` which does not exist in the `GET /agents` response. The timestamp is nested inside `last_health_check.timestamp`. Updated both display and sort to use the correct path.

### 4. Site Detail page — add health_state to Status column
Added `health_state` pill alongside the existing lifecycle badge and connectivity dot in the device table Status column. Color reference: healthy=green, warning=yellow, error=red, maintenance=blue, unknown=gray.

### 5. Documentation
Added Site Detail device table column reference with colour codes to `docs/device-lifecycle-and-ownership.md`.

## Verification
- black/isort/flake8/mypy: all clean
- `npx vite build`: passes