### PR TITLE
feat: Add is_simulated flag to Device model

### DIFF
--- a/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
@@ -364,6 +364,7 @@ async def list_device(
                             else "inactive"
                         ),
                         "is_monitored": device.is_monitored,
+                        "is_simulated": device.is_simulated,
                         "created_at": (
                             device.created_at.isoformat() if device.created_at else None
                         ),
@@ -507,6 +508,7 @@ async def get_device(
                     "network_monitoring": False,
                 },
                 "is_monitored": device.is_monitored,
+                "is_simulated": device.is_simulated,
                 "created_at": (
                     device.created_at.isoformat() if device.created_at else None
                 ),
@@ -1776,6 +1778,7 @@ async def get_devices_by_site(
                 "status": d.status,
                 "ip_address": d.ip_address,
                 "is_monitored": d.is_monitored,
+                "is_simulated": d.is_simulated,
                 "active_alerts": alert_map.get(d.device_id, 0),
                 "enrollment_method": getattr(d, "enrollment_method", "pre-provisioned"),
                 "last_seen": d.last_seen.isoformat() if d.last_seen else None,

--- a/backend/src/homepot/migrations/versions/20260726_add_is_simulated_to_devices.py
+++ b/backend/src/homepot/migrations/versions/20260726_add_is_simulated_to_devices.py
@@ -19,7 +19,12 @@ def upgrade() -> None:
     """Add is_simulated column to devices table."""
     op.add_column(
         "devices",
-        sa.Column("is_simulated", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column(
+            "is_simulated",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
     )
 
 

--- a/backend/src/homepot/migrations/versions/20260726_add_is_simulated_to_devices.py
+++ b/backend/src/homepot/migrations/versions/20260726_add_is_simulated_to_devices.py
@@ -1,0 +1,28 @@
+"""Add is_simulated column to devices table.
+
+Revision ID: 20260726_add_is_simulated
+Revises: 20260720_add_device_assignments_events
+Create Date: 2026-07-26
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20260726_add_is_simulated"
+down_revision = "20260720_add_device_assignments_events"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add is_simulated column to devices table."""
+    op.add_column(
+        "devices",
+        sa.Column("is_simulated", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Rollback is_simulated column."""
+    op.drop_column("devices", "is_simulated")

--- a/backend/src/homepot/models.py
+++ b/backend/src/homepot/models.py
@@ -390,6 +390,7 @@ class Device(Base):
     # DEPRECATED: use lifecycle_state — active/pending/suspended → True, unpaired/retired → False
     is_active = Column(Boolean, default=True)
     is_monitored = Column(Boolean, default=False)
+    is_simulated = Column(Boolean, default=False)
     created_at = Column(DateTime(timezone=True), default=utc_now)
     updated_at = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)
 

--- a/backend/utils/seed_data.py
+++ b/backend/utils/seed_data.py
@@ -471,6 +471,7 @@ async def init_database():
         ip_address,
         config,
         is_monitored=False,
+        is_simulated=True,
         enrollment_method="pre-provisioned",
         enrollment_token=None,
     ):
@@ -487,11 +488,12 @@ async def init_database():
             config=config,
             last_seen=datetime.now(timezone.utc),
             is_monitored=is_monitored,
+            is_simulated=is_simulated,
             enrollment_method=enrollment_method,
             enrollment_token=enrollment_token,
         )
         print(
-            f"Created device: {device.name} ({device_id}) [Monitored: {is_monitored}] [Method: {enrollment_method}]"
+            f"Created device: {device.name} ({device_id}) [Monitored: {is_monitored}] [Simulated: {is_simulated}] [Method: {enrollment_method}]"
         )
         return device
 

--- a/frontend/src/pages/Device/DeviceList.jsx
+++ b/frontend/src/pages/Device/DeviceList.jsx
@@ -151,6 +151,11 @@ export default function DeviceList() {
                   >
                     {device.lifecycle_state?.toUpperCase() || 'UNKNOWN'}
                   </div>
+                  {device.is_simulated && (
+                    <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-purple-500/10 text-purple-400 border border-purple-500/20">
+                      SIM
+                    </span>
+                  )}
                 </div>
               </div>
 

--- a/frontend/src/pages/Device/DeviceWidgets.jsx
+++ b/frontend/src/pages/Device/DeviceWidgets.jsx
@@ -489,6 +489,14 @@ export const DeviceInfoWidget = ({ device }) => (
           {device?.credential_status || 'N/A'}
         </span>
       </div>
+      {device?.is_simulated && (
+        <div className="flex justify-between">
+          <span className="text-slate-400">Source</span>
+          <span className="px-2 py-0.5 rounded text-xs font-medium bg-purple-500/10 text-purple-400 border border-purple-500/20">
+            SIMULATED
+          </span>
+        </div>
+      )}
       <div className="flex justify-between">
         <span className="text-slate-400">IP Address</span>
         <span className="text-slate-200 font-mono">{device?.ip_address || 'N/A'}</span>

--- a/frontend/src/pages/Sites/SiteDetail.jsx
+++ b/frontend/src/pages/Sites/SiteDetail.jsx
@@ -315,6 +315,11 @@ export default function SiteDetail() {
                               />
                               {device.lifecycle_state || 'Unknown'}
                             </span>
+                            {device.is_simulated && (
+                              <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium bg-purple-500/10 text-purple-400 border border-purple-500/20">
+                                SIM
+                              </span>
+                            )}
                             <span
                               className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium ${
                                 device.health_state === 'healthy'


### PR DESCRIPTION
## Summary

Adds an `is_simulated` boolean field to the Device model so the Dashboard can distinguish real devices from simulated seed data. Real registration paths default to `false`; seed scripts explicitly set `true`.

## Changes

### Backend
- **`backend/src/homepot/models.py`** — Added `is_simulated = Column(Boolean, default=False)` after `is_monitored`
- **`backend/src/homepot/migrations/versions/20260726_add_is_simulated_to_devices.py`** — Additive migration with `server_default=sa.text("false")`
- **`backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py`** — Added `is_simulated` to all three device list/detail response dicts
- **`backend/utils/seed_data.py`** — `get_or_create_device()` accepts and passes `is_simulated=True`; all 10 seed devices set it

### Frontend
- **`frontend/src/pages/Device/DeviceList.jsx`** — Purple `SIM` badge on device card next to lifecycle state
- **`frontend/src/pages/Device/DeviceWidgets.jsx`** — `SIMULATED` source row in DeviceInfoWidget
- **`frontend/src/pages/Sites/SiteDetail.jsx`** — `SIM` badge in device table status column

### What sets is_simulated=false (default — no code change needed)
- POST /provision (agent_service.py)
- POST /bootstrap-provision (agent_service.py)
- POST /enrolment-intents/{id}/claim (database.py)
- POST /device (operator-created, database.py)
- POST /sites/{site_id}/devices (database.py)