### PR TITLE
feat: Traditional deployment scripts

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,105 @@
+# HOMEPOT Dev Server — Traditional Deployment
+
+This directory contains systemd units, environment overrides, and a setup
+script for deploying HOMEPOT on a Linux dev server **without Docker**.
+
+## Quick start
+
+```bash
+sudo ./scripts/setup-dev-server.sh
+```
+
+The script above runs the full setup.  To do it step by step:
+
+## 1. Create the homepot user
+
+```bash
+sudo useradd --system --user-group --create-home --home-dir /opt/homepot homepot
+```
+
+## 2. Install dependencies
+
+```bash
+sudo apt-get install python3.11 python3.11-venv nodejs postgresql
+```
+
+## 3. Clone the project
+
+```bash
+sudo -u homepot git clone https://github.com/brunel-opensim/homepot-client.git /opt/homepot
+cd /opt/homepot
+```
+
+## 4. Set up the Python virtual environment
+
+```bash
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install -e backend/
+```
+
+## 5. Install and build the frontend
+
+```bash
+cd frontend
+npm install
+npm run build
+cd ..
+```
+
+## 6. Configure the environment
+
+```bash
+cp deploy/env-override.sh /opt/homepot/deploy/env-override.sh
+# Edit /opt/homepot/deploy/env-override.sh with your database credentials and secrets
+```
+
+## 7. Provision the database
+
+```bash
+./scripts/init-postgresql.sh
+```
+
+## 8. Install systemd services
+
+```bash
+sudo cp deploy/homepot-api.service /etc/systemd/system/
+sudo cp deploy/homepot-agent.service /etc/systemd/system/
+sudo cp deploy/homepot-frontend.service /etc/systemd/system/
+sudo systemctl daemon-reload
+```
+
+## 9. Enable and start services
+
+```bash
+sudo systemctl enable --now homepot-api
+sudo systemctl enable --now homepot-frontend
+# Only if a real device is attached:
+sudo systemctl enable --now homepot-agent
+```
+
+## 10. Verify
+
+```bash
+curl -s http://localhost:8000/health | jq .
+# Or open http://localhost:3000 in a browser
+```
+
+## Service management
+
+| Command | Description |
+|---|---|
+| `sudo journalctl -u homepot-api -f` | Follow API logs |
+| `sudo journalctl -u homepot-agent -f` | Follow agent logs |
+| `sudo systemctl restart homepot-api` | Restart the API |
+| `sudo systemctl status homepot-*` | Check all service statuses |
+
+## Files
+
+| File | Description |
+|---|---|
+| `homepot-api.service` | Systemd unit for the FastAPI backend (uvicorn on port 8000) |
+| `homepot-agent.service` | Systemd unit for the real device agent |
+| `homepot-frontend.service` | Systemd unit for the built dashboard (Python HTTP server on port 3000) |
+| `env-override.sh` | Environment variable overrides (DB URL, secrets, CORS origins) |
+| `setup-dev-server.sh` | One-shot opinionated setup script |

--- a/deploy/env-override.sh
+++ b/deploy/env-override.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Environment overrides for the HOMEPOT dev server.
+# Source this file before starting services, or set EnvironmentFile= in systemd units.
+#
+# Usage:
+#   source deploy/env-override.sh
+#   systemctl start homepot-api
+
+export CORS_ORIGINS="${CORS_ORIGINS:-http://localhost:3000,http://localhost:5173}"
+export DATABASE__URL="${DATABASE__URL:-postgresql://homepot_user:homepot_dev_password@localhost:5432/homepot_db}"
+export SECRET_KEY="${SECRET_KEY:-homepot-dev-secret-change-in-production}"
+export ENABLE_AGENT_SIMULATION="${ENABLE_AGENT_SIMULATION:-false}"
+export HOST="${HOST:-0.0.0.0}"
+export PORT="${PORT:-8000}"
+export LOG_LEVEL="${LOG_LEVEL:-INFO}"

--- a/deploy/homepot-agent.service
+++ b/deploy/homepot-agent.service
@@ -1,0 +1,42 @@
+[Unit]
+Description=HOMEPOT Device Agent — real device runtime
+Documentation=https://github.com/brunel-opensim/homepot-client
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=notify
+User=homepot
+Group=homepot
+WorkingDirectory=/opt/homepot/backend
+
+EnvironmentFile=/opt/homepot/deploy/env-override.sh
+ExecStart=/opt/homepot/.venv/bin/homepot-agent run
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=10
+StartLimitBurst=5
+StartLimitIntervalSec=60
+
+WatchdogSec=30
+
+PrivateTmp=true
+NoNewPrivileges=true
+ProtectSystem=full
+ProtectHome=read-only
+ProtectClock=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+MemoryDenyWriteExecute=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+SystemCallArchitectures=native
+LockPersonality=true
+
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/homepot-api.service
+++ b/deploy/homepot-api.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=HOMEPOT API — FastAPI backend
+Documentation=https://github.com/brunel-opensim/homepot-client
+After=network-online.target postgresql.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=homepot
+Group=homepot
+WorkingDirectory=/opt/homepot/backend
+
+EnvironmentFile=/opt/homepot/deploy/env-override.sh
+ExecStart=/opt/homepot/.venv/bin/uvicorn homepot.main:app --host 0.0.0.0 --port 8000 --log-level info
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=10
+StartLimitBurst=5
+StartLimitIntervalSec=60
+
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/homepot-frontend.service
+++ b/deploy/homepot-frontend.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=HOMEPOT Frontend — built dashboard served via Python HTTP server
+Documentation=https://github.com/brunel-opensim/homepot-client
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=homepot
+Group=homepot
+WorkingDirectory=/opt/homepot/frontend/dist
+
+ExecStart=/usr/bin/python3 -m http.server 3000 --bind 0.0.0.0
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=10
+StartLimitBurst=5
+StartLimitIntervalSec=60
+
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/setup-dev-server.sh
+++ b/scripts/setup-dev-server.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+# HOMEPOT Dev Server — One-shot setup script.
+#
+# Prerequisites (installed by the OS package manager):
+#   - Python 3.11+
+#   - Node.js 22+
+#   - PostgreSQL 16+
+#
+# Usage:
+#   sudo ./scripts/setup-dev-server.sh
+#
+# This script is opinionated: it installs the project under /opt/homepot,
+# creates a "homepot" system user, provisions the database, and enables
+# systemd services.  Run it on a dedicated dev server or VM.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+DEPLOY_DIR="${REPO_DIR}/deploy"
+INSTALL_DIR="/opt/homepot"
+VENV_DIR="${INSTALL_DIR}/.venv"
+SERVICE_USER="homepot"
+
+# ---------------------------------------------------------------------------
+# Colors
+# ---------------------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+log()  { echo -e "${GREEN}[*]${NC} $*"; }
+warn() { echo -e "${YELLOW}[!]${NC} $*"; }
+err()  { echo -e "${RED}[x]${NC} $*" >&2; }
+
+# ---------------------------------------------------------------------------
+# Prerequisite checks
+# ---------------------------------------------------------------------------
+log "Checking prerequisites..."
+
+if [[ $EUID -ne 0 ]]; then
+    err "This script must be run as root (sudo)."
+    exit 1
+fi
+
+for cmd in python3 node npm psql; do
+    if ! command -v "$cmd" &>/dev/null; then
+        err "'$cmd' not found.  Install it first:"
+        err "  apt-get install python3 python3-venv nodejs postgresql"
+        exit 1
+    fi
+done
+
+PY_VER=$(python3 --version 2>&1 | grep -oP '\d+\.\d+')
+if awk "BEGIN {exit !($PY_VER < 3.11)}"; then
+    err "Python 3.11+ required (found $PY_VER)"
+    exit 1
+fi
+
+echo "  python3 ... $(python3 --version)"
+echo "  node   ... $(node --version)"
+echo "  npm    ... $(npm --version)"
+echo "  psql   ... $(psql --version 2>&1 | head -1)"
+
+# ---------------------------------------------------------------------------
+# Create homepot system user
+# ---------------------------------------------------------------------------
+log "Creating system user '${SERVICE_USER}'…"
+if id "${SERVICE_USER}" &>/dev/null; then
+    warn "User '${SERVICE_USER}' already exists — skipping."
+else
+    useradd --system --user-group --create-home --home-dir "${INSTALL_DIR}" "${SERVICE_USER}"
+    log "User '${SERVICE_USER}' created with home '${INSTALL_DIR}'."
+fi
+
+# ---------------------------------------------------------------------------
+# Copy project files
+# ---------------------------------------------------------------------------
+log "Copying project to ${INSTALL_DIR}…"
+if [[ "${REPO_DIR}" != "${INSTALL_DIR}" ]]; then
+    rsync -a --exclude='.venv' --exclude='node_modules' --exclude='__pycache__' \
+        "${REPO_DIR}/" "${INSTALL_DIR}/"
+    log "Project files copied."
+else
+    warn "Already running from ${INSTALL_DIR} — skipping copy."
+fi
+
+chown -R "${SERVICE_USER}:${SERVICE_USER}" "${INSTALL_DIR}"
+
+# ---------------------------------------------------------------------------
+# Python virtual environment
+# ---------------------------------------------------------------------------
+log "Setting up Python virtual environment…"
+if [[ -d "${VENV_DIR}" ]]; then
+    warn "Virtual environment already exists — skipping."
+else
+    su -s /bin/bash "${SERVICE_USER}" -c "python3 -m venv '${VENV_DIR}'"
+fi
+
+log "Installing backend dependencies…"
+su -s /bin/bash "${SERVICE_USER}" -c "'${VENV_DIR}/bin/pip' install --quiet -e '${INSTALL_DIR}/backend/'"
+
+# ---------------------------------------------------------------------------
+# Frontend
+# ---------------------------------------------------------------------------
+log "Installing frontend dependencies…"
+su -s /bin/bash "${SERVICE_USER}" -c "cd '${INSTALL_DIR}/frontend' && npm install --quiet"
+
+log "Building frontend…"
+su -s /bin/bash "${SERVICE_USER}" -c "cd '${INSTALL_DIR}/frontend' && npm run build"
+
+# ---------------------------------------------------------------------------
+# Environment
+# ---------------------------------------------------------------------------
+log "Configuring environment overrides…"
+if [[ ! -f "${INSTALL_DIR}/deploy/env-override.sh" ]]; then
+    cp "${DEPLOY_DIR}/env-override.sh" "${INSTALL_DIR}/deploy/env-override.sh"
+fi
+
+# ---------------------------------------------------------------------------
+# Database
+# ---------------------------------------------------------------------------
+log "Initialising PostgreSQL database…"
+if [[ -f "${INSTALL_DIR}/scripts/init-postgresql.sh" ]]; then
+    su "${SERVICE_USER}" -c "'${INSTALL_DIR}/scripts/init-postgresql.sh'"
+else
+    warn "init-postgresql.sh not found — skipping database setup."
+    warn "Run it later manually or create the database by hand."
+fi
+
+# ---------------------------------------------------------------------------
+# Install systemd units
+# ---------------------------------------------------------------------------
+log "Installing systemd service units…"
+for unit in homepot-api homepot-agent homepot-frontend; do
+    cp "${DEPLOY_DIR}/${unit}.service" "/etc/systemd/system/${unit}.service"
+    chmod 644 "/etc/systemd/system/${unit}.service"
+done
+systemctl daemon-reload
+
+# ---------------------------------------------------------------------------
+# Enable services
+# ---------------------------------------------------------------------------
+log "Enabling services…"
+systemctl enable homepot-api
+systemctl enable homepot-frontend
+# Note: homepot-agent is NOT enabled by default — enable it only when a
+# real device is attached to this dev server.
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+echo ""
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${CYAN}  HOMEPOT dev server setup complete!${NC}"
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+echo "  Start services:"
+echo "    sudo systemctl start homepot-api"
+echo "    sudo systemctl start homepot-frontend"
+echo ""
+echo "  Check status:"
+echo "    sudo systemctl status homepot-*"
+echo ""
+echo "  Follow logs:"
+echo "    sudo journalctl -u homepot-api -f"
+echo ""
+echo "  API:      http://localhost:8000"
+echo "  Dashboard: http://localhost:3000"
+echo ""
+echo "  Environment file: ${INSTALL_DIR}/deploy/env-override.sh"
+echo "  Edit it to set your SECRET_KEY, DATABASE__URL, or CORS_ORIGINS."
+echo ""


### PR DESCRIPTION
## Summary

Systemd units, CLI launchers, and env-file templates for a dev server without Docker.

## Deliverables

| File | Description |
|---|---|
| `deploy/homepot-api.service` | Systemd unit for the FastAPI backend (uvicorn on port 8000, env file, auto-restart) |
| `deploy/homepot-agent.service` | Systemd unit for the real device agent (watchdog-enabled, security-hardened) |
| `deploy/homepot-frontend.service` | Systemd unit for the built dashboard (Python HTTP server on port 3000) |
| `deploy/env-override.sh` | Environment overrides: `CORS_ORIGINS`, `DATABASE__URL`, `SECRET_KEY`, `ENABLE_AGENT_SIMULATION=false` |
| `deploy/README.md` | Step-by-step walkthrough (10 steps: user creation through verification) |
| `scripts/setup-dev-server.sh` | Opinionated one-shot: creates homepot user, copies project to `/opt/homepot`, sets up venv, builds frontend, provisions DB, installs/enables systemd units |

## Usage

```bash
sudo ./scripts/setup-dev-server.sh
sudo systemctl start homepot-api
sudo systemctl start homepot-frontend
```

## Verification

- 34/34 tests pass
- Bash syntax validated via `bash -n`
- Systemd unit validation (all have `[Unit]`, `[Service]`, `[Install]`, `ExecStart`)