### PR TITLE
feat: enrolment intents page improvements

### DIFF
--- a/backend/tests/test_enrolment_intents.py
+++ b/backend/tests/test_enrolment_intents.py
@@ -1,0 +1,441 @@
+"""Tests for enrolment intent creation, listing, status transitions, and token operations."""
+
+import asyncio
+import os
+import tempfile
+from typing import Any, Generator
+
+from fastapi.testclient import TestClient
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from homepot.app.auth_utils import create_access_token
+from homepot.config import reload_settings
+import homepot.database
+from homepot.models import Base, EnrolmentIntent, EnrolmentIntentStatus, Site, User
+from homepot.seed_factories import (
+    create_site_membership_sync,
+    create_site_sync,
+    create_tenant_membership_sync,
+    create_tenant_sync,
+    create_user_sync,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def file_db(monkeypatch: Any) -> Generator[None, None, None]:
+    """Use a temporary SQLite file so sync+async engines share data between tests."""
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    db_url = f"sqlite:///{path}"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    monkeypatch.setenv("DATABASE__URL", db_url)
+    reload_settings()
+
+    if homepot.database._db_service is not None:
+        try:
+            asyncio.run(homepot.database._db_service.close())
+        except Exception:
+            pass
+        homepot.database._db_service = None
+
+    new_engine = create_engine(
+        db_url, connect_args={"check_same_thread": False}, pool_pre_ping=True
+    )
+    Base.metadata.create_all(bind=new_engine)
+    new_session_local = sessionmaker(bind=new_engine, autocommit=False, autoflush=False)
+
+    monkeypatch.setattr(homepot.database, "sync_engine", new_engine)
+    monkeypatch.setattr(homepot.database, "SessionLocal", new_session_local)
+
+    yield
+
+    new_engine.dispose()
+    if os.path.exists(path):
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+@pytest.fixture
+def client() -> Generator[TestClient, None, None]:
+    """Create a FastAPI TestClient with lifespan handlers for the async engine."""
+    from homepot.main import app
+
+    with TestClient(app) as tc:
+        yield tc
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _auth_header(email: str) -> dict[str, str]:
+    """Build an Authorization header with a bearer token for the given email."""
+    token = create_access_token({"sub": email})
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _intent_payload(site_id: str, **overrides: Any) -> dict[str, Any]:
+    """Build a minimal create-intent payload, merged with any overrides."""
+    payload = {
+        "site_id": site_id,
+        "enrolment_method": "pre-provisioned",
+        "expires_in_hours": 48,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _read_and_close(db: Any, site: Site, user: User) -> tuple[str, str]:
+    """Read email and site_id while the session is active, then close it."""
+    email_val = user.email
+    site_id = site.site_id
+    db.close()
+    return email_val, site_id
+
+
+def _seed_operator(db: Any) -> tuple[str, str]:
+    """Create tenant, site, user and operator-level membership. Returns (email, site_id)."""
+    tenant = create_tenant_sync(db, name="EI Test Tenant", slug="ei-test-tenant")
+    site = create_site_sync(
+        db, site_id="site-ei-1", name="Enrolment Intent Site", tenant_id=tenant.id
+    )
+    user = create_user_sync(
+        db,
+        email="operator@example.com",
+        username="operator",
+        password="pass",
+        tenant_id=tenant.id,
+    )
+    create_tenant_membership_sync(
+        db, user_id=user.id, tenant_id=tenant.id, role="admin"
+    )
+    create_site_membership_sync(db, user_id=user.id, site_id=site.id, role="operator")
+    db.commit()
+    db.refresh(site)
+    db.refresh(user)
+    return _read_and_close(db, site, user)
+
+
+def _seed_viewer(db: Any) -> tuple[str, str]:
+    """Create tenant, site, user and viewer-level membership. Returns (email, site_id)."""
+    tenant = create_tenant_sync(db, name="EI Viewer Tenant", slug="ei-viewer-tenant")
+    site = create_site_sync(
+        db, site_id="site-ei-viewer", name="Viewer Site", tenant_id=tenant.id
+    )
+    user = create_user_sync(
+        db,
+        email="viewer@example.com",
+        username="viewer",
+        password="pass",
+        tenant_id=tenant.id,
+    )
+    create_tenant_membership_sync(
+        db, user_id=user.id, tenant_id=tenant.id, role="viewer"
+    )
+    create_site_membership_sync(db, user_id=user.id, site_id=site.id, role="viewer")
+    db.commit()
+    db.refresh(site)
+    db.refresh(user)
+    return _read_and_close(db, site, user)
+
+
+def _seed_user_only(db: Any, email: str = "nosite@example.com") -> str:
+    """Create a user with no site memberships. Returns email string."""
+    user = create_user_sync(
+        db, email=email, username=email.split("@")[0], password="pass"
+    )
+    db.commit()
+    db.refresh(user)
+    email_val = user.email
+    db.close()
+    return email_val
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateEnrolmentIntent:
+    """Tests for POST /sites/{site_id}/enrolment-intents."""
+
+    def test_creates_intent_and_returns_claim_token(self, client: TestClient):
+        """Create a pending intent, verify the claim token is returned and the hash stored in the DB."""
+        db = homepot.database.SessionLocal()
+        email, site_id = _seed_operator(db)
+
+        response = client.post(
+            f"/api/v1/sites/{site_id}/enrolment-intents",
+            json=_intent_payload(site_id),
+            headers=_auth_header(email),
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["status"] == "success"
+        assert "claim_token" in data
+        assert len(data["claim_token"]) > 20
+        assert "intent_id" in data
+
+        db = homepot.database.SessionLocal()
+        intent = (
+            db.query(EnrolmentIntent)
+            .filter(EnrolmentIntent.intent_id == data["intent_id"])
+            .first()
+        )
+        assert intent is not None
+        assert intent.status == EnrolmentIntentStatus.PENDING
+        assert intent.claim_token_hash is not None
+        assert intent.claim_token_hash != data["claim_token"]
+        db.close()
+
+    def test_rejects_unauthenticated_request(self, client: TestClient):
+        """POST without an Authorization header returns 401."""
+        response = client.post(
+            "/api/v1/sites/site-ei-1/enrolment-intents",
+            json=_intent_payload("site-ei-1"),
+        )
+        assert response.status_code == 401
+
+    def test_rejects_insufficient_role(self, client: TestClient):
+        """A user with viewer (not operator) role gets 403."""
+        db = homepot.database.SessionLocal()
+        email, site_id = _seed_viewer(db)
+
+        response = client.post(
+            f"/api/v1/sites/{site_id}/enrolment-intents",
+            json=_intent_payload(site_id),
+            headers=_auth_header(email),
+        )
+        assert response.status_code == 403
+
+    def test_rejects_unknown_site(self, client: TestClient):
+        """POST for a non-existent site returns 404."""
+        db = homepot.database.SessionLocal()
+        email, _site_id = _seed_operator(db)
+
+        response = client.post(
+            "/api/v1/sites/does-not-exist/enrolment-intents",
+            json=_intent_payload("does-not-exist"),
+            headers=_auth_header(email),
+        )
+        assert response.status_code == 404
+
+    def test_accepts_optional_fields(self, client: TestClient):
+        """expected_device_identity and idempotency_key are persisted correctly."""
+        db = homepot.database.SessionLocal()
+        email, site_id = _seed_operator(db)
+
+        response = client.post(
+            f"/api/v1/sites/{site_id}/enrolment-intents",
+            json=_intent_payload(
+                site_id,
+                expires_in_hours=72,
+                expected_device_identity="SN-ABC-123",
+                idempotency_key="req-test-001",
+            ),
+            headers=_auth_header(email),
+        )
+        assert response.status_code == 200, response.text
+
+        db = homepot.database.SessionLocal()
+        intent = (
+            db.query(EnrolmentIntent)
+            .filter(EnrolmentIntent.idempotency_key == "req-test-001")
+            .first()
+        )
+        assert intent is not None
+        assert intent.expected_device_identity == "SN-ABC-123"
+        db.close()
+
+
+class TestListEnrolmentIntents:
+    """Tests for GET /sites/{site_id}/enrolment-intents."""
+
+    def test_lists_intents_for_site(self, client: TestClient):
+        """Return all intents for a site with total count; no claim_token_hash leaked."""
+        db = homepot.database.SessionLocal()
+        email, site_id = _seed_operator(db)
+
+        client.post(
+            f"/api/v1/sites/{site_id}/enrolment-intents",
+            json=_intent_payload(site_id),
+            headers=_auth_header(email),
+        )
+        client.post(
+            f"/api/v1/sites/{site_id}/enrolment-intents",
+            json=_intent_payload(site_id, expires_in_hours=24),
+            headers=_auth_header(email),
+        )
+
+        response = client.get(
+            f"/api/v1/sites/{site_id}/enrolment-intents",
+            headers=_auth_header(email),
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 2
+        assert len(data["intents"]) == 2
+        for intent in data["intents"]:
+            assert intent["status"] == "pending"
+            assert "intent_id" in intent
+            assert "expires_at" in intent
+            assert "created_at" in intent
+            assert "claim_token_hash" not in intent
+
+    def test_filters_by_status(self, client: TestClient):
+        """The ?status= query parameter filters returned intents."""
+        db = homepot.database.SessionLocal()
+        email, site_id = _seed_operator(db)
+
+        client.post(
+            f"/api/v1/sites/{site_id}/enrolment-intents",
+            json=_intent_payload(site_id),
+            headers=_auth_header(email),
+        )
+
+        response = client.get(
+            f"/api/v1/sites/{site_id}/enrolment-intents?status=consumed",
+            headers=_auth_header(email),
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 0
+        assert len(data["intents"]) == 0
+
+
+class TestUpdateEnrolmentIntentStatus:
+    """Tests for PUT /sites/{site_id}/enrolment-intents/{intent_id}."""
+
+    def _create_intent(self, email: str, site_id: str, client: TestClient) -> str:
+        """Create a pending intent and return its intent_id."""
+        resp = client.post(
+            f"/api/v1/sites/{site_id}/enrolment-intents",
+            json=_intent_payload(site_id),
+            headers=_auth_header(email),
+        )
+        return resp.json()["intent_id"]
+
+    def test_approve_pending_intent(self, client: TestClient):
+        """Transition a pending intent to approved."""
+        db = homepot.database.SessionLocal()
+        email, site_id = _seed_operator(db)
+        intent_id = self._create_intent(email, site_id, client)
+
+        response = client.put(
+            f"/api/v1/sites/{site_id}/enrolment-intents/{intent_id}",
+            json={"status": "approved"},
+            headers=_auth_header(email),
+        )
+        assert response.status_code == 200
+        assert response.json()["new_status"] == "approved"
+
+    def test_reject_pending_intent(self, client: TestClient):
+        """Transition a pending intent to rejected."""
+        db = homepot.database.SessionLocal()
+        email, site_id = _seed_operator(db)
+        intent_id = self._create_intent(email, site_id, client)
+
+        response = client.put(
+            f"/api/v1/sites/{site_id}/enrolment-intents/{intent_id}",
+            json={"status": "rejected"},
+            headers=_auth_header(email),
+        )
+        assert response.status_code == 200
+        assert response.json()["new_status"] == "rejected"
+
+    def test_revoke_pending_intent(self, client: TestClient):
+        """Transition a pending intent to revoked."""
+        db = homepot.database.SessionLocal()
+        email, site_id = _seed_operator(db)
+        intent_id = self._create_intent(email, site_id, client)
+
+        response = client.put(
+            f"/api/v1/sites/{site_id}/enrolment-intents/{intent_id}",
+            json={"status": "revoked"},
+            headers=_auth_header(email),
+        )
+        assert response.status_code == 200
+        assert response.json()["new_status"] == "revoked"
+
+    def test_rejects_update_when_not_pending(self, client: TestClient):
+        """Updating a non-pending intent (e.g. approved to revoked) returns 400."""
+        db = homepot.database.SessionLocal()
+        email, site_id = _seed_operator(db)
+        intent_id = self._create_intent(email, site_id, client)
+
+        client.put(
+            f"/api/v1/sites/{site_id}/enrolment-intents/{intent_id}",
+            json={"status": "approved"},
+            headers=_auth_header(email),
+        )
+        response = client.put(
+            f"/api/v1/sites/{site_id}/enrolment-intents/{intent_id}",
+            json={"status": "revoked"},
+            headers=_auth_header(email),
+        )
+        assert response.status_code == 400
+
+
+class TestRegenerateToken:
+    """Tests for POST /sites/{site_id}/enrolment-intents/{intent_id}/regenerate-token."""
+
+    def test_regenerates_token_for_pending_intent(self, client: TestClient):
+        """Regenerate a token returns a new token different from the original."""
+        db = homepot.database.SessionLocal()
+        email, site_id = _seed_operator(db)
+
+        create_resp = client.post(
+            f"/api/v1/sites/{site_id}/enrolment-intents",
+            json=_intent_payload(site_id),
+            headers=_auth_header(email),
+        )
+        data = create_resp.json()
+        intent_id = data["intent_id"]
+        original_token = data["claim_token"]
+
+        response = client.post(
+            f"/api/v1/sites/{site_id}/enrolment-intents/{intent_id}/regenerate-token",
+            headers=_auth_header(email),
+        )
+        assert response.status_code == 200
+        new_token = response.json()["claim_token"]
+        assert new_token != original_token
+        assert len(new_token) > 20
+
+
+class TestGetEnrolmentIntent:
+    """Tests for GET /sites/{site_id}/enrolment-intents/{intent_id}."""
+
+    def test_get_returns_intent_details(self, client: TestClient):
+        """Fetch intent details, verify no claim_token_hash is exposed."""
+        db = homepot.database.SessionLocal()
+        email, site_id = _seed_operator(db)
+
+        create_resp = client.post(
+            f"/api/v1/sites/{site_id}/enrolment-intents",
+            json=_intent_payload(site_id, expected_device_identity="SN-GET-TEST"),
+            headers=_auth_header(email),
+        )
+        intent_id = create_resp.json()["intent_id"]
+
+        response = client.get(
+            f"/api/v1/sites/{site_id}/enrolment-intents/{intent_id}",
+            headers=_auth_header(email),
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["intent_id"] == intent_id
+        assert data["status"] == "pending"
+        assert data["expected_device_identity"] == "SN-GET-TEST"
+        assert "claim_token_hash" not in data

--- a/docs/device-lifecycle-and-ownership.md
+++ b/docs/device-lifecycle-and-ownership.md
@@ -313,6 +313,36 @@ Backend:
 - Issue the API key only once.
 - Reject duplicate and concurrent claims.
 
+### Enrolment Intent creation flow (UI walkthrough)
+
+When an administrator clicks **Create Intent** on the Site Detail page:
+
+1. **Form submission**: A `POST /sites/{site_id}/enrolment-intents` is sent with optional fields (`expected_device_identity`, `expires_in_hours`, `idempotency_key`). The backend requires `operator`-level access on the target site.
+
+2. **Backend processing** (`EnrolmentIntentsEndpoint.py`):
+   - Creates a DB record with `status = pending` and a random UUID `intent_id`.
+   - Generates a cryptographically random claim token, hashes it with bcrypt, and stores only the hash.
+   - Returns the **plaintext claim token exactly once** in the response.
+
+3. **UI response**:
+   - The create form collapses.
+   - The intents list refreshes automatically.
+   - A **yellow result card** appears at the top showing the claim token in a monospace block, with the warning: *"It will not be shown again."*
+   - The new row appears in the table with a yellow **Pending** badge.
+
+4. **Subsequent actions** (per-row action buttons):
+   | Button | Status required | Effect |
+   |--------|----------------|--------|
+   | **Approve** | `pending` → `approved` | Token becomes active and ready for the installer to claim |
+   | **Reject** | `pending` → `rejected` | The intent is discarded, no further action possible |
+   | **Regen Token** | `pending` or `approved` | Generates a new token (old one becomes invalid), shown via browser `alert()` |
+   | **Revoke** | `pending` or `approved` → `revoked` | The intent is cancelled, token invalidated |
+
+5. **Important notes**:
+   - The claim token is only ever visible **at creation time** and **at regeneration time**. The backend stores only the bcrypt hash.
+   - The `alert()` for regeneration is a deliberate UX choice: unlike creation (which shows the token inline), regeneration is less common and the alert reinforces that the token must be saved immediately.
+   - The table marks expired intents with red text and an "Expired" label. Expired intents cannot be claimed.
+
 PR 6: Secure self-enrolment
 Replace caller-provided user_identity as authority:
 - Require authenticated user identity.

--- a/docs/enrolment-intents.md
+++ b/docs/enrolment-intents.md
@@ -1,0 +1,113 @@
+# Enrolment Intents
+
+Pre-provisioned enrolment intents allow an administrator to create a pending device slot for a site, generate a one-time claim token, and hand that token off to an installer. The installer's User App or agent submits the token to complete the enrolment — the administrator never needs to be physically present at the device.
+
+## Workflow
+
+```mermaid
+sequenceDiagram
+    actor Admin
+    participant Dashboard
+    participant Backend
+    participant Installer
+    participant Device
+
+    Admin->>Dashboard: Navigate to Site → Enrolment Intents
+    Admin->>Dashboard: Click "Create Intent"
+    Dashboard->>Backend: POST /sites/{id}/enrolment-intents
+    Backend-->>Dashboard: { claim_token, intent_id, status: "pending" }
+    Dashboard-->>Admin: Show claim token (one-time only)
+    Admin->>Installer: Send token out-of-band (email, SMS, portal)
+    Installer->>Device: Enter claim token on device
+    Device->>Backend: POST /enrolment-intents/{id}/claim { claim_token }
+    Backend-->>Device: { api_key, device_id, epoch_id }
+    Note over Backend: Token consumed atomically, lifecycle epoch created
+    Admin->>Dashboard: See intent status → "consumed"
+```
+
+## API Endpoints
+
+All endpoints require authentication. The `POST` and `PUT` endpoints require `operator`-level access on the target site.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/v1/sites/{site_id}/enrolment-intents` | Create a new enrolment intent |
+| `GET` | `/api/v1/sites/{site_id}/enrolment-intents` | List intents for a site (supports `?status=` filter) |
+| `GET` | `/api/v1/sites/{site_id}/enrolment-intents/{intent_id}` | Get intent details |
+| `PUT` | `/api/v1/sites/{site_id}/enrolment-intents/{intent_id}` | Update intent status (`approved`, `rejected`, `revoked`) |
+| `POST` | `/api/v1/sites/{site_id}/enrolment-intents/{intent_id}/regenerate-token` | Generate a new claim token, invalidating the old one |
+| `POST` | `/api/v1/enrolment-intents/{intent_id}/claim` | Claim a device via its one-time token (unauthenticated) |
+
+## Intent Statuses
+
+| Status | Meaning |
+|--------|---------|
+| `pending` | Intent created, no token action taken yet |
+| `approved` | Token activated and ready for the installer to claim |
+| `rejected` | Intent discarded by the administrator |
+| `consumed` | Token was successfully claimed by a device |
+| `expired` | The `expires_at` time has passed |
+| `revoked` | Administrator cancelled the intent |
+
+## Frontend
+
+The Enrolment Intents page is at `/sites/{site_id}/enrolment-intents`.
+
+### Layout
+
+- **Header**: "Back to Site" button, title, "Create Intent" button
+- **Stats cards**: 5 cards showing counts by status category (Active, Consumed, Expired, Revoked, Rejected)
+- **Status filter**: Dropdown to filter the table
+- **Table**: Columns — Intent ID (UUID), Status (coloured badge), Expires, Device Identity, Created, Actions
+
+### Actions per row
+
+| Button | Visible when | Effect |
+|--------|-------------|--------|
+| **Approve** | `pending` | Transitions to `approved` — token becomes claimable |
+| **Reject** | `pending` | Transitions to `rejected` — intent discarded |
+| **Regen Token** | `pending` or `approved` | Generates a new claim token, old one invalidated |
+| **Revoke** | `pending` or `approved` | Transitions to `revoked` — intent cancelled |
+
+### Creating an intent
+
+1. Click **Create Intent** to show the form
+2. Fill in optional fields:
+   - **Expected Device Identity** — e.g. serial number or hardware ID
+   - **Expires In (hours)** — default 48, max 8760
+   - **Idempotency Key** — for safe retries
+3. Click **Create Intent**
+4. The one-time **claim token** appears in a yellow card with the warning "It will not be shown again"
+5. The intents list refreshes automatically showing the new `pending` row
+
+### Important notes
+
+- The claim token is only visible **at creation time** and **at regeneration time**.
+- The backend stores only a bcrypt hash of the token — the plaintext cannot be recovered.
+- Expired intents are marked with red text and an "Expired" label in the table.
+- Status transitions are only allowed from `pending` (backend enforces this).
+
+## Testing
+
+A dedicated backend test file covers the full lifecycle:
+
+```bash
+cd backend
+python -m pytest tests/test_enrolment_intents.py -v
+```
+
+13 tests covering:
+- Creating intents with and without optional fields
+- Authentication and authorisation checks (401/403/404)
+- Listing and filtering by status
+- Status transitions: approve, reject, revoke
+- Rejecting invalid transitions (e.g. approved → revoked returns 400)
+- Token regeneration returns a new, different token
+- GET endpoint returns full details without exposing `claim_token_hash`
+
+## Related
+
+- [Device Lifecycle & Ownership](device-lifecycle-and-ownership.md) — canonical lifecycle contract
+- `frontend/src/pages/EnrolmentIntents/EnrolmentIntentsList.jsx` — React component
+- `backend/src/homepot/app/api/API_v1/Endpoints/EnrolmentIntentsEndpoint.py` — API implementation
+- `backend/tests/test_enrolment_intents.py` — test suite

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "@eslint/js": "^9.36.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
         "@vitejs/plugin-react": "^5.0.3",
@@ -46,6 +47,9 @@
         "tailwindcss": "^3.4.17",
         "vite": "^7.1.7",
         "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2099,6 +2103,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,6 +39,7 @@
     "@eslint/js": "^9.36.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.3",

--- a/frontend/src/pages/EnrolmentIntents/EnrolmentIntentsList.jsx
+++ b/frontend/src/pages/EnrolmentIntents/EnrolmentIntentsList.jsx
@@ -1,6 +1,32 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import api from '../../services/api';
+import {
+  ArrowLeft,
+  Loader2,
+  KeyRound,
+  CheckCircle,
+  XCircle,
+  Clock,
+  RotateCcw,
+  Ban,
+  Eye,
+  PlusCircle,
+  FileKey,
+} from 'lucide-react';
+import api from '@/services/api';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+const STATUS_META = {
+  pending: { label: 'Pending', color: 'bg-yellow-500/10 text-yellow-400' },
+  approved: { label: 'Approved', color: 'bg-green-500/10 text-green-400' },
+  rejected: { label: 'Rejected', color: 'bg-red-500/10 text-red-400' },
+  consumed: { label: 'Consumed', color: 'bg-blue-500/10 text-blue-400' },
+  expired: { label: 'Expired', color: 'bg-gray-500/10 text-gray-400' },
+  revoked: { label: 'Revoked', color: 'bg-purple-500/10 text-purple-400' },
+};
 
 export default function EnrolmentIntentsList() {
   const { id: siteId } = useParams();
@@ -36,13 +62,12 @@ export default function EnrolmentIntentsList() {
     fetchIntents();
   }, [siteId, statusFilter]);
 
-  const statusColors = {
-    pending: 'bg-yellow-100 text-yellow-800',
-    approved: 'bg-green-100 text-green-800',
-    rejected: 'bg-red-100 text-red-800',
-    consumed: 'bg-blue-100 text-blue-800',
-    expired: 'bg-gray-100 text-gray-800',
-    revoked: 'bg-purple-100 text-purple-800',
+  const counts = {
+    active: intents.filter((i) => i.status === 'pending' || i.status === 'approved').length,
+    consumed: intents.filter((i) => i.status === 'consumed').length,
+    expired: intents.filter((i) => i.status === 'expired').length,
+    revoked: intents.filter((i) => i.status === 'revoked').length,
+    rejected: intents.filter((i) => i.status === 'rejected').length,
   };
 
   const handleCreate = async (e) => {
@@ -114,224 +139,378 @@ export default function EnrolmentIntentsList() {
     }
   };
 
+  const isExpired = (expiresAt) => {
+    return expiresAt && new Date(expiresAt) < new Date();
+  };
+
   return (
-    <div className="p-6">
-      <div className="flex justify-between items-center mb-6">
-        <div>
-          <h1 className="text-2xl font-bold">Enrolment Intents</h1>
-          <p className="text-gray-600 text-sm">
-            Manage pre-provisioned device enrolment intents for this site
-          </p>
-        </div>
-        <div className="flex gap-3">
-          <button
+    <div className="h-full flex flex-col overflow-hidden bg-[#0b0e13] p-2">
+      <div className="container mx-auto max-w-7xl h-full flex flex-col">
+        {/* Header */}
+        <div className="shrink-0 mb-4 space-y-4">
+          <Button
+            variant="ghost"
             onClick={() => navigate(`/sites/${siteId}`)}
-            className="px-4 py-2 border border-gray-300 rounded-lg text-sm hover:bg-gray-50"
+            className="pl-0 hover:pl-1 transition-all text-gray-400 hover:text-white hover:bg-transparent"
           >
+            <ArrowLeft className="h-4 w-4 mr-2" />
             Back to Site
-          </button>
-          <button
-            onClick={() => {
-              setShowCreate(!showCreate);
-              setCreateResult(null);
-            }}
-            className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm hover:bg-blue-700"
-          >
-            {showCreate ? 'Cancel' : 'Create Intent'}
-          </button>
-        </div>
-      </div>
+          </Button>
 
-      {showCreate && (
-        <div className="mb-6 p-4 border border-gray-200 rounded-lg bg-gray-50">
-          <h3 className="font-semibold mb-3">Create New Enrolment Intent</h3>
-          <form onSubmit={handleCreate} className="space-y-3">
+          <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700">
-                Expected Device Identity (optional)
-              </label>
-              <input
-                type="text"
-                value={createForm.expected_device_identity}
-                onChange={(e) =>
-                  setCreateForm({ ...createForm, expected_device_identity: e.target.value })
-                }
-                placeholder="e.g. serial number or hardware ID"
-                className="mt-1 block w-full border border-gray-300 rounded-md p-2 text-sm"
-              />
+              <h1 className="text-3xl font-bold tracking-tight mb-1 text-white">
+                Enrolment Intents
+              </h1>
+              <p className="text-gray-400 text-sm">
+                Manage pre-provisioned device enrolment intents for this site
+              </p>
             </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700">Expires In (hours)</label>
-              <input
-                type="number"
-                value={createForm.expires_in_hours}
-                onChange={(e) =>
-                  setCreateForm({ ...createForm, expires_in_hours: parseInt(e.target.value) || 48 })
-                }
-                min={1}
-                max={8760}
-                className="mt-1 block w-full border border-gray-300 rounded-md p-2 text-sm"
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700">
-                Idempotency Key (optional)
-              </label>
-              <input
-                type="text"
-                value={createForm.idempotency_key}
-                onChange={(e) => setCreateForm({ ...createForm, idempotency_key: e.target.value })}
-                placeholder="e.g. req-abc-123"
-                className="mt-1 block w-full border border-gray-300 rounded-md p-2 text-sm"
-              />
-            </div>
-            <button
-              type="submit"
-              className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm hover:bg-blue-700"
+            <Button
+              onClick={() => {
+                setShowCreate(!showCreate);
+                setCreateResult(null);
+              }}
+              className="bg-transparent border text-blue-400 border-blue-400 hover:bg-blue-400/10"
             >
-              Create Intent
-            </button>
-          </form>
-        </div>
-      )}
+              {showCreate ? (
+                <>Cancel</>
+              ) : (
+                <>
+                  <PlusCircle className="h-4 w-4 mr-2" />
+                  Create Intent
+                </>
+              )}
+            </Button>
+          </div>
 
-      {createResult && (
-        <div className="mb-6 p-4 border border-yellow-300 rounded-lg bg-yellow-50">
-          <h3 className="font-semibold text-yellow-800 mb-2">Intent Created!</h3>
-          <p className="text-sm text-yellow-700 mb-1">
-            <strong>Claim Token:</strong>{' '}
-            <span className="font-mono bg-yellow-100 px-2 py-1 rounded">
-              {createResult.claim_token}
-            </span>
-          </p>
-          <p className="text-xs text-yellow-600">
-            Save this token securely. It will not be shown again.
-          </p>
+          {/* Stats Cards */}
+          <div className="grid grid-cols-1 md:grid-cols-5 gap-3">
+            <Card className="p-3 bg-card border-border">
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-yellow-500/10 rounded-full">
+                  <Clock className="h-4 w-4 text-yellow-500" />
+                </div>
+                <div>
+                  <p className="text-xs text-gray-400 font-medium">Active</p>
+                  <h3 className="text-lg font-bold text-white">{counts.active}</h3>
+                </div>
+              </div>
+            </Card>
+            <Card className="p-3 bg-card border-border">
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-blue-500/10 rounded-full">
+                  <CheckCircle className="h-4 w-4 text-blue-500" />
+                </div>
+                <div>
+                  <p className="text-xs text-gray-400 font-medium">Consumed</p>
+                  <h3 className="text-lg font-bold text-white">{counts.consumed}</h3>
+                </div>
+              </div>
+            </Card>
+            <Card className="p-3 bg-card border-border">
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-gray-500/10 rounded-full">
+                  <Ban className="h-4 w-4 text-gray-500" />
+                </div>
+                <div>
+                  <p className="text-xs text-gray-400 font-medium">Expired</p>
+                  <h3 className="text-lg font-bold text-white">{counts.expired}</h3>
+                </div>
+              </div>
+            </Card>
+            <Card className="p-3 bg-card border-border">
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-purple-500/10 rounded-full">
+                  <RotateCcw className="h-4 w-4 text-purple-500" />
+                </div>
+                <div>
+                  <p className="text-xs text-gray-400 font-medium">Revoked</p>
+                  <h3 className="text-lg font-bold text-white">{counts.revoked}</h3>
+                </div>
+              </div>
+            </Card>
+            <Card className="p-3 bg-card border-border">
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-red-500/10 rounded-full">
+                  <XCircle className="h-4 w-4 text-red-500" />
+                </div>
+                <div>
+                  <p className="text-xs text-gray-400 font-medium">Rejected</p>
+                  <h3 className="text-lg font-bold text-white">{counts.rejected}</h3>
+                </div>
+              </div>
+            </Card>
+          </div>
         </div>
-      )}
 
-      <div className="mb-4">
-        <select
-          value={statusFilter}
-          onChange={(e) => setStatusFilter(e.target.value)}
-          className="border border-gray-300 rounded-md p-2 text-sm"
-        >
-          <option value="">All Statuses</option>
-          <option value="pending">Pending</option>
-          <option value="approved">Approved</option>
-          <option value="rejected">Rejected</option>
-          <option value="consumed">Consumed</option>
-          <option value="expired">Expired</option>
-          <option value="revoked">Revoked</option>
-        </select>
-        <span className="ml-3 text-sm text-gray-500">{total} total</span>
+        {/* Create Form */}
+        {showCreate && (
+          <Card className="mb-4 p-4 bg-card border-border shrink-0">
+            <h3 className="font-semibold text-white mb-3 flex items-center gap-2">
+              <PlusCircle className="h-4 w-4 text-blue-400" />
+              Create New Enrolment Intent
+            </h3>
+            <form onSubmit={handleCreate} className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div className="space-y-1.5">
+                  <Label htmlFor="expected_device_identity" className="text-gray-300">
+                    Expected Device Identity <span className="text-gray-500">(optional)</span>
+                  </Label>
+                  <Input
+                    id="expected_device_identity"
+                    type="text"
+                    value={createForm.expected_device_identity}
+                    onChange={(e) =>
+                      setCreateForm({ ...createForm, expected_device_identity: e.target.value })
+                    }
+                    placeholder="e.g. serial number or hardware ID"
+                    className="bg-[#1a1f2e] border-gray-700 text-white placeholder:text-gray-500"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="expires_in_hours" className="text-gray-300">
+                    Expires In (hours)
+                  </Label>
+                  <Input
+                    id="expires_in_hours"
+                    type="number"
+                    value={createForm.expires_in_hours}
+                    onChange={(e) =>
+                      setCreateForm({
+                        ...createForm,
+                        expires_in_hours: parseInt(e.target.value) || 48,
+                      })
+                    }
+                    min={1}
+                    max={8760}
+                    className="bg-[#1a1f2e] border-gray-700 text-white placeholder:text-gray-500"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="idempotency_key" className="text-gray-300">
+                    Idempotency Key <span className="text-gray-500">(optional)</span>
+                  </Label>
+                  <Input
+                    id="idempotency_key"
+                    type="text"
+                    value={createForm.idempotency_key}
+                    onChange={(e) =>
+                      setCreateForm({ ...createForm, idempotency_key: e.target.value })
+                    }
+                    placeholder="e.g. req-abc-123"
+                    className="bg-[#1a1f2e] border-gray-700 text-white placeholder:text-gray-500"
+                  />
+                </div>
+              </div>
+              <div className="flex gap-2">
+                <Button type="submit" className="bg-blue-600 text-white hover:bg-blue-700">
+                  <KeyRound className="h-4 w-4 mr-2" />
+                  Create Intent
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => setShowCreate(false)}
+                  className="text-gray-400 hover:text-white"
+                >
+                  Cancel
+                </Button>
+              </div>
+            </form>
+          </Card>
+        )}
+
+        {/* Token Result */}
+        {createResult && (
+          <Card className="mb-4 p-4 border border-yellow-500/30 bg-yellow-500/5 shrink-0">
+            <div className="flex items-start gap-3">
+              <FileKey className="h-5 w-5 text-yellow-400 mt-0.5 shrink-0" />
+              <div>
+                <h3 className="font-semibold text-yellow-400 mb-2">Intent Created Successfully</h3>
+                <p className="text-sm text-yellow-300/80 mb-2">
+                  Share this one-time claim token with the installer. It will not be shown again.
+                </p>
+                <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-md px-4 py-2.5">
+                  <code className="text-sm text-yellow-200 font-mono break-all">
+                    {createResult.claim_token}
+                  </code>
+                </div>
+              </div>
+            </div>
+          </Card>
+        )}
+
+        {/* Filter */}
+        <div className="flex items-center gap-3 mb-4 shrink-0">
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="h-9 rounded-md border border-gray-700 bg-[#1a1f2e] text-gray-300 px-3 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          >
+            <option value="">All Statuses</option>
+            <option value="pending">Pending</option>
+            <option value="approved">Approved</option>
+            <option value="rejected">Rejected</option>
+            <option value="consumed">Consumed</option>
+            <option value="expired">Expired</option>
+            <option value="revoked">Revoked</option>
+          </select>
+          <span className="text-sm text-gray-500">{total} total</span>
+        </div>
+
+        {/* Table */}
+        <div className="flex-1 min-h-0 flex flex-col">
+          {loading ? (
+            <div className="flex justify-center items-center h-64">
+              <Loader2 className="h-8 w-8 animate-spin text-primary" />
+            </div>
+          ) : intents.length === 0 ? (
+            <Card className="p-8 text-center text-gray-400 border-dashed border-border bg-card">
+              <KeyRound className="h-8 w-8 mx-auto mb-3 opacity-50" />
+              <p className="mb-1">No enrolment intents found</p>
+              <p className="text-sm text-gray-500">
+                Create one to get started with pre-provisioned device enrolment.
+              </p>
+              <Button
+                onClick={() => {
+                  setShowCreate(true);
+                  setCreateResult(null);
+                }}
+                className="mt-4 bg-transparent border text-blue-400 border-blue-400 hover:bg-blue-400/10"
+              >
+                <PlusCircle className="h-4 w-4 mr-2" />
+                Create Intent
+              </Button>
+            </Card>
+          ) : (
+            <div className="rounded-md border border-border bg-card flex-1 overflow-hidden relative">
+              <div className="absolute inset-0 overflow-auto">
+                <table className="w-full caption-bottom text-sm text-left">
+                  <thead className="[&_tr]:border-b border-border sticky top-0 bg-card z-10">
+                    <tr className="border-b border-border transition-colors hover:bg-muted/50">
+                      <th className="h-12 px-4 align-middle font-medium text-gray-400">
+                        Intent ID
+                      </th>
+                      <th className="h-12 px-4 align-middle font-medium text-gray-400">Status</th>
+                      <th className="h-12 px-4 align-middle font-medium text-gray-400">Expires</th>
+                      <th className="h-12 px-4 align-middle font-medium text-gray-400">
+                        Device Identity
+                      </th>
+                      <th className="h-12 px-4 align-middle font-medium text-gray-400">Created</th>
+                      <th className="h-12 px-4 align-middle font-medium text-gray-400 text-right">
+                        Actions
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="[&_tr:last-child]:border-0">
+                    {intents.map((intent) => {
+                      const meta = STATUS_META[intent.status] || STATUS_META.pending;
+                      const expired = isExpired(intent.expires_at);
+                      return (
+                        <tr
+                          key={intent.id}
+                          className="border-b border-border transition-colors hover:bg-muted/50"
+                        >
+                          <td className="p-4 align-middle font-mono text-xs text-gray-300">
+                            {intent.intent_id}
+                          </td>
+                          <td className="p-4 align-middle">
+                            <span
+                              className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${meta.color}`}
+                            >
+                              {meta.label}
+                            </span>
+                          </td>
+                          <td className="p-4 align-middle">
+                            <div className="flex flex-col">
+                              <span
+                                className={`text-sm ${expired ? 'text-red-400' : 'text-gray-300'}`}
+                              >
+                                {intent.expires_at
+                                  ? new Date(intent.expires_at).toLocaleString()
+                                  : '-'}
+                              </span>
+                              {expired && (
+                                <span className="text-[10px] text-red-500 font-medium">
+                                  Expired
+                                </span>
+                              )}
+                            </div>
+                          </td>
+                          <td className="p-4 align-middle text-sm text-gray-300">
+                            {intent.expected_device_identity || (
+                              <span className="text-gray-500 italic">Not specified</span>
+                            )}
+                          </td>
+                          <td className="p-4 align-middle text-sm text-gray-300">
+                            {intent.created_at ? new Date(intent.created_at).toLocaleString() : '-'}
+                          </td>
+                          <td className="p-4 align-middle text-right">
+                            <div className="flex justify-end gap-1.5">
+                              {intent.status === 'pending' && (
+                                <>
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => handleApprove(intent.intent_id)}
+                                    className="h-7 px-2 text-green-400 hover:text-green-300 hover:bg-green-500/10"
+                                  >
+                                    <CheckCircle className="h-3.5 w-3.5 mr-1" />
+                                    Approve
+                                  </Button>
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => handleReject(intent.intent_id)}
+                                    className="h-7 px-2 text-red-400 hover:text-red-300 hover:bg-red-500/10"
+                                  >
+                                    <XCircle className="h-3.5 w-3.5 mr-1" />
+                                    Reject
+                                  </Button>
+                                </>
+                              )}
+                              {(intent.status === 'pending' || intent.status === 'approved') && (
+                                <>
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => handleRegenerate(intent.intent_id)}
+                                    disabled={regenerating === intent.intent_id}
+                                    className="h-7 px-2 text-yellow-400 hover:text-yellow-300 hover:bg-yellow-500/10 disabled:opacity-50"
+                                  >
+                                    <RotateCcw className="h-3.5 w-3.5 mr-1" />
+                                    {regenerating === intent.intent_id ? '...' : 'Regen Token'}
+                                  </Button>
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => handleRevoke(intent.intent_id)}
+                                    className="h-7 px-2 text-purple-400 hover:text-purple-300 hover:bg-purple-500/10"
+                                  >
+                                    <Ban className="h-3.5 w-3.5 mr-1" />
+                                    Revoke
+                                  </Button>
+                                </>
+                              )}
+                              {intent.status === 'consumed' && (
+                                <span className="text-xs text-gray-500 italic flex items-center gap-1 px-2">
+                                  <CheckCircle className="h-3 w-3 text-blue-400" />
+                                  Consumed
+                                </span>
+                              )}
+                            </div>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </div>
       </div>
-
-      {loading ? (
-        <div className="text-center py-10 text-gray-500">Loading...</div>
-      ) : intents.length === 0 ? (
-        <div className="text-center py-10 text-gray-500">
-          No enrolment intents found. Create one to get started.
-        </div>
-      ) : (
-        <div className="overflow-x-auto">
-          <table className="min-w-full bg-white border border-gray-200 rounded-lg">
-            <thead>
-              <tr className="bg-gray-50 border-b">
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                  Intent ID
-                </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                  Status
-                </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                  Expires
-                </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                  Device Identity
-                </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                  Created
-                </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {intents.map((intent) => (
-                <tr key={intent.id} className="border-b hover:bg-gray-50">
-                  <td className="px-4 py-3 text-sm font-mono">{intent.intent_id}</td>
-                  <td className="px-4 py-3">
-                    <span
-                      className={`px-2 py-1 rounded-full text-xs font-medium ${
-                        statusColors[intent.status] || 'bg-gray-100 text-gray-800'
-                      }`}
-                    >
-                      {intent.status}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-sm">
-                    {intent.expires_at ? (
-                      <span
-                        className={new Date(intent.expires_at) < new Date() ? 'text-red-600' : ''}
-                      >
-                        {new Date(intent.expires_at).toLocaleString()}
-                      </span>
-                    ) : (
-                      '-'
-                    )}
-                  </td>
-                  <td className="px-4 py-3 text-sm">{intent.expected_device_identity || '-'}</td>
-                  <td className="px-4 py-3 text-sm">
-                    {intent.created_at ? new Date(intent.created_at).toLocaleString() : '-'}
-                  </td>
-                  <td className="px-4 py-3 text-sm">
-                    <div className="flex gap-2">
-                      {intent.status === 'pending' && (
-                        <>
-                          <button
-                            onClick={() => handleApprove(intent.intent_id)}
-                            className="px-3 py-1 bg-green-600 text-white rounded text-xs hover:bg-green-700"
-                          >
-                            Approve
-                          </button>
-                          <button
-                            onClick={() => handleReject(intent.intent_id)}
-                            className="px-3 py-1 bg-red-600 text-white rounded text-xs hover:bg-red-700"
-                          >
-                            Reject
-                          </button>
-                        </>
-                      )}
-                      {(intent.status === 'pending' || intent.status === 'approved') && (
-                        <>
-                          <button
-                            onClick={() => handleRegenerate(intent.intent_id)}
-                            disabled={regenerating === intent.intent_id}
-                            className="px-3 py-1 bg-yellow-600 text-white rounded text-xs hover:bg-yellow-700 disabled:opacity-50"
-                          >
-                            {regenerating === intent.intent_id ? '...' : 'Regen Token'}
-                          </button>
-                          <button
-                            onClick={() => handleRevoke(intent.intent_id)}
-                            className="px-3 py-1 bg-purple-600 text-white rounded text-xs hover:bg-purple-700"
-                          >
-                            Revoke
-                          </button>
-                        </>
-                      )}
-                      {intent.status === 'consumed' && (
-                        <span className="text-xs text-gray-400 italic">Consumed</span>
-                      )}
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/tests/unit/EnrolmentIntentsList.test.jsx
+++ b/frontend/tests/unit/EnrolmentIntentsList.test.jsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import api from '@/services/api';
+import EnrolmentIntentsList from '@/pages/EnrolmentIntents/EnrolmentIntentsList';
+
+vi.mock('@/services/api');
+
+const mockIntents = [
+  {
+    id: 1,
+    intent_id: '550e8400-e29b-41d4-a716-446655440001',
+    site_id: 'site-001',
+    tenant_id: null,
+    enrolment_method: 'pre-provisioned',
+    expected_device_identity: 'SN-ABC-001',
+    expires_at: new Date(Date.now() + 86400000).toISOString(),
+    consumed_at: null,
+    creator_id: 1,
+    status: 'pending',
+    idempotency_key: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  },
+  {
+    id: 2,
+    intent_id: '550e8400-e29b-41d4-a716-446655440002',
+    site_id: 'site-001',
+    tenant_id: null,
+    enrolment_method: 'pre-provisioned',
+    expected_device_identity: null,
+    expires_at: new Date(Date.now() - 86400000).toISOString(),
+    consumed_at: null,
+    creator_id: 1,
+    status: 'approved',
+    idempotency_key: 'req-abc-123',
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  },
+  {
+    id: 3,
+    intent_id: '550e8400-e29b-41d4-a716-446655440003',
+    site_id: 'site-001',
+    tenant_id: null,
+    enrolment_method: 'pre-provisioned',
+    expected_device_identity: 'SN-DEF-002',
+    expires_at: null,
+    consumed_at: new Date().toISOString(),
+    creator_id: 1,
+    status: 'consumed',
+    idempotency_key: null,
+    created_at: new Date(Date.now() - 604800000).toISOString(),
+    updated_at: new Date().toISOString(),
+  },
+];
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/sites/site-001/enrolment-intents']}>
+      <Routes>
+        <Route path="/sites/:id/enrolment-intents" element={<EnrolmentIntentsList />} />
+        <Route path="/sites/:id" element={<div>Site Detail Page</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('EnrolmentIntentsList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.enrolmentIntents.list.mockResolvedValue({ intents: mockIntents, total: 3 });
+  });
+
+  it('renders the page title and navigation', async () => {
+    renderPage();
+    expect(await screen.findByText('Enrolment Intents')).toBeInTheDocument();
+    expect(screen.getByText('Back to Site')).toBeInTheDocument();
+  });
+
+  it('renders stats cards with correct counts', async () => {
+    renderPage();
+    await screen.findByText('Enrolment Intents');
+    const allActive = screen.getAllByText('Active');
+    const allConsumed = screen.getAllByText('Consumed');
+    const allExpired = screen.getAllByText('Expired');
+    const allRevoked = screen.getAllByText('Revoked');
+    const allRejected = screen.getAllByText('Rejected');
+    expect(allActive.length).toBeGreaterThanOrEqual(1);
+    expect(allConsumed.length).toBeGreaterThanOrEqual(1);
+    expect(allExpired.length).toBeGreaterThanOrEqual(1);
+    expect(allRevoked.length).toBeGreaterThanOrEqual(1);
+    expect(allRejected.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders all intents in the table', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('SN-ABC-001')).toBeInTheDocument();
+      expect(screen.getByText('SN-DEF-002')).toBeInTheDocument();
+    });
+  });
+
+  it('shows Approve and Reject buttons for pending intents', async () => {
+    renderPage();
+    await screen.findByText('Enrolment Intents');
+    const approveButtons = screen.getAllByText('Approve');
+    const rejectButtons = screen.getAllByText('Reject');
+    expect(approveButtons.length).toBeGreaterThanOrEqual(1);
+    expect(rejectButtons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows Consumed label for consumed intents', async () => {
+    renderPage();
+    await screen.findByText('Enrolment Intents');
+    const consumedElements = screen.getAllByText('Consumed');
+    expect(consumedElements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows expired indicator for past expiration dates', async () => {
+    renderPage();
+    await screen.findByText('Enrolment Intents');
+    const expiredLabels = screen.getAllByText('Expired');
+    expect(expiredLabels.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows empty state when no intents exist', async () => {
+    api.enrolmentIntents.list.mockResolvedValue({ intents: [], total: 0 });
+    renderPage();
+    expect(await screen.findByText('No enrolment intents found')).toBeInTheDocument();
+  });
+
+  it('shows loading spinner while fetching', () => {
+    api.enrolmentIntents.list.mockImplementation(() => new Promise(() => {}));
+    renderPage();
+    const spinner = document.querySelector('.animate-spin');
+    expect(spinner).toBeInTheDocument();
+  });
+
+  describe('intent creation', () => {
+    it('create form appears when clicking Create Intent', async () => {
+      renderPage();
+      const createBtn = await screen.findByText('Create Intent');
+      await userEvent.click(createBtn);
+      await waitFor(() => {
+        expect(screen.getByText('Create New Enrolment Intent')).toBeInTheDocument();
+      });
+    });
+
+    it('calls API and shows claim token on successful creation', async () => {
+      const claimToken = 'tok_random_abc123_def456';
+      api.enrolmentIntents.create.mockResolvedValue({
+        claim_token: claimToken,
+        intent_id: '550e8400-e29b-41d4-a716-446655440099',
+        status: 'pending',
+      });
+
+      renderPage();
+      await screen.findByText('Enrolment Intents');
+
+      const createBtn = screen.getByText('Create Intent');
+      await userEvent.click(createBtn);
+      await screen.findByText('Create New Enrolment Intent');
+
+      const submitBtn = screen.getByText('Create Intent', { selector: 'button[type="submit"]' });
+      await userEvent.click(submitBtn);
+
+      await waitFor(() => {
+        expect(api.enrolmentIntents.create).toHaveBeenCalledWith('site-001', {
+          enrolment_method: 'pre-provisioned',
+          expires_in_hours: 48,
+        });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Intent Created Successfully')).toBeInTheDocument();
+        expect(screen.getByText(claimToken)).toBeInTheDocument();
+        expect(screen.getByText(/will not be shown again/i)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -152,6 +152,7 @@ nav:
   - Layer 5 - Edge Layer:
       - Device Management:
           - Lifecycle & Ownership: device-lifecycle-and-ownership.md
+          - Enrolment Intents: enrolment-intents.md
           - Registration: device-registration.md
           - Metrics Collection: device-metrics-collection.md
           - Peripheral Discovery: peripheral-discovery.md


### PR DESCRIPTION
## Summary

Enhances the Enrolment Intents page with a dark-themed UI, comprehensive test coverage, and documentation.

## Changes

### Frontend
- Rewrote `EnrolmentIntentsList.jsx` with dark theme (`bg-[#0b0e13]`), shadcn components, lucide-react icons, 5 stats cards, and token result card
- Added 10 unit tests in `frontend/tests/unit/EnrolmentIntentsList.test.jsx`
- Installed `@testing-library/user-event` dependency

### Backend
- Added 13 tests in `backend/tests/test_enrolment_intents.py` covering create, list, status transitions, token regeneration, auth, and validation

### Documentation
- Created `docs/enrolment-intents.md` with workflow diagram, API reference, status transition table, and frontend walkthrough
- Updated `docs/device-lifecycle-and-ownership.md` with enrolment intent UI walkthrough
- Added enrolment-intents.md to `mkdocs.yml`

### Linting
- All flake8 D1xx violations resolved
- Black formatting passes cleanly