### PR TITLE
fix: make login session permanent until explicit sign-out

### DIFF
--- a/backend/src/homepot/app/auth_utils.py
+++ b/backend/src/homepot/app/auth_utils.py
@@ -48,8 +48,8 @@ if not _SECRET_KEY:
     raise RuntimeError("SECRET_KEY environment variable is not set!")
 SECRET_KEY: str = _SECRET_KEY
 ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_HOURS = 1
-REFRESH_TOKEN_EXPIRE_DAYS = 7
+ACCESS_TOKEN_EXPIRE_HOURS = 87600  # 10 years — session persists until explicit sign-out
+REFRESH_TOKEN_EXPIRE_DAYS = 3650  # 10 years
 
 COOKIE_NAME = "access_token"
 REFRESH_COOKIE_NAME = "refresh_token"


### PR DESCRIPTION
The access token expired after 1 hour (`ACCESS_TOKEN_EXPIRE_HOURS = 1`). The frontend never calls the `/auth/refresh` endpoint, so when the token expired the backend returned a 401 and the frontend immediately redirected to the login page with a "Session expired" message.

**Change:** Increased both token expiry constants:\n- `ACCESS_TOKEN_EXPIRE_HOURS`: 1 → **87600** (10 years)\n- `REFRESH_TOKEN_EXPIRE_DAYS`: 7 → **3650** (10 years)\n\nCookie `Max-Age` values are derived from these constants and now show `315360000` seconds (10 years) for both the access and refresh cookies.

The session now persists across browser restarts and only ends when the technician clicks the Sign Out button.