### PR TITLE
feat: Secure command endpoint with audit logging and rate limiting

### DIFF
--- a/backend/src/homepot/app/api/API_v1/Endpoints/DeviceCommandsEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DeviceCommandsEndpoint.py
@@ -69,10 +69,10 @@ class CommandResponse(BaseModel):
 @limiter.limit("30/minute")
 async def queue_command(
     device_id: str,
-    request: CreateCommandRequest,
+    command_request: CreateCommandRequest,
+    request: Request,
     sync_db: SASession = Depends(get_db),
     current_user: UserDict = Depends(require_user()),
-    http_request: Optional[Request] = None,
 ) -> CommandResponse:
     """Queue a command for a specific device (by device_id string).
 
@@ -90,22 +90,23 @@ async def queue_command(
 
     command = await db.create_device_command(
         device_id=device.id,  # type: ignore
-        command_type=request.command_type,
-        payload=request.payload,
+        command_type=command_request.command_type,
+        payload=command_request.payload,
     )
 
     # Audit log
     audit_logger = get_audit_logger()
     await audit_logger.log_event(
         AuditEventType.COMMAND_QUEUED,
-        f"User '{current_user['email']}' queued {request.command_type} command for device '{device_id}'",
+        f"User '{current_user['email']}' queued {command_request.command_type} "
+        f"command for device '{device_id}'",
         user_id=db_user.id,  # type: ignore
         device_id=device.id,  # type: ignore
         site_id=device.site_id,  # type: ignore
         new_values={
             "command_id": str(command.command_id),
-            "command_type": request.command_type,
-            "payload": request.payload,
+            "command_type": command_request.command_type,
+            "payload": command_request.payload,
         },
     )
 

--- a/backend/src/homepot/app/api/API_v1/Endpoints/DeviceCommandsEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DeviceCommandsEndpoint.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List, Optional, cast
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session as SASession
 
@@ -12,6 +12,8 @@ from homepot.app.auth_utils import (
     require_user,
     verify_device_belongs_to_user,
 )
+from homepot.app.utils.limiter import limiter
+from homepot.audit import AuditEventType, get_audit_logger
 from homepot.database import get_database_service, get_db
 from homepot.models import CommandStatus, Device, User
 
@@ -64,11 +66,13 @@ class CommandResponse(BaseModel):
     response_model=CommandResponse,
     status_code=status.HTTP_201_CREATED,
 )
+@limiter.limit("30/minute")
 async def queue_command(
     device_id: str,
     request: CreateCommandRequest,
     sync_db: SASession = Depends(get_db),
     current_user: UserDict = Depends(require_user()),
+    http_request: Optional[Request] = None,
 ) -> CommandResponse:
     """Queue a command for a specific device (by device_id string).
 
@@ -89,6 +93,22 @@ async def queue_command(
         command_type=request.command_type,
         payload=request.payload,
     )
+
+    # Audit log
+    audit_logger = get_audit_logger()
+    await audit_logger.log_event(
+        AuditEventType.COMMAND_QUEUED,
+        f"User '{current_user['email']}' queued {request.command_type} command for device '{device_id}'",
+        user_id=db_user.id,  # type: ignore
+        device_id=device.id,  # type: ignore
+        site_id=device.site_id,  # type: ignore
+        new_values={
+            "command_id": str(command.command_id),
+            "command_type": request.command_type,
+            "payload": request.payload,
+        },
+    )
+
     return CommandResponse(
         command_id=command.command_id,  # type: ignore
         command_type=command.command_type,  # type: ignore

--- a/backend/src/homepot/audit.py
+++ b/backend/src/homepot/audit.py
@@ -46,6 +46,7 @@ class AuditEventType(str, Enum):
 
     # Job management
     JOB_CREATED = "job_created"
+    COMMAND_QUEUED = "command_queued"
     JOB_STARTED = "job_started"
     JOB_COMPLETED = "job_completed"
     JOB_FAILED = "job_failed"


### PR DESCRIPTION
## Summary

Two concrete gaps that block real-device command execution.

## Real device agent (already implemented)

These were already fully wired:

- **pending_commands_loop** — polls `GET /api/v1/devices/pending` at a fixed interval (active in `run_agent`)
- **process_command** — dispatches `ping`, `restart`, `shutdown`, `update_config` with permission gating
- **update_command_status** — reports outcomes via `PUT /api/v1/devices/{command_id}/status`
- **RetryQueue** — used throughout for offline resilience

## Backend security (this PR)

### audit.py
- Added `COMMAND_QUEUED` event type to `AuditEventType`

### DeviceCommandsEndpoint.py
- **Rate limiting**: `POST /{device_id}/commands` limited to 30 requests/minute via slowapi
- **Audit logging**: Each queued command is logged with: who (user email), what (command_type), for which device (device_id)

## Verification

- 34/34 tests pass
- flake8, mypy, black, isort all clean