### PR TITLE
feat: device emulator framework, Linux POS emulator, and EMU/SIM badge distinction

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -30,6 +30,8 @@ per-file-ignores =
     backend/src/homepot/cli_timescaledb.py:F541,E501,F401,D403,
     # Utility scripts: allow relaxed style rules for developer tooling
     backend/utils/*:E501,E402,F841,F541,E226,E712,E741,D400,D401,S105,S106
+    # Device emulators: standalone scripts, docstring rules relaxed
+    emulators/*:D100,D101,D102,D103,D104,D105,D106,D107,S105,S106,E501
 exclude = 
     .git,
     __pycache__,

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -43,16 +43,16 @@ jobs:
         pip install -e backend/
 
     - name: Run Black formatter check
-      run: black --check backend/src/homepot/ backend/tests/ ai/ uq/
+      run: black --check backend/src/homepot/ backend/tests/ ai/ uq/ emulators/
 
     - name: Run isort import sorting check
-      run: isort --check-only backend/src/homepot/ backend/tests/ ai/ uq/
+      run: isort --check-only backend/src/homepot/ backend/tests/ ai/ uq/ emulators/
 
     - name: Run flake8 linting
-      run: flake8 backend/src/homepot/ backend/tests/ ai/ uq/
+      run: flake8 backend/src/homepot/ backend/tests/ ai/ uq/ emulators/
 
     - name: Run mypy type checking
-      run: mypy --config-file=backend/mypy.ini backend/src/homepot/ ai/ uq/
+      run: mypy --config-file=backend/mypy.ini backend/src/homepot/ ai/ uq/ emulators/
 
     - name: Validate documentation files
       run: |

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -146,12 +146,12 @@ extend-exclude = '''
 # isort configuration
 [tool.isort]
 profile = "black"
-multi_line_output = 3
 line_length = 88
 known_first_party = ["homepot"]
 known_third_party = ["fastapi", "pydantic", "pytest"]
 src_paths = ["src"]
 force_sort_within_sections = true
+order_by_type = true
 
 # MyPy configuration
 [tool.mypy]

--- a/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
@@ -513,6 +513,10 @@ async def get_device(
                 },
                 "is_monitored": device.is_monitored,
                 "is_simulated": device.is_simulated,
+                "enrollment_method": device.enrollment_method or "pre-provisioned",
+                "device_source": (
+                    device.config.get("device_source") if device.config else None
+                ),
                 "created_at": (
                     device.created_at.isoformat() if device.created_at else None
                 ),
@@ -1785,6 +1789,7 @@ async def get_devices_by_site(
                 "is_simulated": d.is_simulated,
                 "active_alerts": alert_map.get(d.device_id, 0),
                 "enrollment_method": getattr(d, "enrollment_method", "pre-provisioned"),
+                "device_source": d.config.get("device_source") if d.config else None,
                 "last_seen": d.last_seen.isoformat() if d.last_seen else None,
                 "last_heartbeat_at": (
                     d.last_heartbeat_at.isoformat() if d.last_heartbeat_at else None

--- a/backend/src/homepot/app/repositories/agent_repository.py
+++ b/backend/src/homepot/app/repositories/agent_repository.py
@@ -41,6 +41,7 @@ class AgentRepository:
         wan_ip: Optional[str],
         lifecycle_state: str = LifecycleState.ACTIVE.value,
         enrollment_method: Optional[str] = None,
+        is_simulated: bool = False,
     ) -> Device:
         """Create and persist a new device record."""
         device = Device(
@@ -55,6 +56,7 @@ class AgentRepository:
             is_active=True,
             lifecycle_state=lifecycle_state,
             enrollment_method=enrollment_method,
+            is_simulated=is_simulated,
         )
         self.db.add(device)
         self.db.commit()

--- a/backend/src/homepot/app/schemas/agent.py
+++ b/backend/src/homepot/app/schemas/agent.py
@@ -35,6 +35,10 @@ class AgentRegisterRequest(BaseModel):
     device_type: str = Field(
         default="pos_terminal", description="Device type for new records"
     )
+    device_source: Optional[str] = Field(
+        None,
+        description="Source identifier for the device — 'physical', 'emulator', or 'simulation'",
+    )
 
     model_config = ConfigDict(
         json_schema_extra={

--- a/backend/src/homepot/app/schemas/bootstrap.py
+++ b/backend/src/homepot/app/schemas/bootstrap.py
@@ -20,6 +20,10 @@ class BootstrapProvisionRequest(BaseModel):
     os_details: Optional[str] = Field(
         None, description="Operating system name and version reported by the device"
     )
+    provisioning_source: Optional[str] = Field(
+        "physical",
+        description="Source of the device: 'physical' for real hardware, 'emulator' for emulated devices",
+    )
 
     model_config = ConfigDict(
         json_schema_extra={

--- a/backend/src/homepot/app/services/agent_service.py
+++ b/backend/src/homepot/app/services/agent_service.py
@@ -65,6 +65,15 @@ class AgentService:
                     peripherals=payload.peripherals,
                 )
 
+                if payload.device_source:
+                    updated_obj = cast(Any, updated)
+                    existing_config: Dict[str, Any] = dict(
+                        cast(Dict[str, Any], updated_obj.config or {})
+                    )
+                    existing_config["device_source"] = payload.device_source
+                    updated_obj.config = existing_config
+                    self.repository.save_device(updated)
+
                 return {
                     "device_id": updated.device_id,
                     "site_id": updated.site.site_id if updated.site else None,
@@ -86,6 +95,7 @@ class AgentService:
 
             from homepot.app.schemas.permissions import derive_capabilities
 
+            is_emulator_dna = payload.device_source == "emulator"
             created = self.repository.create_device(
                 device_id=payload.device_id,
                 name=payload.device_name or payload.device_id,
@@ -96,10 +106,20 @@ class AgentService:
                 local_ip=payload.local_ip,
                 wan_ip=payload.wan_ip,
                 lifecycle_state=LifecycleState.ACTIVE.value,
+                enrollment_method=(
+                    EnrollmentMethod.EMULATED.value if is_emulator_dna else None
+                ),
+                is_simulated=is_emulator_dna,
             )
 
             created_obj = cast(Any, created)
             created_obj.capabilities = derive_capabilities(payload.os_details)
+
+            if is_emulator_dna:
+                existing_config = dict(cast(Dict[str, Any], created_obj.config or {}))
+                existing_config["device_source"] = "emulator"
+                created_obj.config = existing_config
+
             self.repository.save_device(created)
 
             return {
@@ -322,6 +342,7 @@ class AgentService:
             device_id = f"{payload.device_type}-{secrets.token_hex(4)}"
             api_key = secrets.token_urlsafe(32)
 
+            is_emulator = payload.provisioning_source == "emulator"
             created = self.repository.create_device(
                 device_id=device_id,
                 name=payload.device_name or device_id,
@@ -332,7 +353,12 @@ class AgentService:
                 local_ip=None,
                 wan_ip=None,
                 lifecycle_state=LifecycleState.PENDING.value,
-                enrollment_method=EnrollmentMethod.SELF_ENROLLED.value,
+                enrollment_method=(
+                    EnrollmentMethod.EMULATED.value
+                    if is_emulator
+                    else EnrollmentMethod.SELF_ENROLLED.value
+                ),
+                is_simulated=is_emulator,
             )
 
             created_obj = cast(Any, created)
@@ -348,6 +374,8 @@ class AgentService:
                     "os": payload.os_details,
                 }
             )
+            if is_emulator:
+                existing_config["device_source"] = "emulator"
             created_obj.config = existing_config
             created_obj.last_heartbeat_at = None
 

--- a/backend/src/homepot/models.py
+++ b/backend/src/homepot/models.py
@@ -117,6 +117,7 @@ class EnrollmentMethod(str, Enum):
 
     PRE_PROVISIONED = "pre-provisioned"
     SELF_ENROLLED = "self-enrolled"
+    EMULATED = "emulated"
 
 
 class EnrolmentIntentStatus(str, Enum):

--- a/docs/device-emulators.md
+++ b/docs/device-emulators.md
@@ -70,6 +70,22 @@ Only **Linux POS** is implemented. Each future emulator targets a specific OS an
 
 Credentials are persisted across restarts. If the emulator is stopped and re-run, it skips provisioning and resumes from its saved credentials. To force re-provisioning, delete the credentials file at `~/.homepot/emulators/<device_name>.json`.
 
+### Restarting
+
+**Standalone** — Press `Ctrl+C` in the terminal where it's running, then re-launch:
+
+```bash
+# Stop any running instance
+pkill -f linux_pos_emulator.py
+
+# Re-launch
+./scripts/start-emulator.sh
+```
+
+**User App (Electron)** — Quit and re-open the User App. The Electron main process kills the child emulator on quit; re-opening restarts it automatically when the setup-to-home flow completes.
+
+**Why restart?** The emulator re-registers device DNA on each startup. If backend logic was updated (e.g. new fields like `device_source`), restarting the emulator ensures the device record picks up those changes.
+
 ## Configuration reference
 
 ### Config file (`emulators/linux_pos_emulator.json`)

--- a/docs/device-emulators.md
+++ b/docs/device-emulators.md
@@ -173,6 +173,141 @@ Credentials live at `~/.homepot/emulators/<device_name>.json` with `0600` permis
 
 Emulators can run multiple instances simultaneously by using different `device_name` values (each gets its own credentials file and provisions independently).
 
+## User App integration (design sketch)
+
+The emulator can be spawned and managed directly from the User App's Electron shell, giving developers the full "real device" experience — the setup wizard provisions a device, the emulator starts as a background process, and the User App shows/manages it just like a physical device.
+
+### Architecture
+
+```
+User App (Electron)
+  ┌──────────────────────────────┐
+  │ Renderer (React)            │
+  │  - SetupWizard adds emulator │
+  │    mode toggle + type picker │
+  │  - Existing views unchanged  │
+  └──────────┬───────────────────┘
+             │ IPC
+  ┌──────────▼───────────────────┐
+  │ Main Process (Node)         │
+  │  - emulator:start handler   │
+  │  - emulator:stop handler    │
+  │  - emulator:status handler  │
+  │  - spawns/kills child proc  │
+  │  - watches credential file  │
+  └──────────┬───────────────────┘
+             │ child_process.spawn
+  ┌──────────▼───────────────────┐
+  │ Emulator (Python)           │
+  │  - Provisions via backend   │
+  │  - Writes credentials to    │
+  │    ~/.homepot/emulators/    │
+  │  - Runs loops until killed  │
+  └──────────────────────────────┘
+```
+
+### New IPC handlers (Electron main)
+
+| Channel | Direction | Purpose |
+|---------|-----------|---------|
+| `emulator:start` | Renderer → Main | Spawn emulator with config, returns `{device_id, api_key}` when provisioned |
+| `emulator:stop` | Renderer → Main | Kill the emulator child process |
+| `emulator:status` | Renderer → Main | Return `{running: bool, pid, device_id}` |
+
+### SetupWizard flow change
+
+1. **Step 1** (existing): Site ID, hostname, device type, OS
+2. **Step 2** (new): Mode selection — "Real device" (current flow) or **"Launch emulator"**
+3. **Step 3** (new, emulator mode only): Emulator type picker — Linux POS, Android POS (future), etc.
+4. **Review** (modified): Shows config + "Start Emulator" button; on click, Electron writes a temp JSON config, spawns the Python emulator, waits for it to provision and write credentials, then navigates to `/home`
+
+### Lifecycle
+
+- **Startup**: Electron spawns `python3 emulators/linux_pos_emulator.py --config <temp-file>`. The temp config contains backend URL, site ID, bootstrap key, and mock DNA values for the selected emulator type.
+- **Provisioning wait**: Main process polls `~/.homepot/emulators/<device_name>.json` until it appears (emulator writes it after provisioning).
+- **Runtime**: Main process monitors the child process — if it dies unexpectedly, a warning banner appears in the UI.
+- **Shutdown**: On app quit or unpair, main process sends SIGTERM → waits 3 s → SIGKILL if needed.
+- **Restart**: If the User App reopens and credentials still exist, the device is shown as provisioned (no emulator restart needed if already running).
+
+### Design decisions
+
+| Decision | Chosen approach |
+|----------|-----------------|
+| **Dev-only vs toggleable** | Dev-only (`import.meta.env.DEV`). Hidden from production builds — it is a developer tool, not a user feature. |
+| **Python discovery** | Try `.venv/bin/python3` first, then fall back to `python3` on PATH, with a configurable override. |
+| **Single vs multiple** | Single emulator per User App instance. Matches the real-world model (one device per User App). |
+| **Emulator output** | Stdout/stderr piped to `~/.homepot/emulators/<name>.log`. A debug panel in Electron DevTools can tail it. |
+
+### Preload API shape
+
+```typescript
+interface Window {
+  electronAPI?: {
+    // Existing channels
+    credentials: { ... }
+    device: { ... }
+    app: { ... }
+
+    // New channels
+    emulator: {
+      start(config: EmulatorStartConfig): Promise<{ deviceId: string; apiKey: string }>
+      stop(): Promise<boolean>
+      status(): Promise<{ running: boolean; pid?: number; deviceId?: string }>
+    }
+  }
+}
+
+interface EmulatorStartConfig {
+  emulatorType: 'linux_pos' | 'android_pos'  // | ...future
+  backendUrl: string
+  siteId: string
+  bootstrapKey: string
+  deviceName: string
+  mockMac?: string
+  mockIp?: string
+  mockHostname?: string
+  heartbeatInterval?: number
+  telemetryInterval?: number
+}
+```
+
+### SetupWizard emulator step mock-up
+
+```
+┌─────────────────────────────────────────┐
+│  HOMEPOT Agent          Step 2 of 4     │
+│                                         │
+│  ● ● ○ ○                                │
+│                                         │
+│  How would you like to set up?          │
+│                                         │
+│  ┌─────────────────────────────────────┐│
+│  │  ◉  Launch emulated device          ││
+│  │     (for development / testing)     ││
+│  │                                     ││
+│  │  ○  Set up a real device            ││
+│  └─────────────────────────────────────┘│
+│                                         │
+│  ┌─────────────────────────────────────┐│
+│  │ Device type:  [Linux POS       ▼]  ││
+│  │ OS:           [Linux 6.8      ▼]  ││
+│  │ Mock MAC:     02:42:ac:11:00:02    ││
+│  │ Mock IP:      192.168.1.100        ││
+│  └─────────────────────────────────────┘│
+│                                         │
+│         [  Next → ]                     │
+└─────────────────────────────────────────┘
+```
+
+### Implementation order
+
+1. Add `emulator:start`, `emulator:stop`, `emulator:status` IPC handlers to `electron/main.ts`
+2. Expose emulator channels in `electron/preload.ts`
+3. Update `SetupWizard.tsx` — add mode selection step and emulator type picker
+4. Add `EmulatorStartConfig` type to `credentialStorage.ts` or a new types file
+5. Update `AppContext.tsx` — add emulator state (`isEmulatorRunning`, `emulatorType`)
+6. Wire ReviewStep to call `window.electronAPI.emulator.start()` instead of the dev-mode mock path
+
 ## Related documentation
 
 - [Device lifecycle and ownership](device-lifecycle-and-ownership.md) — Full device lifecycle, PR history, and remaining work

--- a/docs/device-emulators.md
+++ b/docs/device-emulators.md
@@ -1,0 +1,181 @@
+# Device Emulators
+
+Standalone Python scripts that simulate real hardware devices for end-to-end testing of the Dashboard, User App, and device lifecycle flows without physical hardware.
+
+Each emulator runs as an independent process that provisions itself with the backend, then sends heartbeats, telemetry, and responds to commands — just like a real device would.
+
+## Quick start
+
+```bash
+# 1. Start the Dashboard (backend + frontend)
+./scripts/start-dashboard.sh
+
+# 2. Generate a bootstrap key for your site (via API or operator UI)
+#    POST /api/v1/sites/{site_id}/bootstrap-key
+
+# 3. Run the Linux POS emulator
+./scripts/start-emulator.sh --site-id site-1 --bootstrap-key <key>
+
+# 4. (Optional) Start the User App to manage the emulated device
+./scripts/start-userapp.sh
+```
+
+The Dashboard immediately shows the emulated device with its mock DNA, online status, and live telemetry. Commands queued via the Dashboard are picked up, ACKed, and completed with realistic mock results.
+
+## Available emulators
+
+| Emulator | File | OS | Device type |
+|----------|------|----|-------------|
+| Linux POS | `emulators/linux_pos_emulator.py` | Linux | `pos_terminal` |
+| Android POS | — | Android | `pos_terminal` |
+| Windows POS | — | Windows | `pos_terminal` |
+| macOS POS | — | macOS | `pos_terminal` |
+| iOS | — | iOS | `tablet` |
+| Web Browser | — | Web | `virtual_terminal` |
+| MQTT Sensor | — | Linux | `mobile_scanner` |
+
+Only **Linux POS** is implemented. Each future emulator targets a specific OS and may include OS-specific behaviours (e.g. WNS push on Windows, FCM on Android).
+
+## How an emulator works
+
+```
+┌──────────────────┐     POST /devices/bootstrap-provision     ┌──────────────┐
+│   Emulator       │ ──────────────────────────────────────────▶              │
+│  (standalone     │     POST /agent/device-dna                │   Backend    │
+│   Python script) │ ──────────────────────────────────────────▶  (FastAPI)   │
+│                  │     POST /agent/heartbeat  (every 10s)    │              │
+│  Mock DNA:       │ ──────────────────────────────────────────▶              │
+│   MAC, IP,       │     POST /agent/telemetry   (every 15s)   │              │
+│   hostname, OS   │ ──────────────────────────────────────────▶              │
+│                  │     GET  /devices/pending   (every 15s)   │              │
+│  Simulated       │ ◀─────────────────────────────────────────│              │
+│   CPU/mem/disk   │     POST /commands/{id}/ack               │              │
+│                  │ ──────────────────────────────────────────▶              │
+│                  │     PUT  /commands/{id}/status (result)    │              │
+│                  │ ──────────────────────────────────────────▶              │
+└──────────────────┘                                            └──────────────┘
+```
+
+### Lifecycle
+
+1. **Config** — The emulator reads a JSON config file or CLI arguments specifying backend URL, site ID, bootstrap key, mock DNA values, and interval timings.
+2. **Provision** — On first run, calls `POST /devices/bootstrap-provision` to register the device. Credentials (`device_id`, `api_key`) are saved to `~/.homepot/emulators/<device_name>.json`.
+3. **DNA registration** — Calls `POST /agent/device-dna` with the mock MAC address, local IP, and OS details so the backend has realistic device identity data.
+4. **Loops** — Three concurrent async loops run until shutdown:
+   - **Heartbeat** — `POST /agent/heartbeat` at a configurable interval
+   - **Telemetry** — `POST /agent/telemetry` with simulated CPU/memory/disk metrics that vary realistically over time
+   - **Command polling** — `GET /devices/pending`, ACK each command, simulate execution, then report result via `PUT /devices/{command_id}/status`
+
+### Persistence
+
+Credentials are persisted across restarts. If the emulator is stopped and re-run, it skips provisioning and resumes from its saved credentials. To force re-provisioning, delete the credentials file at `~/.homepot/emulators/<device_name>.json`.
+
+## Configuration reference
+
+### Config file (`emulators/linux_pos_emulator.json`)
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `backend_url` | `http://localhost:8000` | Backend API root URL |
+| `site_id` | — | Site ID to provision under |
+| `bootstrap_key` | — | Bootstrap key for self-enrolment |
+| `device_name` | `linux-pos-emulator-1` | Human-readable device name |
+| `device_type` | `pos_terminal` | Device type category |
+| `os_details` | `Linux 6.8.0 (Debian 12)` | Operating system label |
+| `mock_mac` | `02:42:ac:11:00:02` | MAC address reported as device DNA |
+| `mock_ip` | `192.168.1.100` | Local IP reported as device DNA |
+| `mock_hostname` | `linux-pos-001` | Hostname reported as device DNA |
+| `heartbeat_interval_seconds` | `10` | Seconds between heartbeats |
+| `telemetry_interval_seconds` | `15` | Seconds between telemetry samples |
+| `command_poll_interval_seconds` | `15` | Seconds between pending-command polls |
+
+### CLI flags
+
+Every config field maps to a `--flag`. CLI values override config file values.
+
+```bash
+python emulators/linux_pos_emulator.py \
+  --site-id site-1 \
+  --bootstrap-key abc123... \
+  --device-name "My Custom POS" \
+  --mock-mac "aa:bb:cc:dd:ee:ff" \
+  --mock-ip "10.0.0.50" \
+  --heartbeat-interval 5
+```
+
+## Running a full simulation session
+
+```
+Terminal 1:  ./scripts/start-dashboard.sh
+             # Backend on :8000, Dashboard on :5173
+
+Terminal 2:  ./scripts/start-emulator.sh --site-id site-1 --bootstrap-key <key>
+             # Emulator provisions, heartbeats, sends telemetry
+
+Terminal 3:  ./scripts/start-userapp.sh
+             # User App on :5174 — login and manage the emulated device
+```
+
+The Dashboard at http://localhost:5173 shows the emulated device in the device list with:
+- Mock hostname, MAC, IP (from DNA registration)
+- `online` connectivity (via heartbeats)
+- Live CPU/memory/disk gauges (via telemetry)
+- Command queueing and history
+
+Queuing a command via the Dashboard (e.g. `restart`, `ping`, `update_config`) sends it to the emulator which ACKs, simulates execution, and reports a result. The full round-trip takes a few seconds.
+
+## Command response simulation
+
+| Command type | Simulated result |
+|-------------|------------------|
+| `restart` | `reboot_time_seconds: 45` |
+| `shutdown` | Immediate completion |
+| `update_config` | `applied_settings: { log_level: "INFO" }` |
+| `ping` | Random latency 5–50 ms |
+| *(unknown)* | No-op with warning |
+
+## Creating a new emulator
+
+Each emulator is a standalone runnable script. The simplest approach is to copy `linux_pos_emulator.py` and adjust:
+
+1. **Config defaults** — Change the OS details, device type, mock MAC/IP/hostname defaults.
+2. **Simulated metrics** — Override `SimulatedMetrics` for OS-specific metrics (e.g. Android battery level, iOS thermal state).
+3. **Command responses** — Add OS-specific command handlers in `_simulate_command_result`.
+4. **Platform-specific behaviours** — Override loops or add new ones (e.g. WNS channel registration for Windows, FCM token refresh for Android).
+5. **Config file** — Create a dedicated JSON config with appropriate defaults.
+
+### Directory layout
+
+```
+emulators/
+├── __init__.py
+├── linux_pos_emulator.py       # Linux POS (implemented)
+├── linux_pos_emulator.json      # Linux POS config example
+├── android_pos_emulator.py      # Android POS (future)
+├── android_pos_emulator.json    # Android POS config example
+├── windows_pos_emulator.py      # Windows POS (future)
+└── ...
+```
+
+## Credential storage
+
+Credentials live at `~/.homepot/emulators/<device_name>.json` with `0600` permissions:
+
+```json
+{
+  "device_id": "a1b2c3d4-...",
+  "api_key": "mM2...",
+  "site_id": "site-1",
+  "device_name": "linux-pos-emulator-1",
+  ...
+}
+```
+
+Emulators can run multiple instances simultaneously by using different `device_name` values (each gets its own credentials file and provisions independently).
+
+## Related documentation
+
+- [Device lifecycle and ownership](device-lifecycle-and-ownership.md) — Full device lifecycle, PR history, and remaining work
+- [Real device agent](real-device-agent.md) — Production agent runtime for physical hardware
+- [Agent simulation](agent-simulation.md) — Legacy simulator fleet (23 simulated agents)
+- [User App guide](user-app-frontend-guide.md) — Electron-based device management UI

--- a/emulators/linux_pos_emulator.json
+++ b/emulators/linux_pos_emulator.json
@@ -1,0 +1,14 @@
+{
+  "backend_url": "http://localhost:8000",
+  "site_id": "site-1",
+  "bootstrap_key": "REPLACE_WITH_GENERATED_KEY",
+  "device_name": "linux-pos-emulator-1",
+  "device_type": "pos_terminal",
+  "os_details": "Linux 6.8.0 (Debian 12)",
+  "mock_mac": "02:42:ac:11:00:02",
+  "mock_ip": "192.168.1.100",
+  "mock_hostname": "linux-pos-001",
+  "heartbeat_interval_seconds": 10,
+  "telemetry_interval_seconds": 15,
+  "command_poll_interval_seconds": 15
+}

--- a/emulators/linux_pos_emulator.py
+++ b/emulators/linux_pos_emulator.py
@@ -25,13 +25,13 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timezone
 import json
+from pathlib import Path
 import random
 import signal
 import sys
-from dataclasses import dataclass
-from datetime import datetime, timezone
-from pathlib import Path
 from typing import cast
 
 import httpx
@@ -212,6 +212,7 @@ class LinuxPOSEmulator:
             "device_name": self.config.device_name,
             "device_type": self.config.device_type,
             "os_details": self.config.os_details,
+            "provisioning_source": "emulator",
         }
         resp = await self._http.post(
             f"{self._backend}/devices/bootstrap-provision", json=payload
@@ -244,6 +245,7 @@ class LinuxPOSEmulator:
             "site_id": self.config.site_id,
             "device_name": self.config.device_name,
             "device_type": self.config.device_type,
+            "device_source": "emulator",
         }
         resp = await self._http.post(
             f"{self._backend}/agent/device-dna", json=payload, headers=self._headers()
@@ -376,25 +378,25 @@ class LinuxPOSEmulator:
     def _simulate_command_result(self, command_type: str) -> dict:
         outcomes = {
             "restart": {
-                "status": "COMPLETED",
+                "status": "completed",
                 "result": {
                     "message": "Device restart initiated",
                     "reboot_time_seconds": 45,
                 },
             },
             "shutdown": {
-                "status": "COMPLETED",
+                "status": "completed",
                 "result": {"message": "Device shutdown initiated"},
             },
             "update_config": {
-                "status": "COMPLETED",
+                "status": "completed",
                 "result": {
                     "message": "Configuration updated successfully",
                     "applied_settings": {"log_level": "INFO"},
                 },
             },
             "ping": {
-                "status": "COMPLETED",
+                "status": "completed",
                 "result": {
                     "message": "pong",
                     "latency_ms": round(random.uniform(5, 50), 1),
@@ -404,7 +406,7 @@ class LinuxPOSEmulator:
         return outcomes.get(
             command_type,
             {
-                "status": "COMPLETED",
+                "status": "completed",
                 "result": {
                     "message": f"Unknown command '{command_type}' executed as no-op"
                 },
@@ -436,6 +438,8 @@ class LinuxPOSEmulator:
         try:
             if not self._try_restore():
                 await self._provision()
+            else:
+                await self._register_dna()
 
             print(f"\n  Device ID: {self.device_id}")
             print(f"  API Key:   {self.api_key[:16]}...")

--- a/emulators/linux_pos_emulator.py
+++ b/emulators/linux_pos_emulator.py
@@ -25,13 +25,13 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timezone
 import json
+from pathlib import Path
 import random
 import signal
 import sys
-from dataclasses import dataclass
-from datetime import datetime, timezone
-from pathlib import Path
 from typing import cast
 
 import httpx

--- a/emulators/linux_pos_emulator.py
+++ b/emulators/linux_pos_emulator.py
@@ -26,15 +26,13 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
-import os
 import random
 import signal
 import sys
-import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import cast
 
 import httpx
 
@@ -126,7 +124,11 @@ class SimulatedMetrics:
         disk = self._disk_baseline + random.gauss(0, 1.5)
         disk = max(0, min(100, disk))
 
-        return {"cpu_usage": round(cpu, 1), "memory_usage": round(mem, 1), "disk_usage": round(disk, 1)}
+        return {
+            "cpu_usage": round(cpu, 1),
+            "memory_usage": round(mem, 1),
+            "disk_usage": round(disk, 1),
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -142,7 +144,7 @@ def load_credentials(device_name: str) -> dict | None:
     path = _credentials_path(device_name)
     if path.exists():
         try:
-            return json.loads(path.read_text())
+            return cast(dict, json.loads(path.read_text()))
         except (json.JSONDecodeError, OSError):
             return None
     return None
@@ -169,8 +171,7 @@ class LinuxPOSEmulator:
         self._api_key: str | None = None
         self._shutdown_event = asyncio.Event()
         self._metrics = SimulatedMetrics()
-        self._client: httpx.AsyncClient | None = None
-        self._http: httpx.AsyncClient | None = None
+        self._http: httpx.AsyncClient
 
     @property
     def device_id(self) -> str:
@@ -212,7 +213,9 @@ class LinuxPOSEmulator:
             "device_type": self.config.device_type,
             "os_details": self.config.os_details,
         }
-        resp = await self._http.post(f"{self._backend}/devices/bootstrap-provision", json=payload)
+        resp = await self._http.post(
+            f"{self._backend}/devices/bootstrap-provision", json=payload
+        )
         if resp.status_code >= 400:
             body = resp.json()
             detail = body.get("detail", resp.text)
@@ -223,7 +226,10 @@ class LinuxPOSEmulator:
         self._api_key = data["api_key"]
         self.config.site_id = data["site_id"]
 
-        save_credentials(self.config.device_name, self.config.to_credentials(self._device_id, self._api_key))
+        save_credentials(
+            self.config.device_name,
+            self.config.to_credentials(self._device_id, self._api_key),
+        )
         print(f"  Provisioned device {self._device_id}")
 
         await self._register_dna()
@@ -239,11 +245,19 @@ class LinuxPOSEmulator:
             "device_name": self.config.device_name,
             "device_type": self.config.device_type,
         }
-        resp = await self._http.post(f"{self._backend}/agent/device-dna", json=payload, headers=self._headers())
+        resp = await self._http.post(
+            f"{self._backend}/agent/device-dna", json=payload, headers=self._headers()
+        )
         if resp.status_code >= 400:
-            print(f"  [dna] warning: registration returned {resp.status_code}: {resp.text[:120]}")
+            print(
+                f"  [dna] warning: registration returned {resp.status_code}: {resp.text[:120]}"
+            )
         else:
-            print(f"  Registered DNA: hostname={self.config.mock_hostname}, MAC={self.config.mock_mac}, IP={self.config.mock_ip}")
+            print(
+                "  Registered DNA:"
+                f" hostname={self.config.mock_hostname}"
+                f", MAC={self.config.mock_mac}, IP={self.config.mock_ip}"
+            )
 
     # --
     # Loops
@@ -252,12 +266,21 @@ class LinuxPOSEmulator:
     async def _heartbeat_loop(self) -> None:
         while not self._shutdown_event.is_set():
             try:
-                payload = {"device_id": self.device_id, "timestamp": datetime.now(timezone.utc).isoformat()}
-                resp = await self._http.post(f"{self._backend}/agent/heartbeat", json=payload, headers=self._headers())
+                payload = {
+                    "device_id": self.device_id,
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                }
+                resp = await self._http.post(
+                    f"{self._backend}/agent/heartbeat",
+                    json=payload,
+                    headers=self._headers(),
+                )
                 if resp.status_code >= 400:
                     print(f"  [heartbeat] error: {resp.status_code} {resp.text[:120]}")
                 else:
-                    print(f"  [heartbeat] OK  ({datetime.now(timezone.utc).strftime('%H:%M:%S')})")
+                    print(
+                        f"  [heartbeat] OK  ({datetime.now(timezone.utc).strftime('%H:%M:%S')})"
+                    )
             except httpx.RequestError as exc:
                 print(f"  [heartbeat] connection error: {exc}")
 
@@ -267,12 +290,25 @@ class LinuxPOSEmulator:
         while not self._shutdown_event.is_set():
             try:
                 metrics = self._metrics.sample()
-                payload = {"device_id": self.device_id, **metrics, "timestamp": datetime.now(timezone.utc).isoformat()}
-                resp = await self._http.post(f"{self._backend}/agent/telemetry", json=payload, headers=self._headers())
+                payload = {
+                    "device_id": self.device_id,
+                    **metrics,
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                }
+                resp = await self._http.post(
+                    f"{self._backend}/agent/telemetry",
+                    json=payload,
+                    headers=self._headers(),
+                )
                 if resp.status_code >= 400:
                     print(f"  [telemetry] error: {resp.status_code} {resp.text[:120]}")
                 else:
-                    print(f"  [telemetry] OK  cpu={metrics['cpu_usage']}% mem={metrics['memory_usage']}% disk={metrics['disk_usage']}%")
+                    print(
+                        "  [telemetry] OK"
+                        f" cpu={metrics['cpu_usage']}%"
+                        f" mem={metrics['memory_usage']}%"
+                        f" disk={metrics['disk_usage']}%"
+                    )
             except httpx.RequestError as exc:
                 print(f"  [telemetry] connection error: {exc}")
 
@@ -281,15 +317,21 @@ class LinuxPOSEmulator:
     async def _command_poll_loop(self) -> None:
         while not self._shutdown_event.is_set():
             try:
-                resp = await self._http.get(f"{self._backend}/devices/pending", headers=self._headers())
+                resp = await self._http.get(
+                    f"{self._backend}/devices/pending", headers=self._headers()
+                )
                 if resp.status_code >= 400:
-                    print(f"  [commands] poll error: {resp.status_code} {resp.text[:120]}")
+                    print(
+                        f"  [commands] poll error: {resp.status_code} {resp.text[:120]}"
+                    )
                     await self._wait_or_shutdown(self.config.command_poll_interval)
                     continue
 
                 commands = resp.json()
                 if not commands:
-                    print(f"  [commands] none pending ({datetime.now(timezone.utc).strftime('%H:%M:%S')})")
+                    print(
+                        f"  [commands] none pending ({datetime.now(timezone.utc).strftime('%H:%M:%S')})"
+                    )
                 else:
                     print(f"  [commands] {len(commands)} pending")
                     for cmd in commands:
@@ -322,7 +364,10 @@ class LinuxPOSEmulator:
                 headers=self._headers(),
             )
             if status_resp.status_code >= 400:
-                print(f"  [commands] status update failed for {cid}: {status_resp.status_code} {status_resp.text[:120]}")
+                print(
+                    "  [commands] status update failed"
+                    f" for {cid}: {status_resp.status_code} {status_resp.text[:120]}"
+                )
             else:
                 print(f"  [commands] {ctype} completed ({cid})")
         except httpx.RequestError as exc:
@@ -330,12 +375,41 @@ class LinuxPOSEmulator:
 
     def _simulate_command_result(self, command_type: str) -> dict:
         outcomes = {
-            "restart": {"status": "COMPLETED", "result": {"message": "Device restart initiated", "reboot_time_seconds": 45}},
-            "shutdown": {"status": "COMPLETED", "result": {"message": "Device shutdown initiated"}},
-            "update_config": {"status": "COMPLETED", "result": {"message": "Configuration updated successfully", "applied_settings": {"log_level": "INFO"}}},
-            "ping": {"status": "COMPLETED", "result": {"message": "pong", "latency_ms": round(random.uniform(5, 50), 1)}},
+            "restart": {
+                "status": "COMPLETED",
+                "result": {
+                    "message": "Device restart initiated",
+                    "reboot_time_seconds": 45,
+                },
+            },
+            "shutdown": {
+                "status": "COMPLETED",
+                "result": {"message": "Device shutdown initiated"},
+            },
+            "update_config": {
+                "status": "COMPLETED",
+                "result": {
+                    "message": "Configuration updated successfully",
+                    "applied_settings": {"log_level": "INFO"},
+                },
+            },
+            "ping": {
+                "status": "COMPLETED",
+                "result": {
+                    "message": "pong",
+                    "latency_ms": round(random.uniform(5, 50), 1),
+                },
+            },
         }
-        return outcomes.get(command_type, {"status": "COMPLETED", "result": {"message": f"Unknown command '{command_type}' executed as no-op"}})
+        return outcomes.get(
+            command_type,
+            {
+                "status": "COMPLETED",
+                "result": {
+                    "message": f"Unknown command '{command_type}' executed as no-op"
+                },
+            },
+        )
 
     async def _wait_or_shutdown(self, seconds: float) -> None:
         try:
@@ -348,28 +422,39 @@ class LinuxPOSEmulator:
     # --
 
     async def start(self) -> None:
-        print(f"\n{'='*60}")
-        print(f"  HOMEPOT Linux POS Emulator")
+        print(f"\n{'=' * 60}")
+        print("  HOMEPOT Linux POS Emulator")
         print(f"  Device:  {self.config.device_name}")
         print(f"  Backend: {self.config.backend_url}")
-        print(f"  Mock DNA: hostname={self.config.mock_hostname}, MAC={self.config.mock_mac}, IP={self.config.mock_ip}")
-        print(f"{'='*60}\n")
+        print(
+            f"  Mock DNA: hostname={self.config.mock_hostname}"
+            f", MAC={self.config.mock_mac}, IP={self.config.mock_ip}"
+        )
+        print(f"{'=' * 60}\n")
 
-        async with httpx.AsyncClient(timeout=30.0) as self._http:
+        self._http = httpx.AsyncClient(timeout=30.0)
+        try:
             if not self._try_restore():
                 await self._provision()
 
             print(f"\n  Device ID: {self.device_id}")
             print(f"  API Key:   {self.api_key[:16]}...")
             print(f"  Site ID:   {self.config.site_id}")
-            print(f"\n  Starting loops (heartbeat={self.config.heartbeat_interval}s, telemetry={self.config.telemetry_interval}s, commands={self.config.command_poll_interval}s)")
-            print(f"  Press Ctrl+C to stop.\n")
+            print(
+                "\n  Starting loops"
+                f" (heartbeat={self.config.heartbeat_interval}s"
+                f", telemetry={self.config.telemetry_interval}s"
+                f", commands={self.config.command_poll_interval}s)"
+            )
+            print("  Press Ctrl+C to stop.\n")
 
             await asyncio.gather(
                 self._heartbeat_loop(),
                 self._telemetry_loop(),
                 self._command_poll_loop(),
             )
+        finally:
+            await self._http.aclose()
 
     def stop(self) -> None:
         self._shutdown_event.set()
@@ -383,16 +468,45 @@ class LinuxPOSEmulator:
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="HOMEPOT Linux POS Device Emulator")
     parser.add_argument("--config", "-c", type=str, help="Path to JSON config file")
-    parser.add_argument("--backend-url", type=str, default=DEFAULT_BACKEND_URL, help="Backend URL")
-    parser.add_argument("--site-id", type=str, default="", help="Site ID to provision under")
-    parser.add_argument("--bootstrap-key", type=str, default="", help="Bootstrap key for provisioning")
-    parser.add_argument("--device-name", type=str, default="linux-pos-emulator-1", help="Device name")
-    parser.add_argument("--mock-mac", type=str, default="02:42:ac:11:00:02", help="Mock MAC address")
-    parser.add_argument("--mock-ip", type=str, default="192.168.1.100", help="Mock local IP")
-    parser.add_argument("--mock-hostname", type=str, default="linux-pos-001", help="Mock hostname")
-    parser.add_argument("--heartbeat-interval", type=float, default=10.0, help="Heartbeat interval (seconds)")
-    parser.add_argument("--telemetry-interval", type=float, default=15.0, help="Telemetry interval (seconds)")
-    parser.add_argument("--command-poll-interval", type=float, default=15.0, help="Command poll interval (seconds)")
+    parser.add_argument(
+        "--backend-url", type=str, default=DEFAULT_BACKEND_URL, help="Backend URL"
+    )
+    parser.add_argument(
+        "--site-id", type=str, default="", help="Site ID to provision under"
+    )
+    parser.add_argument(
+        "--bootstrap-key", type=str, default="", help="Bootstrap key for provisioning"
+    )
+    parser.add_argument(
+        "--device-name", type=str, default="linux-pos-emulator-1", help="Device name"
+    )
+    parser.add_argument(
+        "--mock-mac", type=str, default="02:42:ac:11:00:02", help="Mock MAC address"
+    )
+    parser.add_argument(
+        "--mock-ip", type=str, default="192.168.1.100", help="Mock local IP"
+    )
+    parser.add_argument(
+        "--mock-hostname", type=str, default="linux-pos-001", help="Mock hostname"
+    )
+    parser.add_argument(
+        "--heartbeat-interval",
+        type=float,
+        default=10.0,
+        help="Heartbeat interval (seconds)",
+    )
+    parser.add_argument(
+        "--telemetry-interval",
+        type=float,
+        default=15.0,
+        help="Telemetry interval (seconds)",
+    )
+    parser.add_argument(
+        "--command-poll-interval",
+        type=float,
+        default=15.0,
+        help="Command poll interval (seconds)",
+    )
     return parser.parse_args(argv)
 
 
@@ -432,7 +546,9 @@ def main(argv: list[str] | None = None) -> None:
 
     if not config.site_id or not config.bootstrap_key:
         print("Error: --site-id and --bootstrap-key are required", file=sys.stderr)
-        print("  Either pass them on the CLI or provide a --config file.", file=sys.stderr)
+        print(
+            "  Either pass them on the CLI or provide a --config file.", file=sys.stderr
+        )
         sys.exit(1)
 
     emulator = LinuxPOSEmulator(config)

--- a/emulators/linux_pos_emulator.py
+++ b/emulators/linux_pos_emulator.py
@@ -25,13 +25,13 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-from dataclasses import dataclass
-from datetime import datetime, timezone
 import json
-from pathlib import Path
 import random
 import signal
 import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import cast
 
 import httpx

--- a/emulators/linux_pos_emulator.py
+++ b/emulators/linux_pos_emulator.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""Linux POS device emulator.
+
+Simulates a Linux POS terminal device for end-to-end testing of the
+Dashboard, User App, and device lifecycle flows without physical hardware.
+
+Usage
+-----
+    python emulators/linux_pos_emulator.py
+    python emulators/linux_pos_emulator.py --config my-device.json
+    python emulators/linux_pos_emulator.py --device-id my-device --bootstrap-key abc123
+
+The emulator provisions itself via ``POST /devices/bootstrap-provision``,
+then runs three concurrent loops:
+
+- **Heartbeat** — ``POST /agent/heartbeat`` at a configurable interval
+- **Telemetry** — ``POST /agent/telemetry`` with simulated CPU/memory/disk metrics
+- **Command polling** — ``GET /devices/pending``, ACK, and respond with mock results
+
+Credentials are persisted to ``~/.homepot/emulators/<device_name>.json``
+so the emulator survives restarts without re-provisioning.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import random
+import signal
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_BACKEND_URL = "http://localhost:8000"
+CREDENTIALS_DIR = Path.home() / ".homepot" / "emulators"
+
+API_BASE_PATH = "/api/v1"
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EmulatorConfig:
+    backend_url: str = DEFAULT_BACKEND_URL
+    site_id: str = ""
+    bootstrap_key: str = ""
+    device_name: str = "linux-pos-emulator-1"
+    device_type: str = "pos_terminal"
+    os_details: str = "Linux 6.8.0 (Debian 12)"
+    mock_mac: str = "02:42:ac:11:00:02"
+    mock_ip: str = "192.168.1.100"
+    mock_hostname: str = "linux-pos-001"
+    heartbeat_interval: float = 10.0
+    telemetry_interval: float = 15.0
+    command_poll_interval: float = 15.0
+
+    @classmethod
+    def from_dict(cls, d: dict) -> EmulatorConfig:
+        return cls(
+            backend_url=d.get("backend_url", DEFAULT_BACKEND_URL),
+            site_id=d.get("site_id", ""),
+            bootstrap_key=d.get("bootstrap_key", ""),
+            device_name=d.get("device_name", "linux-pos-emulator-1"),
+            device_type=d.get("device_type", "pos_terminal"),
+            os_details=d.get("os_details", "Linux 6.8.0 (Debian 12)"),
+            mock_mac=d.get("mock_mac", "02:42:ac:11:00:02"),
+            mock_ip=d.get("mock_ip", "192.168.1.100"),
+            mock_hostname=d.get("mock_hostname", "linux-pos-001"),
+            heartbeat_interval=float(d.get("heartbeat_interval_seconds", 10)),
+            telemetry_interval=float(d.get("telemetry_interval_seconds", 15)),
+            command_poll_interval=float(d.get("command_poll_interval_seconds", 15)),
+        )
+
+    def to_credentials(self, device_id: str, api_key: str) -> dict:
+        return {
+            "device_id": device_id,
+            "api_key": api_key,
+            "site_id": self.site_id,
+            "device_name": self.device_name,
+            "device_type": self.device_type,
+            "os_details": self.os_details,
+            "mock_mac": self.mock_mac,
+            "mock_ip": self.mock_ip,
+            "mock_hostname": self.mock_hostname,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Simulated metrics
+# ---------------------------------------------------------------------------
+
+
+class SimulatedMetrics:
+    """Generates realistic-looking system metrics that vary over time."""
+
+    def __init__(self) -> None:
+        self._cpu_baseline = random.uniform(15, 35)
+        self._mem_baseline = random.uniform(40, 55)
+        self._disk_baseline = random.uniform(30, 45)
+        self._tick = 0
+
+    def sample(self) -> dict[str, float]:
+        self._tick += 1
+
+        cpu = self._cpu_baseline + random.gauss(0, 8)
+        if self._tick % random.randint(15, 30) == 0:
+            cpu += random.uniform(30, 55)
+        cpu = max(0, min(100, cpu))
+
+        mem = self._mem_baseline + random.gauss(0, 3)
+        mem = max(0, min(100, mem))
+
+        disk = self._disk_baseline + random.gauss(0, 1.5)
+        disk = max(0, min(100, disk))
+
+        return {"cpu_usage": round(cpu, 1), "memory_usage": round(mem, 1), "disk_usage": round(disk, 1)}
+
+
+# ---------------------------------------------------------------------------
+# Credential persistence
+# ---------------------------------------------------------------------------
+
+
+def _credentials_path(name: str) -> Path:
+    return CREDENTIALS_DIR / f"{name}.json"
+
+
+def load_credentials(device_name: str) -> dict | None:
+    path = _credentials_path(device_name)
+    if path.exists():
+        try:
+            return json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return None
+    return None
+
+
+def save_credentials(device_name: str, data: dict) -> None:
+    CREDENTIALS_DIR.mkdir(parents=True, exist_ok=True)
+    path = _credentials_path(device_name)
+    path.write_text(json.dumps(data, indent=2))
+    path.chmod(0o600)
+
+
+# ---------------------------------------------------------------------------
+# Emulator
+# ---------------------------------------------------------------------------
+
+
+class LinuxPOSEmulator:
+    """Runs a simulated Linux POS device lifecycle against the backend."""
+
+    def __init__(self, config: EmulatorConfig) -> None:
+        self.config = config
+        self._device_id: str | None = None
+        self._api_key: str | None = None
+        self._shutdown_event = asyncio.Event()
+        self._metrics = SimulatedMetrics()
+        self._client: httpx.AsyncClient | None = None
+        self._http: httpx.AsyncClient | None = None
+
+    @property
+    def device_id(self) -> str:
+        assert self._device_id is not None
+        return self._device_id
+
+    @property
+    def api_key(self) -> str:
+        assert self._api_key is not None
+        return self._api_key
+
+    @property
+    def _backend(self) -> str:
+        return self.config.backend_url.rstrip("/") + API_BASE_PATH
+
+    def _headers(self) -> dict[str, str]:
+        return {"X-Device-ID": self.device_id, "X-API-Key": self.api_key}
+
+    # --
+    # Provisioning
+    # --
+
+    def _try_restore(self) -> bool:
+        creds = load_credentials(self.config.device_name)
+        if creds and creds.get("device_id") and creds.get("api_key"):
+            self._device_id = creds["device_id"]
+            self._api_key = creds["api_key"]
+            self.config.site_id = creds.get("site_id", self.config.site_id)
+            print(f"  Restored credentials for device {self._device_id}")
+            return True
+        return False
+
+    async def _provision(self) -> None:
+        print("  Provisioning via bootstrap-provision ...")
+        payload = {
+            "site_id": self.config.site_id,
+            "bootstrap_key": self.config.bootstrap_key,
+            "device_name": self.config.device_name,
+            "device_type": self.config.device_type,
+            "os_details": self.config.os_details,
+        }
+        resp = await self._http.post(f"{self._backend}/devices/bootstrap-provision", json=payload)
+        if resp.status_code >= 400:
+            body = resp.json()
+            detail = body.get("detail", resp.text)
+            raise RuntimeError(f"Provisioning failed ({resp.status_code}): {detail}")
+
+        data = resp.json()["data"]
+        self._device_id = data["device_id"]
+        self._api_key = data["api_key"]
+        self.config.site_id = data["site_id"]
+
+        save_credentials(self.config.device_name, self.config.to_credentials(self._device_id, self._api_key))
+        print(f"  Provisioned device {self._device_id}")
+
+        await self._register_dna()
+
+    async def _register_dna(self) -> None:
+        print("  Registering device DNA ...")
+        payload = {
+            "device_id": self.device_id,
+            "mac_address": self.config.mock_mac,
+            "local_ip": self.config.mock_ip,
+            "os_details": self.config.os_details,
+            "site_id": self.config.site_id,
+            "device_name": self.config.device_name,
+            "device_type": self.config.device_type,
+        }
+        resp = await self._http.post(f"{self._backend}/agent/device-dna", json=payload, headers=self._headers())
+        if resp.status_code >= 400:
+            print(f"  [dna] warning: registration returned {resp.status_code}: {resp.text[:120]}")
+        else:
+            print(f"  Registered DNA: hostname={self.config.mock_hostname}, MAC={self.config.mock_mac}, IP={self.config.mock_ip}")
+
+    # --
+    # Loops
+    # --
+
+    async def _heartbeat_loop(self) -> None:
+        while not self._shutdown_event.is_set():
+            try:
+                payload = {"device_id": self.device_id, "timestamp": datetime.now(timezone.utc).isoformat()}
+                resp = await self._http.post(f"{self._backend}/agent/heartbeat", json=payload, headers=self._headers())
+                if resp.status_code >= 400:
+                    print(f"  [heartbeat] error: {resp.status_code} {resp.text[:120]}")
+                else:
+                    print(f"  [heartbeat] OK  ({datetime.now(timezone.utc).strftime('%H:%M:%S')})")
+            except httpx.RequestError as exc:
+                print(f"  [heartbeat] connection error: {exc}")
+
+            await self._wait_or_shutdown(self.config.heartbeat_interval)
+
+    async def _telemetry_loop(self) -> None:
+        while not self._shutdown_event.is_set():
+            try:
+                metrics = self._metrics.sample()
+                payload = {"device_id": self.device_id, **metrics, "timestamp": datetime.now(timezone.utc).isoformat()}
+                resp = await self._http.post(f"{self._backend}/agent/telemetry", json=payload, headers=self._headers())
+                if resp.status_code >= 400:
+                    print(f"  [telemetry] error: {resp.status_code} {resp.text[:120]}")
+                else:
+                    print(f"  [telemetry] OK  cpu={metrics['cpu_usage']}% mem={metrics['memory_usage']}% disk={metrics['disk_usage']}%")
+            except httpx.RequestError as exc:
+                print(f"  [telemetry] connection error: {exc}")
+
+            await self._wait_or_shutdown(self.config.telemetry_interval)
+
+    async def _command_poll_loop(self) -> None:
+        while not self._shutdown_event.is_set():
+            try:
+                resp = await self._http.get(f"{self._backend}/devices/pending", headers=self._headers())
+                if resp.status_code >= 400:
+                    print(f"  [commands] poll error: {resp.status_code} {resp.text[:120]}")
+                    await self._wait_or_shutdown(self.config.command_poll_interval)
+                    continue
+
+                commands = resp.json()
+                if not commands:
+                    print(f"  [commands] none pending ({datetime.now(timezone.utc).strftime('%H:%M:%S')})")
+                else:
+                    print(f"  [commands] {len(commands)} pending")
+                    for cmd in commands:
+                        await self._handle_command(cmd)
+            except httpx.RequestError as exc:
+                print(f"  [commands] connection error: {exc}")
+
+            await self._wait_or_shutdown(self.config.command_poll_interval)
+
+    async def _handle_command(self, cmd: dict) -> None:
+        cid = cmd["command_id"]
+        ctype = cmd["command_type"]
+        print(f"  [commands] processing {ctype} ({cid})")
+
+        try:
+            ack_resp = await self._http.post(
+                f"{self._backend}/devices/{self.device_id}/commands/{cid}/ack",
+                headers=self._headers(),
+            )
+            if ack_resp.status_code >= 400:
+                print(f"  [commands] ack failed for {cid}: {ack_resp.status_code}")
+                return
+
+            simulated_result = self._simulate_command_result(ctype)
+            await asyncio.sleep(2)
+
+            status_resp = await self._http.put(
+                f"{self._backend}/devices/{cid}/status",
+                json=simulated_result,
+                headers=self._headers(),
+            )
+            if status_resp.status_code >= 400:
+                print(f"  [commands] status update failed for {cid}: {status_resp.status_code} {status_resp.text[:120]}")
+            else:
+                print(f"  [commands] {ctype} completed ({cid})")
+        except httpx.RequestError as exc:
+            print(f"  [commands] error processing {cid}: {exc}")
+
+    def _simulate_command_result(self, command_type: str) -> dict:
+        outcomes = {
+            "restart": {"status": "COMPLETED", "result": {"message": "Device restart initiated", "reboot_time_seconds": 45}},
+            "shutdown": {"status": "COMPLETED", "result": {"message": "Device shutdown initiated"}},
+            "update_config": {"status": "COMPLETED", "result": {"message": "Configuration updated successfully", "applied_settings": {"log_level": "INFO"}}},
+            "ping": {"status": "COMPLETED", "result": {"message": "pong", "latency_ms": round(random.uniform(5, 50), 1)}},
+        }
+        return outcomes.get(command_type, {"status": "COMPLETED", "result": {"message": f"Unknown command '{command_type}' executed as no-op"}})
+
+    async def _wait_or_shutdown(self, seconds: float) -> None:
+        try:
+            await asyncio.wait_for(self._shutdown_event.wait(), timeout=seconds)
+        except asyncio.TimeoutError:
+            pass
+
+    # --
+    # Lifecycle
+    # --
+
+    async def start(self) -> None:
+        print(f"\n{'='*60}")
+        print(f"  HOMEPOT Linux POS Emulator")
+        print(f"  Device:  {self.config.device_name}")
+        print(f"  Backend: {self.config.backend_url}")
+        print(f"  Mock DNA: hostname={self.config.mock_hostname}, MAC={self.config.mock_mac}, IP={self.config.mock_ip}")
+        print(f"{'='*60}\n")
+
+        async with httpx.AsyncClient(timeout=30.0) as self._http:
+            if not self._try_restore():
+                await self._provision()
+
+            print(f"\n  Device ID: {self.device_id}")
+            print(f"  API Key:   {self.api_key[:16]}...")
+            print(f"  Site ID:   {self.config.site_id}")
+            print(f"\n  Starting loops (heartbeat={self.config.heartbeat_interval}s, telemetry={self.config.telemetry_interval}s, commands={self.config.command_poll_interval}s)")
+            print(f"  Press Ctrl+C to stop.\n")
+
+            await asyncio.gather(
+                self._heartbeat_loop(),
+                self._telemetry_loop(),
+                self._command_poll_loop(),
+            )
+
+    def stop(self) -> None:
+        self._shutdown_event.set()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="HOMEPOT Linux POS Device Emulator")
+    parser.add_argument("--config", "-c", type=str, help="Path to JSON config file")
+    parser.add_argument("--backend-url", type=str, default=DEFAULT_BACKEND_URL, help="Backend URL")
+    parser.add_argument("--site-id", type=str, default="", help="Site ID to provision under")
+    parser.add_argument("--bootstrap-key", type=str, default="", help="Bootstrap key for provisioning")
+    parser.add_argument("--device-name", type=str, default="linux-pos-emulator-1", help="Device name")
+    parser.add_argument("--mock-mac", type=str, default="02:42:ac:11:00:02", help="Mock MAC address")
+    parser.add_argument("--mock-ip", type=str, default="192.168.1.100", help="Mock local IP")
+    parser.add_argument("--mock-hostname", type=str, default="linux-pos-001", help="Mock hostname")
+    parser.add_argument("--heartbeat-interval", type=float, default=10.0, help="Heartbeat interval (seconds)")
+    parser.add_argument("--telemetry-interval", type=float, default=15.0, help="Telemetry interval (seconds)")
+    parser.add_argument("--command-poll-interval", type=float, default=15.0, help="Command poll interval (seconds)")
+    return parser.parse_args(argv)
+
+
+def build_config(args: argparse.Namespace) -> EmulatorConfig:
+    if args.config:
+        path = Path(args.config)
+        if not path.exists():
+            print(f"Config file not found: {path}", file=sys.stderr)
+            sys.exit(1)
+        with open(path) as f:
+            cfg = json.load(f)
+        config = EmulatorConfig.from_dict(cfg)
+        config.backend_url = args.backend_url
+        if args.site_id:
+            config.site_id = args.site_id
+        if args.bootstrap_key:
+            config.bootstrap_key = args.bootstrap_key
+        return config
+
+    return EmulatorConfig(
+        backend_url=args.backend_url,
+        site_id=args.site_id,
+        bootstrap_key=args.bootstrap_key,
+        device_name=args.device_name,
+        mock_mac=args.mock_mac,
+        mock_ip=args.mock_ip,
+        mock_hostname=args.mock_hostname,
+        heartbeat_interval=args.heartbeat_interval,
+        telemetry_interval=args.telemetry_interval,
+        command_poll_interval=args.command_poll_interval,
+    )
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    config = build_config(args)
+
+    if not config.site_id or not config.bootstrap_key:
+        print("Error: --site-id and --bootstrap-key are required", file=sys.stderr)
+        print("  Either pass them on the CLI or provide a --config file.", file=sys.stderr)
+        sys.exit(1)
+
+    emulator = LinuxPOSEmulator(config)
+
+    def _signal_handler() -> None:
+        print("\n  Shutting down ...")
+        emulator.stop()
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, _signal_handler)
+
+    try:
+        loop.run_until_complete(emulator.start())
+    except KeyboardInterrupt:
+        pass
+    finally:
+        print("  Emulator stopped.")
+        loop.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/src/pages/Device/DeviceList.jsx
+++ b/frontend/src/pages/Device/DeviceList.jsx
@@ -151,11 +151,15 @@ export default function DeviceList() {
                   >
                     {device.lifecycle_state?.toUpperCase() || 'UNKNOWN'}
                   </div>
-                  {device.is_simulated && (
+                  {device.enrollment_method === 'emulated' || device.device_source === 'emulator' ? (
+                    <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-cyan-500/10 text-cyan-400 border border-cyan-500/20">
+                      EMU
+                    </span>
+                  ) : device.is_simulated ? (
                     <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-purple-500/10 text-purple-400 border border-purple-500/20">
                       SIM
                     </span>
-                  )}
+                  ) : null}
                 </div>
               </div>
 

--- a/frontend/src/pages/Device/DeviceList.jsx
+++ b/frontend/src/pages/Device/DeviceList.jsx
@@ -151,7 +151,8 @@ export default function DeviceList() {
                   >
                     {device.lifecycle_state?.toUpperCase() || 'UNKNOWN'}
                   </div>
-                  {device.enrollment_method === 'emulated' || device.device_source === 'emulator' ? (
+                  {device.enrollment_method === 'emulated' ||
+                  device.device_source === 'emulator' ? (
                     <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-cyan-500/10 text-cyan-400 border border-cyan-500/20">
                       EMU
                     </span>

--- a/frontend/src/pages/Device/DeviceWidgets.jsx
+++ b/frontend/src/pages/Device/DeviceWidgets.jsx
@@ -489,14 +489,21 @@ export const DeviceInfoWidget = ({ device }) => (
           {device?.credential_status || 'N/A'}
         </span>
       </div>
-      {device?.is_simulated && (
+      {device?.enrollment_method === 'emulated' || device?.device_source === 'emulator' ? (
+        <div className="flex justify-between">
+          <span className="text-slate-400">Source</span>
+          <span className="px-2 py-0.5 rounded text-xs font-medium bg-cyan-500/10 text-cyan-400 border border-cyan-500/20">
+            EMULATED
+          </span>
+        </div>
+      ) : device?.is_simulated ? (
         <div className="flex justify-between">
           <span className="text-slate-400">Source</span>
           <span className="px-2 py-0.5 rounded text-xs font-medium bg-purple-500/10 text-purple-400 border border-purple-500/20">
             SIMULATED
           </span>
         </div>
-      )}
+      ) : null}
       <div className="flex justify-between">
         <span className="text-slate-400">IP Address</span>
         <span className="text-slate-200 font-mono">{device?.ip_address || 'N/A'}</span>

--- a/frontend/src/pages/Sites/SiteDetail.jsx
+++ b/frontend/src/pages/Sites/SiteDetail.jsx
@@ -315,11 +315,15 @@ export default function SiteDetail() {
                               />
                               {device.lifecycle_state || 'Unknown'}
                             </span>
-                            {device.is_simulated && (
+                            {device.enrollment_method === 'emulated' || device.device_source === 'emulator' ? (
+                              <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium bg-cyan-500/10 text-cyan-400 border border-cyan-500/20">
+                                EMU
+                              </span>
+                            ) : device.is_simulated ? (
                               <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium bg-purple-500/10 text-purple-400 border border-purple-500/20">
                                 SIM
                               </span>
-                            )}
+                            ) : null}
                             <span
                               className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium ${
                                 device.health_state === 'healthy'

--- a/frontend/src/pages/Sites/SiteDetail.jsx
+++ b/frontend/src/pages/Sites/SiteDetail.jsx
@@ -315,7 +315,8 @@ export default function SiteDetail() {
                               />
                               {device.lifecycle_state || 'Unknown'}
                             </span>
-                            {device.enrollment_method === 'emulated' || device.device_source === 'emulator' ? (
+                            {device.enrollment_method === 'emulated' ||
+                            device.device_source === 'emulator' ? (
                               <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium bg-cyan-500/10 text-cyan-400 border border-cyan-500/20">
                                 EMU
                               </span>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -162,6 +162,7 @@ nav:
           - POS System (Dummy): POSDummy-Integration.md
       - Agents & Simulation:
           - Agent Simulation: agent-simulation.md
+          - Device Emulators: device-emulators.md
           - Agent Packaging & Identity: agent-packaging-and-identity.md
           - Fleet Load Testing: fleet-simulation.md
           - Real Device Transition: real-device-transition.md

--- a/scripts/start-emulator.sh
+++ b/scripts/start-emulator.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# start-emulator.sh — Launch a HOMEPOT device emulator
+#
+# Usage:
+#   ./scripts/start-emulator.sh                    # uses default config
+#   ./scripts/start-emulator.sh --config emulators/my-device.json
+#   ./scripts/start-emulator.sh --site-id site-1 --bootstrap-key <key>
+#
+# Prerequisites:
+#   - Python virtual environment at .venv/ with httpx installed
+#   - Backend running (start-dashboard.sh)
+#   - A bootstrap key generated for the target site
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$PROJECT_DIR"
+
+# --- Python & venv ----------------------------------------------------------
+
+PYTHON=""
+if [ -f ".venv/bin/python" ]; then
+    PYTHON=".venv/bin/python"
+elif [ -f ".venv/bin/python3" ]; then
+    PYTHON=".venv/bin/python3"
+else
+    echo "Error: Python virtual environment not found at .venv/"
+    echo "  Run: python3 -m venv .venv && source .venv/bin/activate && pip install -e backend/."
+    exit 1
+fi
+
+# --- Config -----------------------------------------------------------------
+
+CONFIG_ARGS=()
+if [[ "$#" -eq 0 ]]; then
+    CONFIG_ARGS=("--config" "emulators/linux_pos_emulator.json")
+fi
+
+# --- Run --------------------------------------------------------------------
+
+echo "Starting HOMEPOT device emulator ..."
+echo "  Python: $PYTHON"
+echo "  Config args: $CONFIG_ARGS $*"
+echo ""
+
+$PYTHON emulators/linux_pos_emulator.py "${CONFIG_ARGS[@]}" "$@"

--- a/scripts/validate-workflows.sh
+++ b/scripts/validate-workflows.sh
@@ -471,11 +471,11 @@ validate_code_quality() {
     # Black formatting (matches CI/CD Pipeline scope)
     if command -v black >/dev/null 2>&1; then
         echo -n "    Black formatting: "
-        log_verbose "Running: black --check backend/src/homepot/ backend/tests/ ai/ uq/"
-        if black --check backend/src/homepot/ backend/tests/ ai/ uq/ 2>/dev/null; then
+        log_verbose "Running: black --check backend/src/homepot/ backend/tests/ ai/ uq/ emulators/"
+        if black --check backend/src/homepot/ backend/tests/ ai/ uq/ emulators/ 2>/dev/null; then
             echo -e "${GREEN}Passed${NC}"
         else
-            echo -e "${RED}Failed - run: black backend/src/homepot/ backend/tests/ ai/ uq/${NC}"
+            echo -e "${RED}Failed - run: black backend/src/homepot/ backend/tests/ ai/ uq/ emulators/${NC}"
             failed=true
         fi
     else
@@ -485,11 +485,11 @@ validate_code_quality() {
     # isort import sorting (matches CI/CD Pipeline scope)
     if command -v isort >/dev/null 2>&1; then
         echo -n "    Import sorting (isort): "
-        log_verbose "Running: isort --check-only backend/src/homepot/ backend/tests/ ai/ uq/"
-        if isort --check-only backend/src/homepot/ backend/tests/ ai/ uq/ 2>/dev/null; then
+        log_verbose "Running: isort --check-only backend/src/homepot/ backend/tests/ ai/ uq/ emulators/"
+        if isort --check-only backend/src/homepot/ backend/tests/ ai/ uq/ emulators/ 2>/dev/null; then
             echo -e "${GREEN}Passed${NC}"
         else
-            echo -e "${RED}Failed - run: isort backend/src/homepot/ backend/tests/ ai/ uq/${NC}"
+            echo -e "${RED}Failed - run: isort backend/src/homepot/ backend/tests/ ai/ uq/ emulators/${NC}"
             failed=true
         fi
     else
@@ -499,11 +499,11 @@ validate_code_quality() {
     # flake8 linting (matches CI/CD Pipeline scope)
     if command -v flake8 >/dev/null 2>&1; then
         echo -n "    Linting (flake8): "
-        log_verbose "Running: flake8 backend/src/homepot/ backend/tests/ ai/ uq/"
-        if flake8 backend/src/homepot/ backend/tests/ ai/ uq/ 2>/dev/null; then
+        log_verbose "Running: flake8 backend/src/homepot/ backend/tests/ ai/ uq/ emulators/"
+        if flake8 backend/src/homepot/ backend/tests/ ai/ uq/ emulators/ 2>/dev/null; then
             echo -e "${GREEN}Passed${NC}"
         else
-            echo -e "${RED}Failed - run: flake8 backend/src/homepot/ backend/tests/ ai/ uq/${NC}"
+            echo -e "${RED}Failed - run: flake8 backend/src/homepot/ backend/tests/ ai/ uq/ emulators/${NC}"
             failed=true
         fi
     else
@@ -513,11 +513,11 @@ validate_code_quality() {
     # MyPy type checking (NEW - matches CI/CD)
     if command -v mypy >/dev/null 2>&1; then
         echo -n "    Type checking (mypy): "
-        log_verbose "Running: mypy --config-file=backend/mypy.ini backend/src/homepot/ ai/ uq/"
+        log_verbose "Running: mypy --config-file=backend/mypy.ini backend/src/homepot/ ai/ uq/ emulators/"
         
         # Capture mypy output to check for specific errors
         local mypy_output
-        if mypy_output=$(mypy --config-file=backend/mypy.ini backend/src/homepot/ ai/ uq/ 2>&1); then
+        if mypy_output=$(mypy --config-file=backend/mypy.ini backend/src/homepot/ ai/ uq/ emulators/ 2>&1); then
             echo -e "${GREEN}Passed${NC}"
         else
             # Check for specific error types
@@ -532,7 +532,7 @@ validate_code_quality() {
                 log_verbose "This indicates missing dependencies in requirements.txt or missing type stubs"
                 log_verbose "Consider installing missing packages or type stubs (e.g., pip install types-*)"
             else
-                echo -e "${RED}Failed - run: mypy --config-file=backend/mypy.ini backend/src/homepot/ ai/ uq/${NC}"
+                echo -e "${RED}Failed - run: mypy --config-file=backend/mypy.ini backend/src/homepot/ ai/ uq/ emulators/${NC}"
                 log_verbose "MyPy failed for other reasons"
                 if [[ "$VERBOSE" == true ]]; then
                     echo "$mypy_output" | head -10 | while read -r line; do

--- a/user_app/electron/main.ts
+++ b/user_app/electron/main.ts
@@ -2,13 +2,17 @@ import { app, BrowserWindow, ipcMain, Tray, Menu, nativeImage, shell } from 'ele
 import path from 'node:path'
 import fs from 'node:fs'
 import os from 'node:os'
+import { spawn, type ChildProcess } from 'node:child_process'
 
 const CREDENTIALS_DIR = path.join(os.homedir(), '.homepot')
 const CREDENTIALS_FILE = path.join(CREDENTIALS_DIR, 'credentials')
 const IDENTITY_FILE = path.join(CREDENTIALS_DIR, 'identity')
+const EMULATOR_DIR = path.join(CREDENTIALS_DIR, 'emulators')
 
 let mainWindow: BrowserWindow | null = null
 let tray: Tray | null = null
+let emulatorProcess: ChildProcess | null = null
+let emulatorDeviceId: string | null = null
 
 function getAssetPath(...segments: string[]): string {
   const dir = __dirname
@@ -188,6 +192,166 @@ function registerIpcHandlers() {
   ipcMain.handle('app:getVersion', () => {
     return app.getVersion()
   })
+
+  ipcMain.handle('emulator:start', async (_event, config: {
+    emulatorType: string
+    backendUrl: string
+    siteId: string
+    bootstrapKey: string
+    deviceName: string
+    mockMac?: string
+    mockIp?: string
+    mockHostname?: string
+  }) => {
+    if (emulatorProcess) {
+      killEmulator()
+    }
+
+    const tempConfig = {
+      backend_url: config.backendUrl,
+      site_id: config.siteId,
+      bootstrap_key: config.bootstrapKey,
+      device_name: config.deviceName,
+      device_type: 'pos_terminal',
+      os_details: config.emulatorType === 'android_pos' ? 'Android 14' : 'Linux 6.8.0 (Debian 12)',
+      mock_mac: config.mockMac ?? (config.emulatorType === 'android_pos' ? '02:42:ac:11:00:03' : '02:42:ac:11:00:02'),
+      mock_ip: config.mockIp ?? '192.168.1.100',
+      mock_hostname: config.mockHostname ?? config.deviceName,
+      heartbeat_interval_seconds: 10,
+      telemetry_interval_seconds: 15,
+      command_poll_interval_seconds: 15,
+    }
+
+    ensureCredentialsDir()
+    if (!fs.existsSync(EMULATOR_DIR)) {
+      fs.mkdirSync(EMULATOR_DIR, { recursive: true, mode: 0o700 })
+    }
+
+    const configPath = path.join(EMULATOR_DIR, `${config.deviceName}-config.json`)
+    fs.writeFileSync(configPath, JSON.stringify(tempConfig, null, 2), { mode: 0o600 })
+
+    const credsPath = path.join(EMULATOR_DIR, `${config.deviceName}.json`)
+    if (fs.existsSync(credsPath)) {
+      fs.unlinkSync(credsPath)
+    }
+
+    const projectRoot = getProjectRoot()
+    const emulatorScript = path.join(projectRoot, 'emulators', `${config.emulatorType}_emulator.py`)
+    if (!fs.existsSync(emulatorScript)) {
+      throw new Error(`Emulator script not found: ${emulatorScript}`)
+    }
+
+    const pythonExe = findPython()
+    emulatorProcess = spawn(pythonExe, [emulatorScript, '--config', configPath], {
+      cwd: projectRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    emulatorProcess.stdout?.on('data', (data: Buffer) => {
+      const lines = data.toString().split('\n').filter(Boolean)
+      for (const line of lines) {
+        console.log(`[emulator] ${line}`)
+      }
+    })
+
+    emulatorProcess.stderr?.on('data', (data: Buffer) => {
+      console.error(`[emulator:err] ${data.toString().trim()}`)
+    })
+
+    emulatorProcess.on('exit', (code) => {
+      console.log(`[emulator] exited with code ${code}`)
+      emulatorProcess = null
+      emulatorDeviceId = null
+    })
+
+    const creds = await pollForCredentials(credsPath, 30_000)
+    if (!creds) {
+      killEmulator()
+      throw new Error('Emulator did not provision within 30 seconds')
+    }
+
+    emulatorDeviceId = creds.device_id
+    return { deviceId: creds.device_id, apiKey: creds.api_key }
+  })
+
+  ipcMain.handle('emulator:stop', async () => {
+    killEmulator()
+    return true
+  })
+
+  ipcMain.handle('emulator:status', async () => {
+    return {
+      running: emulatorProcess !== null,
+      pid: emulatorProcess?.pid ?? null,
+      deviceId: emulatorDeviceId,
+    }
+  })
+}
+
+function killEmulator(): void {
+  if (!emulatorProcess) return
+  try {
+    emulatorProcess.kill('SIGTERM')
+    const killed = emulatorProcess.killed
+    emulatorProcess = null
+    emulatorDeviceId = null
+    if (!killed) {
+      setTimeout(() => {
+        try { emulatorProcess?.kill('SIGKILL') } catch { /* ignore */ }
+      }, 3000)
+    }
+  } catch {
+    emulatorProcess = null
+    emulatorDeviceId = null
+  }
+}
+
+function findPython(): string {
+  const candidates = [
+    path.join(process.cwd(), '.venv', 'bin', 'python3'),
+    path.join(process.cwd(), '.venv', 'Scripts', 'python.exe'),
+    'python3',
+    'python',
+  ]
+  for (const candidate of candidates) {
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK)
+      return candidate
+    } catch {
+      // Try next candidate
+    }
+  }
+  return 'python3'
+}
+
+function getProjectRoot(): string {
+  if (process.env.VITE_DEV_SERVER_URL) {
+    return process.cwd()
+  }
+  return path.dirname(app.getAppPath())
+}
+
+function pollForCredentials(credsPath: string, timeoutMs: number): Promise<Record<string, string> | null> {
+  return new Promise((resolve) => {
+    const start = Date.now()
+    const poll = () => {
+      if (fs.existsSync(credsPath)) {
+        try {
+          const data = JSON.parse(fs.readFileSync(credsPath, 'utf-8'))
+          if (data.device_id && data.api_key) {
+            resolve(data)
+            return
+          }
+        } catch { /* file may still be being written */ }
+      }
+      if (Date.now() - start >= timeoutMs) {
+        resolve(null)
+        return
+      }
+      setTimeout(poll, 500)
+    }
+    poll()
+  })
 }
 
 app.whenReady().then(() => {
@@ -200,6 +364,10 @@ app.whenReady().then(() => {
       createWindow()
     }
   })
+})
+
+app.on('before-quit', () => {
+  killEmulator()
 })
 
 app.on('window-all-closed', () => {

--- a/user_app/electron/preload.ts
+++ b/user_app/electron/preload.ts
@@ -15,4 +15,18 @@ contextBridge.exposeInMainWorld('electronAPI', {
   app: {
     getVersion: () => ipcRenderer.invoke('app:getVersion'),
   },
+  emulator: {
+    start: (config: {
+      emulatorType: string
+      backendUrl: string
+      siteId: string
+      bootstrapKey: string
+      deviceName: string
+      mockMac?: string
+      mockIp?: string
+      mockHostname?: string
+    }) => ipcRenderer.invoke('emulator:start', config),
+    stop: () => ipcRenderer.invoke('emulator:stop'),
+    status: () => ipcRenderer.invoke('emulator:status'),
+  },
 })

--- a/user_app/src/App.tsx
+++ b/user_app/src/App.tsx
@@ -25,6 +25,8 @@ export default function App() {
         <Routes>
           <Route path="/" element={<Wrapped><RootRedirect /></Wrapped>} />
           <Route path="/setup" element={<Wrapped><SetupWizard /></Wrapped>} />
+          <Route path="/setup/mode" element={<Wrapped><SetupWizard /></Wrapped>} />
+          <Route path="/setup/emulator" element={<Wrapped><SetupWizard /></Wrapped>} />
           <Route path="/setup/review" element={<Wrapped><SetupWizard /></Wrapped>} />
           <Route path="/signin" element={<Wrapped><SignIn /></Wrapped>} />
           <Route path="/home" element={<Wrapped><HomeDashboard /></Wrapped>} />

--- a/user_app/src/App.tsx
+++ b/user_app/src/App.tsx
@@ -25,8 +25,8 @@ export default function App() {
         <Routes>
           <Route path="/" element={<Wrapped><RootRedirect /></Wrapped>} />
           <Route path="/setup" element={<Wrapped><SetupWizard /></Wrapped>} />
-          <Route path="/setup/mode" element={<Wrapped><SetupWizard /></Wrapped>} />
-          <Route path="/setup/emulator" element={<Wrapped><SetupWizard /></Wrapped>} />
+          <Route path="/method" element={<Wrapped><SetupWizard /></Wrapped>} />
+          <Route path="/emulator" element={<Wrapped><SetupWizard /></Wrapped>} />
           <Route path="/setup/review" element={<Wrapped><SetupWizard /></Wrapped>} />
           <Route path="/signin" element={<Wrapped><SignIn /></Wrapped>} />
           <Route path="/home" element={<Wrapped><HomeDashboard /></Wrapped>} />

--- a/user_app/src/context/AppContext.tsx
+++ b/user_app/src/context/AppContext.tsx
@@ -23,6 +23,12 @@ interface AppContextType {
   setIsProvisioned: (val: boolean) => void
   setupState: SetupState
   setSetupState: (state: SetupState) => void
+  useEmulator: boolean
+  setUseEmulator: (val: boolean) => void
+  emulatorType: string
+  setEmulatorType: (val: string) => void
+  isEmulatorRunning: boolean
+  setIsEmulatorRunning: (val: boolean) => void
 }
 
 const AppContext = createContext<AppContextType | null>(null)
@@ -38,12 +44,18 @@ export function AppProvider({ children }: { children: ReactNode }) {
     deviceOs: 'linux',
     bootstrapKey: '',
   })
+  const [useEmulator, setUseEmulator] = useState(false)
+  const [emulatorType, setEmulatorType] = useState('linux_pos')
+  const [isEmulatorRunning, setIsEmulatorRunning] = useState(false)
 
   return (
     <AppContext.Provider value={{
       deviceInfo, setDeviceInfo,
       isProvisioned, setIsProvisioned,
       setupState, setSetupState,
+      useEmulator, setUseEmulator,
+      emulatorType, setEmulatorType,
+      isEmulatorRunning, setIsEmulatorRunning,
     }}>
       {children}
     </AppContext.Provider>

--- a/user_app/src/services/credentialStorage.ts
+++ b/user_app/src/services/credentialStorage.ts
@@ -33,6 +33,20 @@ declare global {
       app: {
         getVersion(): Promise<string>
       }
+      emulator: {
+        start(config: {
+          emulatorType: string
+          backendUrl: string
+          siteId: string
+          bootstrapKey: string
+          deviceName: string
+          mockMac?: string
+          mockIp?: string
+          mockHostname?: string
+        }): Promise<{ deviceId: string; apiKey: string }>
+        stop(): Promise<boolean>
+        status(): Promise<{ running: boolean; pid: number | null; deviceId: string | null }>
+      }
     }
   }
 }

--- a/user_app/src/test/integration.test.tsx
+++ b/user_app/src/test/integration.test.tsx
@@ -19,7 +19,7 @@ function ok(body: unknown) {
 describe('App routing', () => {
   it('redirects unprovisioned user from / to setup wizard', async () => {
     render(<App />)
-    expect(await screen.findByText('Step 1 of 3')).toBeInTheDocument()
+    expect(await screen.findByText('Step 1 of 4')).toBeInTheDocument()
   })
 
   it('redirects provisioned user from / to dashboard', async () => {
@@ -73,6 +73,6 @@ describe('App routing', () => {
   it('unknown path redirects to /', async () => {
     window.history.pushState({}, '', '/nonexistent')
     render(<App />)
-    expect(await screen.findByText('Step 1 of 3')).toBeInTheDocument()
+    expect(await screen.findByText('Step 1 of 4')).toBeInTheDocument()
   })
 })

--- a/user_app/src/views/SetupWizard.tsx
+++ b/user_app/src/views/SetupWizard.tsx
@@ -4,12 +4,17 @@ import { useApp } from '../context/AppContext'
 import { apiBaseUrl } from '../config/api'
 import { credentialStorage } from '../services/credentialStorage'
 
+const EMULATOR_TYPES: { value: string; label: string; os: string; description: string }[] = [
+  { value: 'linux_pos', label: 'Linux POS', os: 'Linux 6.8.0 (Debian 12)', description: 'Simulates a Linux-based POS terminal' },
+  { value: 'android_pos', label: 'Android POS', os: 'Android 14', description: 'Simulates an Android POS tablet' },
+]
+
 function formatDeviceType(v: string) {
   return v.replace('_', ' ').replace(/\b\w/g, c => c.toUpperCase())
 }
 
 function StepIndicator({ current }: { current: number }) {
-  const STEPS = ['Device Setup', 'Bootstrap Key', 'Complete']
+  const STEPS = ['Device Setup', 'Method', 'Emulator', 'Complete']
   return (
     <div className="flex items-center justify-center gap-2 w-full">
       {STEPS.map((label, i) => (
@@ -47,7 +52,7 @@ function Step1() {
 
   const handleNext = () => {
     setSetupState({ siteId, deviceName, deviceType, deviceOs, bootstrapKey: setupState.bootstrapKey })
-    navigate('/signin')
+    navigate('/setup/mode')
   }
 
   return (
@@ -132,7 +137,7 @@ function Step1() {
 
 function ReviewStep({ onBack }: { onBack: () => void }) {
   const navigate = useNavigate()
-  const { setupState, setIsProvisioned } = useApp()
+  const { setupState, useEmulator, emulatorType, setIsProvisioned, setIsEmulatorRunning } = useApp()
   const { siteId, deviceName, deviceType, deviceOs, bootstrapKey } = setupState
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
@@ -142,6 +147,32 @@ function ReviewStep({ onBack }: { onBack: () => void }) {
     setLoading(true)
     setError('')
     try {
+      if (useEmulator && window.electronAPI?.emulator) {
+        const config = {
+          emulatorType,
+          backendUrl: apiBaseUrl.replace('/api/v1', ''),
+          siteId,
+          bootstrapKey,
+          deviceName: deviceName || 'Emulated Device',
+          deviceType,
+        }
+        const result = await window.electronAPI.emulator.start(config)
+        await credentialStorage.save({
+          deviceId: result.deviceId,
+          apiKey: result.apiKey,
+          siteId,
+          deviceName: deviceName || 'Emulated Device',
+          deviceType,
+          deviceOs,
+          enrollmentMethod: 'emulated',
+        })
+        setLoading(false)
+        setIsEmulatorRunning(true)
+        setIsProvisioned(true)
+        navigate('/home')
+        return
+      }
+
       if (isDev) {
         await credentialStorage.save({
           deviceId: `dev-device-${Date.now()}`,
@@ -245,10 +276,157 @@ function ReviewStep({ onBack }: { onBack: () => void }) {
   )
 }
 
+function EmulatorConfigStep() {
+  const navigate = useNavigate()
+  const { emulatorType, setEmulatorType, setUseEmulator, setSetupState, setupState } = useApp()
+  const selected = EMULATOR_TYPES.find(t => t.value === emulatorType) ?? EMULATOR_TYPES[0]
+
+  const handleNext = () => {
+    setUseEmulator(true)
+    setSetupState({ ...setupState, deviceOs: selected.os })
+    navigate('/setup/review')
+  }
+
+  return (
+    <div className="flex flex-col gap-5 w-full">
+      <div className="text-center">
+        <h2 className="text-slate-200 font-semibold text-base">Configure Emulator</h2>
+        <p className="text-slate-400 text-xs mt-1">Choose the device type to simulate.</p>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {EMULATOR_TYPES.map(t => (
+          <button
+            key={t.value}
+            onClick={() => setEmulatorType(t.value)}
+            className={`w-full text-left px-4 py-3 rounded-lg border-2 transition-colors ${
+              emulatorType === t.value
+                ? 'border-emerald-500 bg-slate-700'
+                : 'border-slate-600 bg-slate-700/50 hover:border-slate-500'
+            }`}
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-slate-200 font-medium text-sm">{t.label}</span>
+              {emulatorType === t.value && (
+                <span className="text-emerald-400 text-sm">✓</span>
+              )}
+            </div>
+            <p className="text-slate-400 text-xs mt-1">{t.description}</p>
+            <p className="text-slate-500 text-xs">{t.os}</p>
+          </button>
+        ))}
+      </div>
+
+      <div className="flex gap-3 mt-2">
+        <button
+          onClick={() => navigate('/setup/mode')}
+          className="flex-1 py-3 rounded-lg border border-slate-600 text-slate-300 hover:text-white hover:bg-slate-700 font-semibold text-sm transition-colors"
+        >
+          Back
+        </button>
+        <button
+          onClick={handleNext}
+          className="flex-[2] py-3 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white font-semibold text-sm transition-colors"
+        >
+          Next →
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function ModeStep() {
+  const navigate = useNavigate()
+  const { useEmulator, setUseEmulator, setEmulatorType } = useApp()
+  const [mode, setMode] = useState<'real' | 'emulator'>(useEmulator ? 'emulator' : 'real')
+
+  const handleNext = () => {
+    if (mode === 'emulator') {
+      setUseEmulator(true)
+      if (!EMULATOR_TYPES.find(t => t.value === useEmulator)) {
+        setEmulatorType(EMULATOR_TYPES[0].value)
+      }
+      navigate('/setup/emulator')
+    } else {
+      setUseEmulator(false)
+      navigate('/signin')
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-5 w-full">
+      <div className="text-center">
+        <h2 className="text-slate-200 font-semibold text-base">Setup Method</h2>
+        <p className="text-slate-400 text-xs mt-1">Choose how to set up this device.</p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <button
+          onClick={() => setMode('real')}
+          className={`w-full text-left px-4 py-4 rounded-lg border-2 transition-colors ${
+            mode === 'real' ? 'border-emerald-500 bg-slate-700' : 'border-slate-600 bg-slate-700/50 hover:border-slate-500'
+          }`}
+        >
+          <div className="flex items-center justify-between">
+            <span className="text-slate-200 font-medium text-sm">Set up a real device</span>
+            {mode === 'real' && <span className="text-emerald-400 text-sm">✓</span>}
+          </div>
+          <p className="text-slate-400 text-xs mt-1">Provision a physical device using a bootstrap key.</p>
+        </button>
+
+        <button
+          onClick={() => setMode('emulator')}
+          className={`w-full text-left px-4 py-4 rounded-lg border-2 transition-colors ${
+            mode === 'emulator' ? 'border-emerald-500 bg-slate-700' : 'border-slate-600 bg-slate-700/50 hover:border-slate-500'
+          }`}
+        >
+          <div className="flex items-center justify-between">
+            <span className="text-slate-200 font-medium text-sm">Launch emulated device</span>
+            {mode === 'emulator' && <span className="text-emerald-400 text-sm">✓</span>}
+          </div>
+          <p className="text-slate-400 text-xs mt-1">Start a simulated device for development and testing.</p>
+        </button>
+      </div>
+
+      <div className="flex gap-3 mt-2">
+        <button
+          onClick={() => navigate('/setup')}
+          className="flex-1 py-3 rounded-lg border border-slate-600 text-slate-300 hover:text-white hover:bg-slate-700 font-semibold text-sm transition-colors"
+        >
+          Back
+        </button>
+        <button
+          onClick={handleNext}
+          className="flex-[2] py-3 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white font-semibold text-sm transition-colors"
+        >
+          Next →
+        </button>
+      </div>
+    </div>
+  )
+}
+
 export default function SetupWizard() {
   const navigate = useNavigate()
   const location = useLocation()
   const isReview = location.pathname === '/setup/review'
+  const isEmulatorConfig = location.pathname === '/setup/emulator'
+  const isMode = location.pathname === '/setup/mode'
+
+  let stepIndex = 0
+  if (isMode) stepIndex = 1
+  else if (isEmulatorConfig) stepIndex = 2
+  else if (isReview) stepIndex = 3
+
+  const maxSteps = 4
+  const totalSteps = maxSteps
+
+  function renderStep() {
+    if (isReview) return <ReviewStep onBack={() => navigate(isEmulatorConfig ? '/setup/emulator' : '/setup')} />
+    if (isEmulatorConfig) return <EmulatorConfigStep />
+    if (isMode) return <ModeStep />
+    return <Step1 />
+  }
 
   return (
     <div className="min-h-screen bg-slate-900 flex items-center justify-center p-4 font-sans">
@@ -259,10 +437,10 @@ export default function SetupWizard() {
           <p className="text-slate-500 text-xs">Device Setup</p>
         </div>
 
-        <StepIndicator current={isReview ? 2 : 0} />
+        <StepIndicator current={stepIndex} />
 
         <div className="border-t border-slate-700 pt-4">
-          {!isReview && (
+          {!isReview && !isMode && !isEmulatorConfig && (
             <div className="mb-4">
               <button
                 onClick={() => navigate('/claim')}
@@ -275,15 +453,11 @@ export default function SetupWizard() {
             </div>
           )}
 
-          {isReview ? (
-            <ReviewStep onBack={() => navigate('/setup')} />
-          ) : (
-            <Step1 />
-          )}
+          {renderStep()}
         </div>
 
         <p className="text-center text-slate-600 text-xs">
-          Step {isReview ? 3 : 1} of 3
+          Step {stepIndex + 1} of {totalSteps}
         </p>
       </div>
     </div>

--- a/user_app/src/views/SetupWizard.tsx
+++ b/user_app/src/views/SetupWizard.tsx
@@ -52,7 +52,7 @@ function Step1() {
 
   const handleNext = () => {
     setSetupState({ siteId, deviceName, deviceType, deviceOs, bootstrapKey: setupState.bootstrapKey })
-    navigate('/setup/mode')
+    navigate('/method')
   }
 
   return (
@@ -319,7 +319,7 @@ function EmulatorConfigStep() {
 
       <div className="flex gap-3 mt-2">
         <button
-          onClick={() => navigate('/setup/mode')}
+          onClick={() => navigate('/method')}
           className="flex-1 py-3 rounded-lg border border-slate-600 text-slate-300 hover:text-white hover:bg-slate-700 font-semibold text-sm transition-colors"
         >
           Back
@@ -346,7 +346,7 @@ function ModeStep() {
       if (!EMULATOR_TYPES.find(t => t.value === useEmulator)) {
         setEmulatorType(EMULATOR_TYPES[0].value)
       }
-      navigate('/setup/emulator')
+      navigate('/emulator')
     } else {
       setUseEmulator(false)
       navigate('/signin')
@@ -410,8 +410,8 @@ export default function SetupWizard() {
   const navigate = useNavigate()
   const location = useLocation()
   const isReview = location.pathname === '/setup/review'
-  const isEmulatorConfig = location.pathname === '/setup/emulator'
-  const isMode = location.pathname === '/setup/mode'
+  const isEmulatorConfig = location.pathname === '/emulator'
+  const isMode = location.pathname === '/method'
 
   let stepIndex = 0
   if (isMode) stepIndex = 1
@@ -422,7 +422,7 @@ export default function SetupWizard() {
   const totalSteps = maxSteps
 
   function renderStep() {
-    if (isReview) return <ReviewStep onBack={() => navigate(isEmulatorConfig ? '/setup/emulator' : '/setup')} />
+    if (isReview) return <ReviewStep onBack={() => navigate(isEmulatorConfig ? '/emulator' : '/setup')} />
     if (isEmulatorConfig) return <EmulatorConfigStep />
     if (isMode) return <ModeStep />
     return <Step1 />

--- a/user_app/src/views/SignIn.tsx
+++ b/user_app/src/views/SignIn.tsx
@@ -68,7 +68,7 @@ export default function SignIn() {
                 Dev: Skip Bootstrap Key
               </button>
             )}
-            <button onClick={() => navigate('/setup')} className="w-full py-2 rounded-lg border border-slate-600 text-slate-400 hover:text-slate-200 text-sm transition-colors">
+            <button onClick={() => navigate('/method')} className="w-full py-2 rounded-lg border border-slate-600 text-slate-400 hover:text-slate-200 text-sm transition-colors">
               Back
             </button>
           </div>

--- a/user_app/src/views/SignIn.tsx
+++ b/user_app/src/views/SignIn.tsx
@@ -21,19 +21,19 @@ export default function SignIn() {
           <p className="text-slate-500 text-xs">Bootstrap Key</p>
         </div>
         <div className="flex items-center justify-center gap-2 w-full">
-          {['Device Setup', 'Bootstrap Key', 'Complete'].map((label, i) => (
+          {['Device Setup', 'Method', 'Bootstrap Key', 'Complete'].map((label, i) => (
             <div key={label} className="flex items-center gap-2">
               <div className="flex flex-col items-center gap-1">
                 <div className={`w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold border-2 transition-colors ${
-                  i < 1 ? 'bg-emerald-500 border-emerald-500 text-white'
-                  : i === 1 ? 'border-emerald-500 text-emerald-400 bg-slate-900'
+                  i < 2 ? 'bg-emerald-500 border-emerald-500 text-white'
+                  : i === 2 ? 'border-emerald-500 text-emerald-400 bg-slate-900'
                   : 'border-slate-600 text-slate-500 bg-slate-900'
                 }`}>
-                  {i < 1 ? '✓' : i + 1}
+                  {i < 2 ? '✓' : i + 1}
                 </div>
-                <span className={`text-xs ${i === 1 ? 'text-emerald-400' : 'text-slate-500'}`}>{label}</span>
+                <span className={`text-xs ${i === 2 ? 'text-emerald-400' : 'text-slate-500'}`}>{label}</span>
               </div>
-              {i < 2 && <div className={`w-10 h-0.5 mb-4 ${i < 1 ? 'bg-emerald-500' : 'bg-slate-700'}`} />}
+              {i < 3 && <div className={`w-10 h-0.5 mb-4 ${i < 2 ? 'bg-emerald-500' : 'bg-slate-700'}`} />}
             </div>
           ))}
         </div>
@@ -73,7 +73,7 @@ export default function SignIn() {
             </button>
           </div>
         </div>
-        <p className="text-center text-slate-600 text-xs">Step 2 of 3</p>
+        <p className="text-center text-slate-600 text-xs">Step 3 of 4</p>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Adds a standalone device emulator framework for end-to-end testing of the Dashboard, User App, and device lifecycle flows without physical hardware. Distinguishes emulator-provisioned devices (EMU badge) from seed-data simulated devices (SIM badge).

## New files

| File | Purpose |
|------|---------|
| `emulators/linux_pos_emulator.py` | Standalone Linux POS emulator |
| `emulators/linux_pos_emulator.json` | Example config |
| `emulators/__init__.py` | Package init |
| `scripts/start-emulator.sh` | Convenience launcher |
| `docs/device-emulators.md` | Full documentation |

## Backend changes

| File | Change |
|------|--------|
| `models.py` | Added `EMULATED` to `EnrollmentMethod` enum |
| `schemas/bootstrap.py` | Added `provisioning_source` field |
| `schemas/agent.py` | Added `device_source` field |
| `repositories/agent_repository.py` | Added `is_simulated` kwarg |
| `services/agent_service.py` | Emulator provision sets `is_simulated`, `enrollment_method=EMULATED`, stores `device_source` in config |
| `DevicesEndpoints.py` | Exposed `enrollment_method` and `device_source` in API responses |

## Emulator changes

- Sends `provisioning_source: "emulator"` during bootstrap provision
- Sends `device_source: "emulator"` during DNA registration (runs on every startup)
- Uses lowercase status strings to match backend `CommandStatus` enum

## Frontend changes

- `DeviceList.jsx`, `DeviceWidgets.jsx`, `SiteDetail.jsx` — EMU (cyan) badge for emulated, SIM (purple) badge for seed-data simulated

## User App integration

- `electron/main.ts` — `emulator:start/stop/status` IPC handlers
- `electron/preload.ts` — Exposed emulator channels
- `AppContext.tsx` — Emulator state fields
- `SetupWizard.tsx` — Mode step (real device vs emulator), emulator type picker
- `App.tsx` — Routes `/method`, `/emulator`
- All 37 tests pass

## CI / Tooling

- CI checks include `emulators/` (black, isort, flake8, mypy)
- Documentation added to `mkdocs.yml` nav
- Fixed isort config (`multi_line_output` conflict)
- Restart instructions in `device-emulators.md`