### PR TITLE
fix: resolve real-device testing blockers (lifecycle persistence, migrations, agent shutdown)

### DIFF
--- a/backend/src/homepot/agent/real_device_agent.py
+++ b/backend/src/homepot/agent/real_device_agent.py
@@ -387,6 +387,22 @@ async def _wait_with_shutdown(interval: int, shutdown_event: asyncio.Event) -> N
         shutdown_event.set()
 
 
+async def _force_shutdown_after_timeout(
+    shutdown_event: asyncio.Event, timeout: float
+) -> None:
+    """Force-exit if graceful shutdown does not complete within *timeout*.
+
+    The countdown only starts once ``shutdown_event`` is set (by a signal
+    handler or the service wrapper), so the agent runs indefinitely under
+    normal operation and this task is a pure backstop for tasks that hang
+    during shutdown.
+    """
+    await shutdown_event.wait()
+    await asyncio.sleep(timeout)
+    logger.warning("Shutdown timeout (%ss) reached, forcing exit", timeout)
+    os._exit(1)
+
+
 def _pop_next_result(app: Any) -> tuple[Optional[str], Optional[Dict[str, Any]]]:
     """Pop the first available command result from IPC storage."""
     with app.state.state_lock:
@@ -764,11 +780,11 @@ async def run_agent(
     if push_listener.wns_channel_mgr is not None:
         push_channel_uri = push_listener.wns_channel_mgr.get_stored_uri()
 
+    shutdown_timeout = int(config.get("shutdown_timeout_seconds", 30))
+
     if shutdown_event is None:
         shutdown_event = asyncio.Event()
         loop = asyncio.get_running_loop()
-
-        shutdown_timeout = int(config.get("shutdown_timeout_seconds", 30))
 
         def _handle_signal() -> None:
             """Set the shutdown event and log the signal."""
@@ -780,19 +796,14 @@ async def run_agent(
             loop.add_signal_handler(signal.SIGINT, _handle_signal)
         except NotImplementedError:
             logger.warning("Signal handlers not supported on this platform")
-
-        async def _shutdown_after_timeout() -> None:
-            """Force shutdown if the agent does not stop gracefully within the timeout."""
-            await asyncio.sleep(shutdown_timeout)
-            if not shutdown_event.is_set():
-                logger.warning(
-                    "Shutdown timeout (%ss) reached, forcing exit", shutdown_timeout
-                )
-                shutdown_event.set()
-
-        asyncio.ensure_future(_shutdown_after_timeout())
     else:
         loop = asyncio.get_running_loop()
+
+    # Force-exit backstop: waits for the shutdown event before starting its
+    # countdown, so it never fires during normal operation.
+    force_exit_task = asyncio.ensure_future(
+        _force_shutdown_after_timeout(shutdown_event, shutdown_timeout)
+    )
 
     async def _cancel_on_shutdown(tasks: list) -> None:
         """Cancel all agent tasks when shutdown_event is set."""
@@ -842,6 +853,9 @@ async def run_agent(
             logger.error("Agent runtime error: %s", e, exc_info=True)
 
     logger.info("Agent stopped")
+
+    # Cancel the force-exit backstop now that shutdown has completed.
+    force_exit_task.cancel()
 
     # Cleanup
     await push_listener.stop()

--- a/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
@@ -836,6 +836,10 @@ async def unpair_device(
         device.lifecycle_state = LifecycleState.UNPAIRED.value  # type: ignore[assignment]
         device.is_active = False  # type: ignore[assignment]
         device.api_key_hash = None  # type: ignore[assignment]
+        # The device was loaded via get_device_by_device_id, whose session is
+        # already closed; merge the changes back into a fresh session so the
+        # state transition actually persists.
+        await db_service.persist_device(device)
 
         # ----- Audit event -----
         ip_address = request.client.host if request.client else None
@@ -1014,6 +1018,8 @@ async def suspend_device(
 
         device.lifecycle_state = LifecycleState.SUSPENDED.value  # type: ignore[assignment]
 
+        await db_service.persist_device(device)
+
         await _record_lifecycle_event(
             db_service,
             device,
@@ -1101,6 +1107,8 @@ async def resume_device(
             )
 
         device.lifecycle_state = LifecycleState.ACTIVE.value  # type: ignore[assignment]
+
+        await db_service.persist_device(device)
 
         await _record_lifecycle_event(
             db_service,
@@ -1198,6 +1206,8 @@ async def retire_device(
         device.lifecycle_state = LifecycleState.RETIRED.value  # type: ignore[assignment]
         device.is_active = False  # type: ignore[assignment]
         device.api_key_hash = None  # type: ignore[assignment]
+
+        await db_service.persist_device(device)
 
         # Revoke active credentials
         async with db_service.get_session() as session:
@@ -1310,7 +1320,11 @@ async def reenrol_device(
             raise HTTPException(status_code=403, detail="User not found")
         db_service = await get_database_service()
 
-        device = await db_service.get_device_by_device_id(device_id)
+        # Re-enrolment targets unpaired devices, which have is_active=False,
+        # so bypass the default active-only filter.
+        device = await db_service.get_device_by_device_id(
+            device_id, include_unpaired=True
+        )
         if not device:
             raise HTTPException(status_code=404, detail="Device not found")
 
@@ -1398,6 +1412,8 @@ async def reenrol_device(
             )
             session.add(new_credential)
         device.api_key_hash = new_key_hash  # type: ignore[assignment]
+
+        await db_service.persist_device(device)
 
         await _record_lifecycle_event(
             db_service,
@@ -1559,6 +1575,7 @@ async def transfer_device(
                     current_epoch.ended_at = now  # type: ignore[assignment]
 
         # Update device
+        old_site_id = str(device.site_id)
         device.site_id = int(target_site.id)  # type: ignore[assignment]
         device.lifecycle_state = LifecycleState.ACTIVE.value  # type: ignore[assignment]
         device.is_active = True  # type: ignore[assignment]
@@ -1606,6 +1623,8 @@ async def transfer_device(
             session.add(new_credential)
         device.api_key_hash = new_key_hash  # type: ignore[assignment]
 
+        await db_service.persist_device(device)
+
         await _record_lifecycle_event(
             db_service,
             device,
@@ -1622,8 +1641,8 @@ async def transfer_device(
         await audit_logger.log_event(
             AuditEventType.DEVICE_TRANSFERRED,
             f"Device '{device.name}' ({device.device_id}) transferred from site "
-            f"'{device.site_id if hasattr(device, 'site_id') else 'unknown'}' "
-            f"to '{payload.target_site_id}' by {current_user['email']}"
+            f"'{old_site_id}' to '{payload.target_site_id}' by "
+            f"{current_user['email']}"
             + (f" — {payload.reason}" if payload.reason else ""),
             device_id=int(device.id),
             site_id=int(target_site.id),
@@ -1632,7 +1651,7 @@ async def transfer_device(
             user_agent=user_agent,
             old_values={
                 "lifecycle_state": current_lifecycle,
-                "site_id": str(device.site_id),
+                "site_id": old_site_id,
             },
             new_values={
                 "lifecycle_state": LifecycleState.ACTIVE.value,

--- a/backend/src/homepot/database.py
+++ b/backend/src/homepot/database.py
@@ -341,18 +341,44 @@ class DatabaseService:
             )
             return result.scalar_one_or_none()
 
-    async def get_device_by_device_id(self, device_id: str) -> Optional[Device]:
-        """Get Device by device_id."""
+    async def get_device_by_device_id(
+        self, device_id: str, include_unpaired: bool = False
+    ) -> Optional[Device]:
+        """Get Device by device_id.
+
+        Args:
+            device_id: Business ID of the device (string).
+            include_unpaired: If True, also return soft-deleted/unpaired
+                devices (``is_active`` is False) so they can be re-enrolled.
+        """
         from sqlalchemy import select
         from sqlalchemy.orm import joinedload
 
         async with self.get_session() as session:
-            result = await session.execute(
+            query = (
                 select(Device)
                 .options(joinedload(Device.site), joinedload(Device.credentials))
-                .where(Device.device_id == device_id, Device.is_active.is_(True))
+                .where(Device.device_id == device_id)
             )
+            if not include_unpaired:
+                query = query.where(Device.is_active.is_(True))
+            result = await session.execute(query)
             return result.unique().scalar_one_or_none()
+
+    async def persist_device(self, device: Device) -> Device:
+        """Persist changes to a (possibly detached) ``Device`` instance.
+
+        :meth:`get_device_by_device_id` returns a ``Device`` whose session
+        is closed, so attribute changes made after that call are not
+        written to the database.  Lifecycle endpoints mutate the returned
+        object and call this method to merge those changes into a fresh
+        session.
+        """
+        async with self.get_session() as session:
+            merged = await session.merge(device)
+            await session.flush()
+            await session.refresh(merged)
+            return merged
 
     async def get_devices_by_site_id(
         self, site_id: str, include_unpaired: bool = False

--- a/backend/src/homepot/migrations/versions/20260801_add_site_device_columns.py
+++ b/backend/src/homepot/migrations/versions/20260801_add_site_device_columns.py
@@ -1,0 +1,57 @@
+"""Add sites.bootstrap_key_hash and devices.device_permissions/capabilities.
+
+Revision ID: 20260801_add_site_device_columns
+Revises: 20260726_add_is_simulated
+Create Date: 2026-08-01
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+# revision identifiers, used by Alembic.
+revision = "20260801_add_site_device_columns"
+down_revision = "20260726_add_is_simulated"
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(table: str, column: str) -> bool:
+    """Return True if *column* already exists on *table*.
+
+    The app creates the schema with ``Base.metadata.create_all`` at startup
+    and this migration targets existing deployments that predate the
+    columns, so guard against pre-existing columns (e.g. created by
+    create_all on a fresh DB or by manual ALTER).
+    """
+    inspector = inspect(op.get_bind())
+    return any(col["name"] == column for col in inspector.get_columns(table))
+
+
+def upgrade() -> None:
+    """Add the missing site/device columns introduced across PRs 220-221."""
+    if not _column_exists("sites", "bootstrap_key_hash"):
+        op.add_column(
+            "sites",
+            sa.Column("bootstrap_key_hash", sa.String(length=255), nullable=True),
+        )
+    if not _column_exists("devices", "device_permissions"):
+        op.add_column(
+            "devices",
+            sa.Column("device_permissions", sa.JSON(), nullable=True),
+        )
+    if not _column_exists("devices", "capabilities"):
+        op.add_column(
+            "devices",
+            sa.Column("capabilities", sa.JSON(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    """Rollback the site/device columns."""
+    if _column_exists("devices", "capabilities"):
+        op.drop_column("devices", "capabilities")
+    if _column_exists("devices", "device_permissions"):
+        op.drop_column("devices", "device_permissions")
+    if _column_exists("sites", "bootstrap_key_hash"):
+        op.drop_column("sites", "bootstrap_key_hash")

--- a/backend/tests/test_agent_production_hardening.py
+++ b/backend/tests/test_agent_production_hardening.py
@@ -184,6 +184,43 @@ class TestGracefulShutdown:
         _handle_signal()
         assert shutdown_event.is_set()
 
+    @pytest.mark.asyncio
+    async def test_force_shutdown_backstop_does_not_fire_until_event(self):
+        """The shutdown backstop never force-exits during normal operation."""
+        from homepot.agent.real_device_agent import _force_shutdown_after_timeout
+
+        exit_calls: list = []
+        with patch(
+            "homepot.agent.real_device_agent.os._exit", side_effect=exit_calls.append
+        ):
+            shutdown_event = asyncio.Event()
+            task = asyncio.ensure_future(
+                _force_shutdown_after_timeout(shutdown_event, timeout=0.05)
+            )
+
+            # Run well past the timeout with no shutdown requested: the agent
+            # must NOT be force-killed (this is the boot self-termination bug).
+            await asyncio.sleep(0.15)
+            assert not task.done()
+            assert exit_calls == []
+
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_force_shutdown_backstop_fires_after_shutdown_requested(self):
+        """The backstop force-exits when shutdown exceeds the timeout."""
+        from homepot.agent.real_device_agent import _force_shutdown_after_timeout
+
+        exit_calls: list = []
+        with patch(
+            "homepot.agent.real_device_agent.os._exit", side_effect=exit_calls.append
+        ):
+            shutdown_event = asyncio.Event()
+            shutdown_event.set()  # simulate a SIGTERM
+            await _force_shutdown_after_timeout(shutdown_event, timeout=0.05)
+            assert exit_calls == [1]
+
 
 # ============================================================================
 # Failure scenarios

--- a/backend/tests/test_lifecycle.py
+++ b/backend/tests/test_lifecycle.py
@@ -152,6 +152,104 @@ async def test_lifecycle_unpaired_device_not_in_active_list(temp_db: Any) -> Non
 
 
 @pytest.mark.asyncio
+async def test_lifecycle_persist_device_persists_detached_mutation(
+    temp_db: Any,
+) -> None:
+    """Mutations to a detached device must persist via persist_device.
+
+    get_device_by_device_id() returns a Device whose session is already
+    closed; attribute changes on that object are silently lost unless the
+    caller merges it back into a fresh session.
+    """
+    db_service = await get_database_service()
+
+    unique_suffix = str(uuid.uuid4())[:8]
+    device_id = f"test-dev-persist-{unique_suffix}"
+    site_id = f"test-site-persist-{unique_suffix}"
+
+    async with db_service.get_session() as session:
+        site = Site(site_id=site_id, name="Test Site", is_active=True)
+        session.add(site)
+        await session.commit()
+        await session.refresh(site)
+
+        device = Device(
+            device_id=device_id,
+            name="Test POS",
+            device_type="pos_terminal",
+            site_id=site.id,
+            is_active=True,
+            lifecycle_state=LifecycleState.ACTIVE.value,
+            api_key_hash="hashed_key_here",
+        )
+        session.add(device)
+        await session.commit()
+
+    detached = await db_service.get_device_by_device_id(device_id)
+    assert detached is not None
+
+    # Simulate the mutation made by the lifecycle endpoints.
+    detached.lifecycle_state = LifecycleState.SUSPENDED.value  # type: ignore[assignment]
+    detached.is_active = False  # type: ignore[assignment]
+    detached.api_key_hash = None  # type: ignore[assignment]
+
+    await db_service.persist_device(detached)
+
+    async with db_service.get_session() as session:
+        result = await session.execute(
+            select(Device).where(Device.device_id == device_id)
+        )
+        fetched = result.scalars().first()
+        assert fetched is not None
+        assert fetched.lifecycle_state == LifecycleState.SUSPENDED.value
+        assert fetched.is_active is False
+        assert fetched.api_key_hash is None
+
+
+@pytest.mark.asyncio
+async def test_get_device_by_device_id_include_unpaired(temp_db: Any) -> None:
+    """An unpaired device is reachable only with include_unpaired=True."""
+    db_service = await get_database_service()
+
+    unique_suffix = str(uuid.uuid4())[:8]
+    device_id = f"test-dev-reenrol-{unique_suffix}"
+    site_id = f"test-site-reenrol-{unique_suffix}"
+
+    async with db_service.get_session() as session:
+        site = Site(site_id=site_id, name="Test Site", is_active=True)
+        session.add(site)
+        await session.commit()
+        await session.refresh(site)
+
+        device = Device(
+            device_id=device_id,
+            name="Test POS",
+            device_type="pos_terminal",
+            site_id=site.id,
+            is_active=True,
+            lifecycle_state=LifecycleState.ACTIVE.value,
+            api_key_hash="hashed_key_here",
+        )
+        session.add(device)
+        await session.commit()
+
+    # Unpair the device (soft delete) so is_active=False.
+    success = await db_service.delete_device(device_id)
+    assert success is True
+
+    # Default lookup filters out unpaired devices.
+    assert await db_service.get_device_by_device_id(device_id) is None
+
+    # Re-enrolment needs to find the unpaired device.
+    unpaired = await db_service.get_device_by_device_id(
+        device_id, include_unpaired=True
+    )
+    assert unpaired is not None
+    assert unpaired.lifecycle_state == LifecycleState.UNPAIRED.value
+    assert unpaired.is_active is False
+
+
+@pytest.mark.asyncio
 async def test_lifecycle_get_device_status_returns_three_dimensions(
     temp_db: Any,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes the three blockers identified during the real-device transition review (PRs #170–#247). These were preventing onboarding a real device to a fresh/existing DB and making the agent unusable.

## Changes

**1. Missing Alembic migration for the U-series columns**
- New `20260801_add_site_device_columns` adds `sites.bootstrap_key_hash`, `devices.device_permissions`, `devices.capabilities` (columns introduced in #220/#221 that never shipped a migration).
- Existence-guarded: no-ops on fresh DBs (already created by `create_all`) and on DBs manually altered in #236; adds them only on older deployments.

**2. Detached-object lifecycle bug (#186/#189)**
- New `DatabaseService.persist_device(device)` merges a detached `Device` back into a fresh session.
- `unpair`/`suspend`/`resume`/`retire`/`re-enrol`/`transfer` now persist their state mutations (`lifecycle_state`, `is_active`, `site_id`, `api_key_hash`) — previously these were silently lost, so devices never actually left `active` and the DB diverged from reported state.
- `transfer` audit log no longer records the **new** site as the old one (`old_site_id` captured before mutation).

**3. Re-enrolment was unreachable**
- `get_device_by_device_id(..., include_unpaired=True)` bypasses the default `is_active` filter; `re-enrol` now finds unpaired devices instead of always 404ing.

**4. Agent self-termination (#197)**
- `_shutdown_after_timeout` was armed at startup, force-exiting the CLI/systemd agent ~30s after launch. Replaced with `_force_shutdown_after_timeout`, which waits for the shutdown event before starting its countdown — a true graceful-shutdown backstop, wired for both CLI and Windows-service paths.

## Tests
- Added: `persist_device` detached-mutation persistence, `include_unpaired` lookup, and two agent backstop tests (doesn't fire during normal operation / fires after shutdown requested).
- Verified green: `test_lifecycle`, `test_device_unpair`, `test_agent_production_hardening`, `test_database`, `test_models`, `test_devices_by_site`, `test_authorization`.
- `black`, `isort`, `flake8`, `mypy` clean; `alembic upgrade head` verified in both column-present and column-absent scenarios.

Note: the MkDocs strict build failure was a local venv drift (Pygments 2.20.0 vs pinned 2.18.0 in `docs/requirements.txt`); no repo change needed.