### PR TITLE
feat: Wire ENABLE_AGENT_SIMULATION env var

### DIFF
--- a/backend/src/homepot/agents.py
+++ b/backend/src/homepot/agents.py
@@ -1016,11 +1016,19 @@ _agent_manager: Optional[AgentManager] = None
 
 
 async def get_agent_manager() -> AgentManager:
-    """Get agent manager singleton."""
+    """Get agent manager singleton.
+
+    When ENABLE_AGENT_SIMULATION is False, the manager is created but not
+    started, so endpoints that reference it receive a valid no-op placeholder
+    instead of crashing.
+    """
     global _agent_manager
     if _agent_manager is None:
+        from homepot.config import get_settings
+
         _agent_manager = AgentManager()
-        await _agent_manager.start()
+        if get_settings().enable_agent_simulation:
+            await _agent_manager.start()
     return _agent_manager
 
 

--- a/backend/src/homepot/app/api/API_v1/Endpoints/AgentsEndpoints.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/AgentsEndpoints.py
@@ -207,6 +207,7 @@ async def send_push_notification(
 @router.post("/agents/simulation/start", tags=["Agents"])
 async def start_simulation() -> Dict[str, str]:
     """Start the device agent simulation."""
+    _require_simulation_enabled()
     try:
         from homepot.agents import get_agent_manager
 
@@ -222,6 +223,7 @@ async def start_simulation() -> Dict[str, str]:
 @router.post("/agents/simulation/stop", tags=["Agents"])
 async def stop_simulation() -> Dict[str, str]:
     """Stop the device agent simulation."""
+    _require_simulation_enabled()
     try:
         from homepot.agents import get_agent_manager
 
@@ -237,6 +239,7 @@ async def stop_simulation() -> Dict[str, str]:
 @router.get("/agents/simulation/status", tags=["Agents"])
 async def get_simulation_status() -> Dict[str, bool]:
     """Get the status of the device agent simulation."""
+    _require_simulation_enabled()
     try:
         from homepot.agents import get_agent_manager
 
@@ -245,3 +248,14 @@ async def get_simulation_status() -> Dict[str, bool]:
     except Exception as e:
         logger.error(f"Failed to get simulation status: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
+
+
+def _require_simulation_enabled() -> None:
+    """Raise 404 if agent simulation is disabled via ENABLE_AGENT_SIMULATION."""
+    from homepot.config import get_settings
+
+    if not get_settings().enable_agent_simulation:
+        raise HTTPException(
+            status_code=404,
+            detail="Agent simulation is disabled (ENABLE_AGENT_SIMULATION=false)",
+        )

--- a/backend/src/homepot/config.py
+++ b/backend/src/homepot/config.py
@@ -172,6 +172,10 @@ class Settings(BaseSettings):
         default="development",
         description="Environment (development, testing, production)",
     )
+    enable_agent_simulation: bool = Field(
+        default=True,
+        description="Enable simulated device agents on startup (set False for dev server with real devices)",
+    )
 
     # Server configuration
     host: str = Field(default="0.0.0.0", description="Server host")  # nosec B104

--- a/backend/src/homepot/main.py
+++ b/backend/src/homepot/main.py
@@ -109,12 +109,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         raise
 
     # Initialize agent manager (Phase 3)
-    try:
-        await get_agent_manager()
-        logger.info("Agent manager initialized")
-    except Exception as e:
-        logger.error(f"Failed to initialize agent manager: {e}")
-        raise
+    if get_settings().enable_agent_simulation:
+        try:
+            await get_agent_manager()
+            logger.info("Agent manager initialized")
+        except Exception as e:
+            logger.error(f"Failed to initialize agent manager: {e}")
+            raise
+    else:
+        logger.info("Agent simulation disabled — skipping agent manager")
 
     # Initialize audit logging (Phase 4)
     try:
@@ -171,7 +174,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # Shutdown agent manager
     try:
         await stop_agent_manager()
-        logger.info("Agent manager stopped")
+        if get_settings().enable_agent_simulation:
+            logger.info("Agent manager stopped")
     except Exception as e:
         logger.error(f"Error stopping agent manager: {e}")
 


### PR DESCRIPTION
## Summary

Wire the  env var (already declared in .env.example) to gate the agent simulator, so a dev server can run without simulated agents polluting real device data.

## Changes

- **config.py**: Added  field to Settings (reads from `ENABLE_AGENT_SIMULATION` env var)
- **agents.py**: `get_agent_manager()` creates the singleton but only starts it when simulation is enabled; returns a valid no-op placeholder otherwise
- **main.py**: Startup skips agent manager init when disabled; shutdown log conditional
- **AgentsEndpoints.py**: `/agents/simulation/start|stop|status` return 404 when simulation is disabled

## Verification

- 34/34 tests pass
- flake8, mypy, black, isort all clean

Closes PR 27 of the dev-server roadmap