### PR TITLE
feat: Environment-agnostic configuration

### DIFF
--- a/backend/src/homepot/agent/cli.py
+++ b/backend/src/homepot/agent/cli.py
@@ -79,6 +79,11 @@ def run(
         dir_okay=False,
         readable=True,
     ),
+    backend_url: Optional[str] = typer.Option(
+        None,
+        "--backend-url",
+        help="Backend API URL override (e.g. https://api.homepot.example.com)",
+    ),
 ) -> None:
     """Run the agent runtime (registration, heartbeat, telemetry).
 
@@ -86,6 +91,8 @@ def run(
     """
     if config:
         os.environ["HOMEPOT_AGENT_CONFIG"] = str(config.resolve())
+    if backend_url:
+        os.environ["HOMEPOT_BACKEND_URL"] = backend_url
     ensure_identity()
     asyncio.run(run_agent())
 

--- a/backend/src/homepot/agent/real_device_agent.py
+++ b/backend/src/homepot/agent/real_device_agent.py
@@ -87,6 +87,11 @@ def load_agent_config() -> Dict[str, Any]:
         if os_details:
             data["os_details"] = os_details
 
+    # CLI --backend-url or HOMEPOT_BACKEND_URL env var trump everything
+    env_backend_url = os.environ.get("HOMEPOT_BACKEND_URL")
+    if env_backend_url:
+        data["backend_url"] = idna_encode_url(env_backend_url)
+
     data.setdefault("heartbeat_interval_seconds", 30)
     data.setdefault("telemetry_interval_seconds", 30)
     data.setdefault("retry_flush_interval_seconds", 60)

--- a/backend/src/homepot/app/main.py
+++ b/backend/src/homepot/app/main.py
@@ -61,16 +61,10 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # ty
 # Create tables
 # database.CreateTables()
 
-# CORS settings
+# CORS settings — origins from CORS_ORIGINS env var, fall back to localhost defaults
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:5173",
-        "http://localhost:5174",
-        "http://localhost:3000",
-        "http://127.0.0.1:5173",
-        "http://127.0.0.1:5174",
-    ],
+    allow_origins=cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/src/homepot/config.py
+++ b/backend/src/homepot/config.py
@@ -138,23 +138,17 @@ class LoggingSettings(BaseSettings):
 
 
 class CorsSettings(BaseSettings):
-    """Existing fields."""
+    """CORS configuration — read from CORS_ORIGINS env var or use defaults."""
 
-    # CORS Configuration
     cors_origins: Union[List[str], str] = Field(
         default=[
-            "http://localhost:3000",
-            "http://localhost:8080",
-            "http://127.0.0.1:3001",
-            "http://127.0.0.1:3000",
-            "http://192.168.0.112:3000",
-            "http://192.168.0.112:3001",
-            "http://192.168.0.112:8080",
-            "http://localhost:5173/",
             "http://localhost:5173",
-            "http://192.168.0.253:5173",
+            "http://localhost:5174",
+            "http://localhost:3000",
+            "http://127.0.0.1:5173",
+            "http://127.0.0.1:5174",
         ],
-        description="Allowed CORS origins",
+        description="Allowed CORS origins (comma-separated string or JSON list)",
     )
 
     @field_validator("cors_origins", mode="before")

--- a/backend/src/homepot/main.py
+++ b/backend/src/homepot/main.py
@@ -29,6 +29,7 @@ from homepot.agents import get_agent_manager, stop_agent_manager
 from homepot.app.api.API_v1.Api import api_v1_router
 from homepot.audit import AuditEventType, get_audit_logger
 from homepot.client import HomepotClient
+from homepot.config import get_settings
 from homepot.database import close_database_service, get_database_service
 from homepot.models import JobPriority
 from homepot.orchestrator import get_job_orchestrator, stop_job_orchestrator
@@ -313,16 +314,11 @@ async def count_requests(
     return response
 
 
-# Add CORS middleware
+# Add CORS middleware — origins from CORS_ORIGINS env var, fall back to localhost defaults
+_cors_origins = get_settings().cors.cors_origins
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:5173",
-        "http://localhost:5174",
-        "http://localhost:3000",
-        "http://127.0.0.1:5173",
-        "http://127.0.0.1:5174",
-    ],
+    allow_origins=_cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,5 +1,9 @@
 # HOMEPOT Frontend Environment Variables
 # Copy this file to .env.local and update with your values
+#
+# For a dev server deployment, override VITE_API_BASE_URL and VITE_WS_URL:
+#   VITE_API_BASE_URL=https://api.homepot.example.com
+#   VITE_WS_URL=wss://api.homepot.example.com
 
 # Backend API Configuration
 VITE_API_BASE_URL=http://localhost:8000

--- a/user_app/.env.example
+++ b/user_app/.env.example
@@ -1,1 +1,7 @@
+# HOMEPOT User App Environment Variables
+# Copy to .env and adjust for your environment.
+#
+# For a dev server deployment, override with the real backend URL:
+#   VITE_API_BASE_URL=https://api.homepot.example.com/api/v1
+
 VITE_API_BASE_URL=http://localhost:8000/api/v1


### PR DESCRIPTION
## Summary

Makes CORS origins, API URLs, and agent backend URL configurable via environment variables instead of hardcoded localhost values, so the same build targets localhost, a dev server, or production.

## Changes

### Backend CORS (both main.py files)
- **`backend/src/homepot/main.py`** — replaced hardcoded `allow_origins` with `get_settings().cors.cors_origins` (reads from `CORS_ORIGINS` env var, falls back to localhost defaults)
- **`backend/src/homepot/app/main.py`** — same; the already-read `cors_origins` variable is now used instead of a second hardcoded list

### Config defaults cleaned up
- **`backend/src/homepot/config.py`** — `CorsSettings.default` simplified to match the localhost list used in main.py (removed stale IP addresses)

### Agent CLI
- **`backend/src/homepot/agent/cli.py`** — `homepot-agent run` now accepts `--backend-url` flag
- **`backend/src/homepot/agent/real_device_agent.py`** — `load_agent_config()` reads `HOMEPOT_BACKEND_URL` env var as highest-priority override

### Frontend / User App docs
- **`frontend/.env.example`** — commented instructions for dev server override
- **`user_app/.env.example`** — same

## Usage

### Dev server
```bash
# Backend
CORS_ORIGINS=https://dashboard.homepot.dev https://agents.homepot.dev \
DATABASE__URL=postgresql://user:pass@dbhost:5432/homepot \
ENABLE_AGENT_SIMULATION=false \
uvicorn homepot.main:app

# Agent
homepot-agent run --backend-url https://api.homepot.dev

# Frontend
VITE_API_BASE_URL=https://api.homepot.dev
```

### Localhost (unchanged — defaults work out of the box)
```bash
uvicorn homepot.main:app  # CORS defaults to localhost:5173, etc.
homepot-agent run          # backend_url defaults to http://localhost:8000
```