### PR TITLE
fix: fail fast when emulator default config has placeholder site/key

### DIFF
--- a/docs/device-emulators.md
+++ b/docs/device-emulators.md
@@ -14,7 +14,7 @@ Each emulator runs as an independent process that provisions itself with the bac
 #    POST /api/v1/sites/{site_id}/bootstrap-key
 
 # 3. Run the Linux POS emulator
-./scripts/start-emulator.sh --site-id site-1 --bootstrap-key <key>
+./scripts/start-emulator.sh --site-id site-it-demo1 --bootstrap-key <key>
 
 # 4. (Optional) Start the User App to manage the emulated device
 ./scripts/start-userapp.sh
@@ -118,7 +118,7 @@ Every config field maps to a `--flag`. CLI values override config file values.
 
 ```bash
 python emulators/linux_pos_emulator.py \
-  --site-id site-1 \
+  --site-id site-it-demo1 \
   --bootstrap-key abc123... \
   --device-name "My Custom POS" \
   --mock-mac "aa:bb:cc:dd:ee:ff" \
@@ -132,7 +132,7 @@ python emulators/linux_pos_emulator.py \
 Terminal 1:  ./scripts/start-dashboard.sh
              # Backend on :8000, Dashboard on :5173
 
-Terminal 2:  ./scripts/start-emulator.sh --site-id site-1 --bootstrap-key <key>
+Terminal 2:  ./scripts/start-emulator.sh --site-id site-it-demo1 --bootstrap-key <key>
              # Emulator provisions, heartbeats, sends telemetry
              # Live output: tail -f logs/emulator.log
 
@@ -199,7 +199,7 @@ Credentials live at `~/.homepot/emulators/<device_name>.json` with `0600` permis
 {
   "device_id": "a1b2c3d4-...",
   "api_key": "mM2...",
-  "site_id": "site-1",
+  "site_id": "site-it-demo1",
   "device_name": "linux-pos-emulator-1",
   ...
 }

--- a/docs/device-emulators.md
+++ b/docs/device-emulators.md
@@ -14,7 +14,8 @@ Each emulator runs as an independent process that provisions itself with the bac
 #    POST /api/v1/sites/{site_id}/bootstrap-key
 
 # 3. Run the Linux POS emulator
-./scripts/start-emulator.sh --site-id site-it-demo1 --bootstrap-key <key>
+./scripts/start-emulator.sh --site-id site-it-demo1 --bootstrap-key <key> --device-name demo-pos-1
+#    Use a different --device-name per emulator to run several on one site
 
 # 4. (Optional) Start the User App to manage the emulated device
 ./scripts/start-userapp.sh
@@ -132,8 +133,9 @@ python emulators/linux_pos_emulator.py \
 Terminal 1:  ./scripts/start-dashboard.sh
              # Backend on :8000, Dashboard on :5173
 
-Terminal 2:  ./scripts/start-emulator.sh --site-id site-it-demo1 --bootstrap-key <key>
+Terminal 2:  ./scripts/start-emulator.sh --site-id site-it-demo1 --bootstrap-key <key> --device-name demo-pos-1
              # Emulator provisions, heartbeats, sends telemetry
+             # Use a different --device-name per emulator to run several on one site
              # Live output: tail -f logs/emulator.log
 
 Terminal 3:  ./scripts/start-userapp.sh

--- a/scripts/start-emulator.sh
+++ b/scripts/start-emulator.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # Usage:
 #   ./scripts/start-emulator.sh                    # uses default config
 #   ./scripts/start-emulator.sh --config emulators/my-device.json
-#   ./scripts/start-emulator.sh --site-id site-1 --bootstrap-key <key>
+#   ./scripts/start-emulator.sh --site-id site-it-demo1 --bootstrap-key <key>
 #
 # Prerequisites:
 #   - Python virtual environment at .venv/ with httpx installed
@@ -40,6 +40,22 @@ fi
 CONFIG_ARGS=()
 if [[ "$#" -eq 0 ]]; then
     CONFIG_ARGS=("--config" "emulators/linux_pos_emulator.json")
+
+    # Fail fast when the default config still has placeholder values. Launching
+    # with them makes provisioning fail on the backend (404 "Site not found")
+    # after the process has already been backgrounded.
+    if grep -q 'REPLACE_WITH_GENERATED_KEY' emulators/linux_pos_emulator.json \
+        || grep -q '"site_id": "site-1"' emulators/linux_pos_emulator.json; then
+        echo "Error: emulators/linux_pos_emulator.json still has placeholder values."
+        echo "  The default site_id/key do not exist on the backend, so provisioning would fail."
+        echo ""
+        echo "  Either edit that file with a real site and bootstrap key, or launch with a key"
+        echo "  generated for your site (POST /api/v1/sites/{site_id}/bootstrap-key):"
+        echo ""
+        echo "    ./scripts/start-emulator.sh --site-id site-it-demo1 --bootstrap-key <key>"
+        echo ""
+        exit 1
+    fi
 fi
 
 # --- Logging ----------------------------------------------------------------

--- a/scripts/start-emulator.sh
+++ b/scripts/start-emulator.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # Usage:
 #   ./scripts/start-emulator.sh                    # uses default config
 #   ./scripts/start-emulator.sh --config emulators/my-device.json
-#   ./scripts/start-emulator.sh --site-id site-it-demo1 --bootstrap-key <key>
+#   ./scripts/start-emulator.sh --site-id site-it-demo1 --bootstrap-key <key> --device-name demo-pos-1
 #
 # Prerequisites:
 #   - Python virtual environment at .venv/ with httpx installed
@@ -52,7 +52,9 @@ if [[ "$#" -eq 0 ]]; then
         echo "  Either edit that file with a real site and bootstrap key, or launch with a key"
         echo "  generated for your site (POST /api/v1/sites/{site_id}/bootstrap-key):"
         echo ""
-        echo "    ./scripts/start-emulator.sh --site-id site-it-demo1 --bootstrap-key <key>"
+        echo "    ./scripts/start-emulator.sh --site-id site-it-demo1 --bootstrap-key <key> --device-name demo-pos-1"
+        echo ""
+        echo "  Use a different --device-name per emulator to run several on one site."
         echo ""
         exit 1
     fi


### PR DESCRIPTION
## Problem

`./scripts/start-emulator.sh` with no arguments uses `emulators/linux_pos_emulator.json`, which still has placeholder values — `site_id: "site-1"` and `bootstrap_key: "REPLACE_WITH_GENERATED_KEY"`. The backend has no `site-1` site (only `site-001`, `site-002`, `site-it-demo1`), so `POST /devices/bootstrap-provision` returned `404 Site not found`. Because the emulator now runs in the background (PR #252), the process died silently and the only trace was the traceback in `logs/emulator.log`:

```
RuntimeError: Provisioning failed (404): Site not found
```

## Fix

- **`scripts/start-emulator.sh`** — when launched with no args, it now checks the default config for the placeholder site/key and fails **fast** with a clear, actionable message showing the exact command to run (including the `POST /api/v1/sites/{site_id}/bootstrap-key` endpoint for generating a real key), instead of backgrounding a process that's guaranteed to die.
- **`docs/device-emulators.md`** — replaces the non-existent `site-1` with the real demo site `site-it-demo1` in all emulator examples.

## Verification

- `./scripts/start-emulator.sh` (no args) → fails immediately with the guidance message, exit code 1, no process spawned.
- `./scripts/start-emulator.sh --site-id site-it-demo1 --bootstrap-key <key> --device-name demo-pos-1` → emulator provisions/resumes, heartbeats/telemetry flow into `logs/emulator.log`.
- `bash -n` and `mkdocs build --strict` pass.