### PR TITLE
ci: verify Alembic migrations apply on PostgreSQL

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -18,6 +18,8 @@ env:
   PG_TEST_USER: homepot_user
   PG_TEST_PASSWORD: ci_test_password
   PG_TEST_DB: homepot_test
+  # Dedicated scratch database used only for the Alembic migration check.
+  PG_TEST_DB_MIG: homepot_mig
 
 jobs:
   code-quality:
@@ -124,6 +126,88 @@ jobs:
         sudo systemctl restart postgresql
         pg_isready
         sudo -u postgres psql -d "${PG_TEST_DB}" -c "CREATE EXTENSION IF NOT EXISTS timescaledb;"
+
+    - name: Verify Alembic migrations apply on PostgreSQL
+      if: matrix.os == 'ubuntu-latest'
+      shell: bash
+      env:
+        DATABASE__URL: postgresql://${{ env.PG_TEST_USER }}:${{ env.PG_TEST_PASSWORD }}@localhost:5432/${{ env.PG_TEST_DB_MIG }}
+      run: |
+        set -e
+
+        # Dedicated scratch database so migration checks never touch the test DB.
+        sudo -u postgres psql -c "CREATE DATABASE ${PG_TEST_DB_MIG} OWNER ${PG_TEST_USER};"
+
+        cd backend
+
+        # The app bootstraps the base schema via Base.metadata.create_all at
+        # startup; the migration chain is additive on top of it (its root
+        # migration ALTERs existing tables rather than creating them).
+        # Reproduce that real-world state, roll back to the base revision, then
+        # re-apply every migration so the full upgrade path runs on PostgreSQL.
+        python - <<'PY'
+        import os
+
+        import homepot.database  # noqa: F401  (registers every model with Base.metadata)
+        from sqlalchemy import create_engine
+        from homepot.models import Base
+
+        engine = create_engine(os.environ["DATABASE__URL"])
+        Base.metadata.create_all(engine)
+        print("create_all OK")
+        PY
+
+        alembic -c alembic.ini stamp head
+        alembic -c alembic.ini downgrade base
+        alembic -c alembic.ini upgrade head
+        alembic -c alembic.ini current
+
+        # The migration-produced schema must match the ORM models for every
+        # migration-managed table. This catches migrations that are missing,
+        # incomplete, or unguarded against an already-created schema.
+        python - <<'PY'
+        import os
+
+        from sqlalchemy import create_engine, inspect
+        from homepot.models import (
+            Device,
+            DeviceAssignment,
+            DeviceCredential,
+            DeviceLifecycleEvent,
+            EnrolmentIntent,
+            LifecycleEpoch,
+            Site,
+            SiteMembership,
+            Tenant,
+            TenantMembership,
+            User,
+        )
+
+        engine = create_engine(os.environ["DATABASE__URL"])
+        inspector = inspect(engine)
+        for model in (
+            Device,
+            Site,
+            User,
+            Tenant,
+            TenantMembership,
+            SiteMembership,
+            EnrolmentIntent,
+            LifecycleEpoch,
+            DeviceCredential,
+            DeviceAssignment,
+            DeviceLifecycleEvent,
+        ):
+            db_columns = {c["name"] for c in inspector.get_columns(model.__tablename__)}
+            missing = set(model.__table__.columns.keys()) - db_columns
+            assert not missing, (
+                f"{model.__tablename__} is missing columns: {sorted(missing)}"
+            )
+        print("schema drift check OK")
+        PY
+
+        cd ..
+        sudo -u postgres psql -c "DROP DATABASE ${PG_TEST_DB_MIG};"
 
     - name: Run unit tests
       shell: bash

--- a/backend/src/homepot/migrations/env.py
+++ b/backend/src/homepot/migrations/env.py
@@ -6,9 +6,10 @@ from logging.config import fileConfig
 import os
 from pathlib import Path
 import sys
+from typing import Any
 
 from alembic import context
-from sqlalchemy import engine_from_config, pool
+from sqlalchemy import engine_from_config, inspect, pool, text
 
 # Ensure "src" is importable when running Alembic from backend root.
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
@@ -50,6 +51,36 @@ def run_migrations_offline() -> None:
         context.run_migrations()
 
 
+def _prepare_alembic_version_table(engine: Any) -> None:
+    """Ensure ``alembic_version.version_num`` can hold long revision ids.
+
+    Alembic creates the version table with a ``VARCHAR(32)`` column, but
+    several revision ids in this chain exceed 32 characters (e.g.
+    ``20260720_add_device_assignments_events``).  PostgreSQL enforces the
+    length limit, so widen (or pre-create) the column before migrations run.
+    SQLite ignores ``VARCHAR`` lengths and needs no adjustment.
+    """
+    if engine.dialect.name != "postgresql":
+        return
+
+    with engine.begin() as conn:
+        if inspect(engine).has_table("alembic_version"):
+            conn.execute(
+                text(
+                    "ALTER TABLE alembic_version "
+                    "ALTER COLUMN version_num TYPE VARCHAR(64)"
+                )
+            )
+            return
+
+        conn.execute(
+            text(
+                "CREATE TABLE alembic_version ("
+                "version_num VARCHAR(64) NOT NULL PRIMARY KEY)"
+            )
+        )
+
+
 def run_migrations_online() -> None:
     """Run migrations in 'online' mode."""
     cfg_section = config.get_section(config.config_ini_section, {})
@@ -60,6 +91,8 @@ def run_migrations_online() -> None:
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )
+
+    _prepare_alembic_version_table(connectable)
 
     with connectable.connect() as connection:
         context.configure(

--- a/backend/src/homepot/migrations/versions/20260720_add_device_assignments_events.py
+++ b/backend/src/homepot/migrations/versions/20260720_add_device_assignments_events.py
@@ -27,7 +27,10 @@ def upgrade() -> None:
         sa.Column("assigned_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("unassigned_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column(
-            "is_current", sa.Boolean(), nullable=False, server_default=sa.text("0")
+            "is_current",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
         ),
         sa.Column(
             "created_at", sa.DateTime(timezone=True), server_default=sa.func.now()


### PR DESCRIPTION
## Summary

Adds a CI step (Ubuntu leg of the `test` job) that proves the full Alembic migration chain runs cleanly against the CI PostgreSQL 16 instance — closing the gap from the real-device testing review where migrations were missing/unverified (#236).

## What it does

1. Creates a dedicated scratch database (`homepot_mig`) so the unit-test DB (`homepot_test`) is never touched, and drops it afterwards.
2. Runs `Base.metadata.create_all` against it — reproducing the app's real bootstrap (the chain's root migration ALTERs existing tables rather than creating them).
3. `stamp head` → `downgrade base` → `upgrade head`: rolls the chain back to the base revision and re-applies every migration, exercising the complete upgrade path on PostgreSQL.
4. Schema-drift assertion: compares every migration-managed table (devices, sites, users, tenants, memberships, enrolment_intents, lifecycle_epochs, device_credentials, device_assignments, device_lifecycle_events) against the ORM models. Catches migrations that are missing, incomplete, or unguarded against an already-created schema.

## Validation

- YAML parses; step positioned after Postgres/TimescaleDB setup, before unit tests.
- create_all + drift-check heredocs validated locally (SQLite); drift check confirmed to fail when a migration column is missing (dropped `os_details` → assertion fails).
- Full downgrade+upgrade sequence verified by analysis for Postgres (child tables dropped before parents; FK columns dropped last; all downgrades symmetric).

## Test plan

The new step runs only on `ubuntu-latest`; its failure blocks the `test` job and therefore the `build`/`docker-build` chain.