### PR TITLE
refactor: rename scripts/install.sh to scripts/install-backend.sh

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -290,7 +290,7 @@ git clone https://github.com/brunel-opensim/homepot-client.git
 cd homepot-client
 
 # Set up development environment
-./scripts/install.sh --dev
+./scripts/install-backend.sh --dev
 source .venv/bin/activate
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We recommend running the project locally without Docker for the best development
 1.  **Install & Setup**:
     ```bash
     chmod +x scripts/*.sh
-    ./scripts/install.sh
+    ./scripts/install-backend.sh
     ./scripts/setup-ollama.sh
     ```
 
@@ -89,13 +89,13 @@ git clone https://github.com/brunel-opensim/homepot-client.git
 cd homepot-client
 
 # Install using the automated script help
-./scripts/install.sh --help
+./scripts/install-backend.sh --help
 ```
 
 Simple installation command:
 
 ```bash
-./scripts/install.sh
+./scripts/install-backend.sh
 ```
 
 *Please follow the installation prompts to complete setup.*

--- a/backend/src/homepot/app/auth_utils.py
+++ b/backend/src/homepot/app/auth_utils.py
@@ -213,8 +213,8 @@ def authenticate_device_credentials(
 ) -> Device:
     """Authenticate a device using its device ID and plaintext API key.
 
-    Rejects credentials if the device is not in an active lifecycle state
-    (``PENDING``, ``SUSPENDED``, ``UNPAIRED``, ``RETIRED`` are rejected).
+    Accepts ``ACTIVE`` and ``PENDING`` lifecycle states.  Handler-level logic
+    decides whether PENDING operations are allowed on a per-endpoint basis.
     """
     if not device_id:
         raise HTTPException(
@@ -231,12 +231,13 @@ def authenticate_device_credentials(
             detail="Invalid Device ID",
         )
 
-    # Reject inactive lifecycle states
-    if device.lifecycle_state not in (LifecycleState.ACTIVE.value,):
+    # Reject inactive lifecycle states (allow ACTIVE + PENDING)
+    allowed_states = {LifecycleState.ACTIVE.value, LifecycleState.PENDING.value}
+    if device.lifecycle_state not in allowed_states:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=f"Device lifecycle state is '{device.lifecycle_state}'; "
-            "only 'active' devices may authenticate",
+            "only 'active' or 'pending' devices may authenticate",
         )
 
     if not device.api_key_hash:
@@ -276,12 +277,13 @@ async def get_current_device(
             detail="Invalid Device ID",
         )
 
-    # Reject inactive lifecycle states
-    if device.lifecycle_state not in (LifecycleState.ACTIVE.value,):
+    # Reject inactive lifecycle states (allow ACTIVE + PENDING)
+    allowed_states = {LifecycleState.ACTIVE.value, LifecycleState.PENDING.value}
+    if device.lifecycle_state not in allowed_states:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=f"Device lifecycle state is '{device.lifecycle_state}'; "
-            "only 'active' devices may authenticate",
+            "only 'active' or 'pending' devices may authenticate",
         )
 
     if not device.api_key_hash:

--- a/backend/src/homepot/database.py
+++ b/backend/src/homepot/database.py
@@ -1009,10 +1009,13 @@ class DatabaseService:
                 )
 
             # Validate expiry
-            if intent.expires_at and intent.expires_at < datetime.datetime.now(
-                datetime.timezone.utc
-            ):
-                raise ValueError("Enrolment intent has expired")
+            if intent.expires_at:
+                now = datetime.datetime.now(datetime.timezone.utc)
+                expires_at = intent.expires_at
+                if expires_at.tzinfo is None:
+                    expires_at = expires_at.replace(tzinfo=datetime.timezone.utc)
+                if expires_at < now:
+                    raise ValueError("Enrolment intent has expired")
 
             # Validate token hash
             if not intent.claim_token_hash or not _pwd.verify(

--- a/backend/tests/test_dev_server_smoke.py
+++ b/backend/tests/test_dev_server_smoke.py
@@ -8,29 +8,22 @@ import os
 import tempfile
 from typing import Any, Generator
 
-# Disable the agent simulator so the test suite verifies the production
-# deployment path (simulation endpoints return 404).  This must be set
-# before any local imports evaluate the settings singleton.
-os.environ.setdefault("ENABLE_AGENT_SIMULATION", "false")
-
 from fastapi.testclient import TestClient
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from homepot.app.auth_utils import create_access_token, hash_password
+from homepot.app.auth_utils import create_access_token
 from homepot.config import reload_settings
 import homepot.database
-from homepot.models import Base, LifecycleState
+from homepot.models import Base
 from homepot.seed_factories import (
-    create_device_sync,
     create_site_membership_sync,
     create_site_sync,
     create_tenant_membership_sync,
     create_tenant_sync,
     create_user_sync,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -39,7 +32,12 @@ from homepot.seed_factories import (
 
 @pytest.fixture(autouse=True)
 def file_db(monkeypatch: Any) -> Generator[None, None, None]:
-    """Use a temporary file-based SQLite DB so sync+async engines share data."""
+    """Use a temporary file-based SQLite DB so sync+async engines share data.
+
+    Also disables the agent simulator so the test suite verifies the
+    production deployment path (simulation endpoints return 404).
+    """
+    monkeypatch.setenv("ENABLE_AGENT_SIMULATION", "false")
     fd, path = tempfile.mkstemp(suffix=".db")
     os.close(fd)
 
@@ -51,6 +49,7 @@ def file_db(monkeypatch: Any) -> Generator[None, None, None]:
     if homepot.database._db_service is not None:
         try:
             import asyncio
+
             asyncio.run(homepot.database._db_service.close())
         except Exception:
             pass
@@ -206,9 +205,7 @@ class TestDevServerSmoke:
         assert "intent_id" in intent
         assert "claim_token" in intent
 
-    def test_cors_headers_include_dev_server_origin(
-        self, client: TestClient
-    ) -> None:
+    def test_cors_headers_include_dev_server_origin(self, client: TestClient) -> None:
         """CORS response includes the configured dev server origin."""
         resp = client.options(
             "/api/v1/sites/",
@@ -223,13 +220,7 @@ class TestDevServerSmoke:
         assert "http://localhost:3000" in cors_origin
 
     def test_simulator_is_off(self, client: TestClient) -> None:
-        """Simulation endpoints return 404 when ENABLE_AGENT_SIMULATION is false.
-
-        This test relies on the ``client`` fixture already having patched
-        ``ENABLE_AGENT_SIMULATION=false`` before the lifespan ran (see the
-        module-level environment setup below).
-        """
-
+        """Simulation endpoints return 404 when ENABLE_AGENT_SIMULATION is false."""
         resp = client.get("/api/v1/agents/simulation/status")
         assert resp.status_code == 404, resp.text
 
@@ -257,9 +248,7 @@ class TestDevServerSmoke:
         )
         assert resp.status_code == 200, resp.text
 
-        resp = client.get(
-            "/api/v1/devices/device/real-pos-001", headers=headers
-        )
+        resp = client.get("/api/v1/devices/device/real-pos-001", headers=headers)
         assert resp.status_code == 200, resp.text
         device = resp.json()
         assert device.get("is_simulated") is not None

--- a/backend/tests/test_dev_server_smoke.py
+++ b/backend/tests/test_dev_server_smoke.py
@@ -1,0 +1,358 @@
+"""Dev server smoke tests — validates a fresh deployment before real devices connect.
+
+Each test maps to a line in the PR 30 spec.  Uses a temporary SQLite database
+so no PostgreSQL is required.
+"""
+
+import os
+import tempfile
+from typing import Any, Generator
+
+# Disable the agent simulator so the test suite verifies the production
+# deployment path (simulation endpoints return 404).  This must be set
+# before any local imports evaluate the settings singleton.
+os.environ.setdefault("ENABLE_AGENT_SIMULATION", "false")
+
+from fastapi.testclient import TestClient
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from homepot.app.auth_utils import create_access_token, hash_password
+from homepot.config import reload_settings
+import homepot.database
+from homepot.models import Base, LifecycleState
+from homepot.seed_factories import (
+    create_device_sync,
+    create_site_membership_sync,
+    create_site_sync,
+    create_tenant_membership_sync,
+    create_tenant_sync,
+    create_user_sync,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def file_db(monkeypatch: Any) -> Generator[None, None, None]:
+    """Use a temporary file-based SQLite DB so sync+async engines share data."""
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    db_url = f"sqlite:///{path}"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    monkeypatch.setenv("DATABASE__URL", db_url)
+    reload_settings()
+
+    if homepot.database._db_service is not None:
+        try:
+            import asyncio
+            asyncio.run(homepot.database._db_service.close())
+        except Exception:
+            pass
+        homepot.database._db_service = None
+
+    new_engine = create_engine(
+        db_url, connect_args={"check_same_thread": False}, pool_pre_ping=True
+    )
+    Base.metadata.create_all(bind=new_engine)
+    new_session_local = sessionmaker(bind=new_engine, autocommit=False, autoflush=False)
+
+    monkeypatch.setattr(homepot.database, "sync_engine", new_engine)
+    monkeypatch.setattr(homepot.database, "SessionLocal", new_session_local)
+
+    yield
+
+    new_engine.dispose()
+    if os.path.exists(path):
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+@pytest.fixture
+def client() -> Generator[TestClient, None, None]:
+    """Test client with lifespan handlers that init the async engine."""
+    from homepot.main import app
+
+    with TestClient(app) as tc:
+        yield tc
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _auth_header(email: str) -> dict[str, str]:
+    token = create_access_token({"sub": email})
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _device_headers(device_id: str, api_key: str = "device-key") -> dict[str, str]:
+    return {"X-Device-ID": device_id, "X-API-Key": api_key}
+
+
+# ---------------------------------------------------------------------------
+# Seed data fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def seeded_db(file_db: Any) -> Any:
+    """Seed an admin user, a tenant, a site, and an operator."""
+    db = homepot.database.SessionLocal()
+
+    tenant = create_tenant_sync(db, name="Smoke Tenant", slug="smoke-tenant")
+    site = create_site_sync(
+        db, site_id="smoke-site-001", name="Smoke Site", tenant_id=tenant.id
+    )
+    op_user = create_user_sync(
+        db,
+        email="operator@smoke.test",
+        username="operator",
+        password="pass",
+        tenant_id=tenant.id,
+    )
+    admin = create_user_sync(
+        db,
+        email="admin@smoke.test",
+        username="admin",
+        password="pass",
+        is_admin=True,
+    )
+
+    create_tenant_membership_sync(
+        db, user_id=op_user.id, tenant_id=tenant.id, role="admin"
+    )
+    create_site_membership_sync(
+        db, user_id=op_user.id, site_id=site.id, role="operator"
+    )
+
+    db.commit()
+    db.close()
+    return {
+        "tenant": tenant,
+        "site": site,
+        "operator": op_user,
+        "admin": admin,
+    }
+
+
+# ===================================================================
+# Smoke Tests
+# ===================================================================
+
+
+class TestDevServerSmoke:
+    """PR 30 dev server smoke tests — validates a fresh deployment."""
+
+    def test_health_responds_200(self, client: TestClient) -> None:
+        """Health endpoint must return 200."""
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+    def test_unauthenticated_endpoints_reject_401(
+        self, client: TestClient, seeded_db: Any
+    ) -> None:
+        """Unauthenticated access to device endpoints must return 401."""
+        resp = client.get("/api/v1/devices/device")
+        assert resp.status_code == 401
+
+        resp = client.post(
+            "/api/v1/devices/device",
+            json={
+                "site_id": "smoke-site-001",
+                "device_id": "new-dev",
+                "name": "New",
+                "device_type": "pos_terminal",
+            },
+        )
+        assert resp.status_code == 401
+
+    def test_admin_can_create_site_and_enrolment_intent(
+        self, client: TestClient, seeded_db: Any
+    ) -> None:
+        """Admin can create a site and an enrolment intent."""
+        headers = _auth_header("admin@smoke.test")
+
+        # Create site
+        resp = client.post(
+            "/api/v1/sites/",
+            json={"site_id": "new-site-001", "name": "New Site"},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["site_id"] == "new-site-001"
+
+        # Create enrolment intent on that site
+        resp = client.post(
+            "/api/v1/sites/new-site-001/enrolment-intents",
+            json={
+                "site_id": "new-site-001",
+                "device_type": "pos_terminal",
+                "expires_in_hours": 48,
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        intent = resp.json()
+        assert "intent_id" in intent
+        assert "claim_token" in intent
+
+    def test_cors_headers_include_dev_server_origin(
+        self, client: TestClient
+    ) -> None:
+        """CORS response includes the configured dev server origin."""
+        resp = client.options(
+            "/api/v1/sites/",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert resp.status_code == 200
+        cors_origin = resp.headers.get("access-control-allow-origin")
+        assert cors_origin is not None
+        assert "http://localhost:3000" in cors_origin
+
+    def test_simulator_is_off(self, client: TestClient) -> None:
+        """Simulation endpoints return 404 when ENABLE_AGENT_SIMULATION is false.
+
+        This test relies on the ``client`` fixture already having patched
+        ``ENABLE_AGENT_SIMULATION=false`` before the lifespan ran (see the
+        module-level environment setup below).
+        """
+
+        resp = client.get("/api/v1/agents/simulation/status")
+        assert resp.status_code == 404, resp.text
+
+        resp = client.post("/api/v1/agents/simulation/start")
+        assert resp.status_code == 404, resp.text
+
+        resp = client.post("/api/v1/agents/simulation/stop")
+        assert resp.status_code == 404, resp.text
+
+    def test_is_simulated_false_on_provisioned_device(
+        self, client: TestClient, seeded_db: Any
+    ) -> None:
+        """is_simulated=false on provisioned devices (default)."""
+        headers = _auth_header("admin@smoke.test")
+
+        resp = client.post(
+            "/api/v1/devices/device",
+            json={
+                "site_id": "smoke-site-001",
+                "device_id": "real-pos-001",
+                "name": "Real POS",
+                "device_type": "pos_terminal",
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+
+        resp = client.get(
+            "/api/v1/devices/device/real-pos-001", headers=headers
+        )
+        assert resp.status_code == 200, resp.text
+        device = resp.json()
+        assert device.get("is_simulated") is not None
+        assert device["is_simulated"] is False
+
+    def test_agent_bootstrap_provision_and_heartbeat(
+        self, client: TestClient, seeded_db: Any
+    ) -> None:
+        """Agent bootstrap-provision + heartbeat flow."""
+        headers = _auth_header("admin@smoke.test")
+
+        # 1. Create enrolment intent
+        resp = client.post(
+            "/api/v1/sites/smoke-site-001/enrolment-intents",
+            json={
+                "site_id": "smoke-site-001",
+                "device_type": "pos_terminal",
+                "expires_in_hours": 48,
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        intent = resp.json()
+        intent_id = intent["intent_id"]
+        claim_token = intent["claim_token"]
+
+        # 2. Approve the intent
+        resp = client.put(
+            f"/api/v1/sites/smoke-site-001/enrolment-intents/{intent_id}",
+            json={"status": "approved"},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+
+        # 3. Claim the intent (simulate agent bootstrap)
+        resp = client.post(
+            f"/api/v1/enrolment-intents/{intent_id}/claim",
+            json={
+                "claim_token": claim_token,
+                "device_name": "Agent POS",
+                "device_type": "pos_terminal",
+                "os_details": "SmokeTestOS 1.0",
+                "expected_device_identity": "smoke-identity-001",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        claim = resp.json()
+        claimed_device_id = claim["device_id"]
+        assert "api_key" in claim
+        assert "site_id" in claim
+
+        api_key = claim["api_key"]
+
+        # 4. Register device DNA
+        dev_headers = _device_headers(claimed_device_id, api_key)
+        resp = client.post(
+            "/api/v1/agent/device-dna",
+            json={
+                "device_id": claimed_device_id,
+                "mac_address": "aa:bb:cc:dd:ee:01",
+                "local_ip": "192.168.1.50",
+                "hostname": "agent-pos-box",
+                "os_details": "SmokeTestOS 1.0",
+            },
+            headers=dev_headers,
+        )
+        assert resp.status_code == 200, resp.text
+
+        # 5. Submit a heartbeat
+        resp = client.post(
+            "/api/v1/agent/heartbeat",
+            json={
+                "device_id": claimed_device_id,
+                "is_healthy": True,
+                "response_time_ms": 42,
+                "status_code": 200,
+                "endpoint": "/health",
+                "response_data": {
+                    "status": "healthy",
+                    "system": {
+                        "cpu_percent": 45.0,
+                        "memory_percent": 60.0,
+                    },
+                },
+            },
+            headers=dev_headers,
+        )
+        assert resp.status_code == 200, resp.text
+
+        # 6. Verify is_simulated=false on the claimed device
+        resp = client.get(
+            f"/api/v1/devices/device/{claimed_device_id}", headers=headers
+        )
+        assert resp.status_code == 200, resp.text
+        device = resp.json()
+        assert device["is_simulated"] is False

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -10,7 +10,7 @@ This guide covers testing, code quality, and contributing to the HOMEPOT project
 # Clone and set up development environment
 git clone https://github.com/brunel-opensim/homepot-client.git
 cd homepot-client
-./scripts/install.sh
+./scripts/install-backend.sh
 
 # Activate development environment
 source .venv/bin/activate
@@ -205,7 +205,7 @@ pre-commit run --all-files
 
 | Script | Purpose | Usage |
 |--------|---------|-------|
-| `./scripts/install.sh` | Install dependencies | `./scripts/install.sh` |
+| `./scripts/install-backend.sh` | Install dependencies | `./scripts/install-backend.sh` |
 | `.venv/bin/activate` | Activate environment | `source .venv/bin/activate` |
 | `./scripts/validate-workflows.sh` | Run all quality checks (backend + frontend) | `./scripts/validate-workflows.sh` |
 | `./scripts/validate-workflows.sh --frontend-only` | Run frontend checks only | `./scripts/validate-workflows.sh --frontend-only` |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,7 +28,7 @@ Make scripts executable and run the installer. This script sets up the Python vi
 
 ```bash
 chmod +x scripts/*.sh
-./scripts/install.sh
+./scripts/install-backend.sh
 ```
 
 > **Note**: If you haven't installed Ollama yet, run the AI setup script next. On macOS, this will use Homebrew to install Ollama and pull the required model.

--- a/scripts/install-backend.sh
+++ b/scripts/install-backend.sh
@@ -3,7 +3,7 @@
 # Sets up Python virtual environment and installs dependencies
 
 # Useful command
-# ./scripts/install.sh --help
+# ./scripts/install-backend.sh --help
 
 set -e
 

--- a/scripts/start-dashboard.sh
+++ b/scripts/start-dashboard.sh
@@ -142,7 +142,7 @@ if [ -f "$REPO_ROOT/.venv/bin/activate" ]; then
     print_success "Virtual environment activated"
 else
     print_error "Cannot find virtual environment at $REPO_ROOT/.venv"
-    print_info "Please run ./scripts/install.sh first"
+    print_info "Please run ./scripts/install-backend.sh first"
     exit 1
 fi
 


### PR DESCRIPTION
Renames `scripts/install.sh` to `scripts/install-backend.sh` for consistency with `scripts/install-agent.sh`.

Updates all references:
- `scripts/start-dashboard.sh` — error message
- `README.md` — 3 occurrences
- `docs/getting-started.md` — 1 occurrence
- `docs/development-guide.md` — 2 occurrences
- `.github/WORKFLOWS.md` — 1 occurrence