### PR TITLE
feat: route User App views through services layer and fix provisioned-state bug

### DIFF
--- a/docs/user-app-implementation.md
+++ b/docs/user-app-implementation.md
@@ -37,6 +37,32 @@ npm run dev
 ```
 
 ## Implementation Phases
-1. **Phase 1 (Current):** Web-based UI layout and scaffolding using Tailwind CSS and raw React components.
-2. **Phase 2:** Wrapping the Vite build in **Electron** (for Desktop OS logic) and **Capacitor** (for Android logic).
-3. **Phase 3:** Connecting the React context state to the local IPC network layer broadcasted by the underlying Python device agent (developed by Dealdio).
+1. **Phase 1:** Web-based UI layout and scaffolding using Tailwind CSS and raw React components. *(merged)*
+2. **Phase 2:** Wrapping the Vite build in **Electron** (for Desktop OS logic) and **Capacitor** (for Android logic). *(Electron shell + emulator bridge merged)*
+3. **Phase 3:** Connecting the React context state to the local IPC network layer broadcasted by the underlying Python device agent. *(in progress — see PR tracker below)*
+
+## PR Tracker
+
+Single source of truth for User App pull requests. Each row links the PR, its branch, and what it delivers against the emulator/backend feature set. Emulator/backend work that the User App UI builds on is listed for reference.
+
+### Prerequisites (merged — emulator/backend)
+
+| PR | Branch | Scope | Status |
+|----|--------|-------|--------|
+| [#250](https://github.com/brunel-opensim/homepot-client/pull/250) | `feat/live-device-reporting` | Live device reporting via POS emulator (logs, audit, jobs, alerts, telemetry) | merged |
+| [#251](https://github.com/brunel-opensim/homepot-client/pull/251) | `feat/emulator-command-response` | Emulator handles status requests and composed push commands | merged |
+| [#252](https://github.com/brunel-opensim/homepot-client/pull/252) | `feat/emulator-logs` | Emulator runs in background with `logs/emulator.log` + stop script | merged |
+| [#253](https://github.com/brunel-opensim/homepot-client/pull/253) | `fix/emulator-start-default-config` | Fail fast when default config has placeholder site/key | merged |
+| [#254](https://github.com/brunel-opensim/homepot-client/pull/254) | `feat/emulator-permissions` | Emulator permission emulation (consent modes + `request_permission`) | merged |
+
+### Planned User App PRs
+
+| # | Branch (proposed) | Scope | Status |
+|---|-------------------|-------|--------|
+| 1 | `feat/user-app-service-refactor` | Route views through `services/api.ts` (currently bypassed with raw `fetch`); fix `AppContext` `isProvisioned` bug (reads `homepot_token`, never written by `SimulationStorage`); fix `ClaimDevice` response-shape handling | planned |
+| 2 | `feat/user-app-live-dashboard` | Real telemetry on HomeDashboard via `GET /devices/device/{id}/metrics` (CPU/mem/disk/net/uptime); real heartbeat from `last_heartbeat_at`; replace hardcoded gauge values | planned |
+| 3 | `feat/user-app-permission-request` | `request_permission` consent prompt (accept/deny operator requests); admin-override flow | planned |
+| 4 | `feat/user-app-activity-screens` | Live Logs + Audit Trail + Jobs + Alerts + Push History screens (emulator emits all; UI absent) | planned |
+| 5 | `feat/user-app-live-updates` | *(optional)* WebSocket live updates (`/ws/status`) | optional |
+
+Update this table as PRs are opened/merged so the tracker stays current.

--- a/user_app/src/App.tsx
+++ b/user_app/src/App.tsx
@@ -10,7 +10,8 @@ import DeviceInfo from './views/DeviceInfo'
 import ClaimDevice from './views/ClaimDevice'
 
 function RootRedirect() {
-  const { isProvisioned } = useApp()
+  const { isProvisioned, provisionedChecked } = useApp()
+  if (!provisionedChecked) return null
   return <Navigate to={isProvisioned ? '/home' : '/setup'} replace />
 }
 

--- a/user_app/src/context/AppContext.tsx
+++ b/user_app/src/context/AppContext.tsx
@@ -1,5 +1,6 @@
-import { createContext, useContext, useState } from 'react'
+import { createContext, useContext, useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
+import { credentialStorage } from '../services/credentialStorage'
 
 interface DeviceInfo {
   deviceId: string
@@ -21,6 +22,7 @@ interface AppContextType {
   setDeviceInfo: (info: DeviceInfo) => void
   isProvisioned: boolean
   setIsProvisioned: (val: boolean) => void
+  provisionedChecked: boolean
   setupState: SetupState
   setSetupState: (state: SetupState) => void
   useEmulator: boolean
@@ -34,9 +36,9 @@ interface AppContextType {
 const AppContext = createContext<AppContextType | null>(null)
 
 export function AppProvider({ children }: { children: ReactNode }) {
-  const provisioned = !!localStorage.getItem('homepot_token')
   const [deviceInfo, setDeviceInfo] = useState<DeviceInfo | null>(null)
-  const [isProvisioned, setIsProvisioned] = useState(provisioned)
+  const [isProvisioned, setIsProvisioned] = useState(false)
+  const [provisionedChecked, setProvisionedChecked] = useState(false)
   const [setupState, setSetupState] = useState<SetupState>({
     siteId: '',
     deviceName: '',
@@ -48,10 +50,29 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [emulatorType, setEmulatorType] = useState('linux_pos')
   const [isEmulatorRunning, setIsEmulatorRunning] = useState(false)
 
+  useEffect(() => {
+    let mounted = true
+    credentialStorage
+      .isProvisioned()
+      .then((provisioned) => {
+        if (mounted) {
+          setIsProvisioned(provisioned)
+          setProvisionedChecked(true)
+        }
+      })
+      .catch(() => {
+        if (mounted) setProvisionedChecked(true)
+      })
+    return () => {
+      mounted = false
+    }
+  }, [])
+
   return (
     <AppContext.Provider value={{
       deviceInfo, setDeviceInfo,
       isProvisioned, setIsProvisioned,
+      provisionedChecked,
       setupState, setSetupState,
       useEmulator, setUseEmulator,
       emulatorType, setEmulatorType,

--- a/user_app/src/services/api.ts
+++ b/user_app/src/services/api.ts
@@ -37,8 +37,27 @@ interface Headers {
   [key: string]: string
 }
 
+export interface UnpairOptions {
+  reason?: string
+  idempotencyKey?: string
+}
+
+export class ApiError extends Error {
+  status: number
+
+  constructor(message: string, status: number) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+  }
+}
+
 function deviceAuthHeaders(deviceId: string, apiKey: string): Headers {
   return { 'X-Device-ID': deviceId, 'X-API-Key': apiKey }
+}
+
+function asApiError(message: string, status: number): ApiError {
+  return new ApiError(message, status)
 }
 
 export async function fetchDevice(deviceId: string, apiKey: string): Promise<DeviceRecord> {
@@ -47,7 +66,7 @@ export async function fetchDevice(deviceId: string, apiKey: string): Promise<Dev
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    throw new Error(body.detail || `Failed to fetch device (${res.status})`)
+    throw asApiError(body.detail || `Failed to fetch device (${res.status})`, res.status)
   }
   return res.json()
 }
@@ -58,7 +77,7 @@ export async function fetchDeviceStatus(deviceId: string, apiKey: string): Promi
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    throw new Error(body.detail || `Failed to fetch status (${res.status})`)
+    throw asApiError(body.detail || `Failed to fetch status (${res.status})`, res.status)
   }
   const json = await res.json()
   return json.data as DeviceStatus
@@ -70,9 +89,10 @@ export async function fetchPermissions(deviceId: string, apiKey: string): Promis
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    throw new Error(body.detail || `Failed to fetch permissions (${res.status})`)
+    throw asApiError(body.detail || `Failed to fetch permissions (${res.status})`, res.status)
   }
-  return res.json()
+  const json = await res.json()
+  return json.data as PermissionsResponse
 }
 
 export async function updatePermissions(
@@ -83,11 +103,11 @@ export async function updatePermissions(
   const res = await fetch(`${apiBaseUrl}/devices/device/${deviceId}/permissions`, {
     method: 'PATCH',
     headers: { ...deviceAuthHeaders(deviceId, apiKey), 'Content-Type': 'application/json' },
-    body: JSON.stringify(permissions),
+    body: JSON.stringify({ permissions }),
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    throw new Error(body.detail || `Failed to update permissions (${res.status})`)
+    throw asApiError(body.detail || `Failed to update permissions (${res.status})`, res.status)
   }
 }
 
@@ -105,7 +125,7 @@ export async function bootstrapProvision(body: {
   })
   if (!res.ok) {
     const err = await res.json().catch(() => ({}))
-    throw new Error(err.detail || `Provision failed (${res.status})`)
+    throw asApiError(err.detail || `Provision failed (${res.status})`, res.status)
   }
   const json = await res.json()
   return json.data
@@ -125,20 +145,31 @@ export async function claimDevice(body: {
   })
   if (!res.ok) {
     const err = await res.json().catch(() => ({}))
-    throw new Error(err.detail || `Claim failed (${res.status})`)
+    throw asApiError(err.detail || `Claim failed (${res.status})`, res.status)
   }
   const json = await res.json()
-  return json.data
+  return {
+    device_id: json.device_id,
+    api_key: json.api_key,
+    site_id: json.site_id,
+  }
 }
 
-export async function unpairDevice(deviceId: string, apiKey: string): Promise<void> {
+export async function unpairDevice(
+  deviceId: string,
+  apiKey: string,
+  options: UnpairOptions = {},
+): Promise<void> {
   const res = await fetch(`${apiBaseUrl}/devices/device/${deviceId}/unpair`, {
     method: 'POST',
     headers: { ...deviceAuthHeaders(deviceId, apiKey), 'Content-Type': 'application/json' },
-    body: JSON.stringify({ reason: 'User-initiated unpair from device settings' }),
+    body: JSON.stringify({
+      reason: options.reason ?? 'User-initiated unpair from device settings',
+      ...(options.idempotencyKey ? { idempotency_key: options.idempotencyKey } : {}),
+    }),
   })
   if (!res.ok && res.status !== 404) {
     const body = await res.json().catch(() => ({}))
-    throw new Error(body.detail || `Unpair failed (${res.status})`)
+    throw asApiError(body.detail || `Unpair failed (${res.status})`, res.status)
   }
 }

--- a/user_app/src/test/api.test.ts
+++ b/user_app/src/test/api.test.ts
@@ -76,8 +76,8 @@ describe('fetchDeviceStatus', () => {
 })
 
 describe('fetchPermissions', () => {
-  it('returns permissions and capabilities', async () => {
-    const resp = { permissions: { root_access: true }, capabilities: { root_access: true } }
+  it('returns permissions and capabilities from nested data field', async () => {
+    const resp = { status: 'success', data: { permissions: { root_access: true }, capabilities: { root_access: true } } }
     mockFetch.mockResolvedValueOnce(ok(resp))
     const result = await fetchPermissions(DEVICE_ID, API_KEY)
     expect(result.permissions.root_access).toBe(true)
@@ -86,7 +86,7 @@ describe('fetchPermissions', () => {
 })
 
 describe('updatePermissions', () => {
-  it('sends PATCH with correct body', async () => {
+  it('sends PATCH with permissions wrapped in body', async () => {
     mockFetch.mockResolvedValueOnce(ok({}))
     await updatePermissions(DEVICE_ID, API_KEY, { root_access: true })
     expect(mockFetch).toHaveBeenCalledWith(
@@ -94,7 +94,7 @@ describe('updatePermissions', () => {
       expect.objectContaining({
         method: 'PATCH',
         headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
-        body: JSON.stringify({ root_access: true }),
+        body: JSON.stringify({ permissions: { root_access: true } }),
       }),
     )
   })
@@ -122,8 +122,8 @@ describe('bootstrapProvision', () => {
 })
 
 describe('claimDevice', () => {
-  it('POSTs claim request and returns data', async () => {
-    const resp = { data: { device_id: 'd2', api_key: 'k2', site_id: 's2' } }
+  it('POSTs claim request and returns flat result', async () => {
+    const resp = { status: 'success', device_id: 'd2', api_key: 'k2', site_id: 's2', epoch_id: 'e2' }
     mockFetch.mockResolvedValueOnce(ok(resp))
     const result = await claimDevice({
       intent_id: 'intent-1',
@@ -133,6 +133,8 @@ describe('claimDevice', () => {
       os_details: 'linux',
     })
     expect(result.device_id).toBe('d2')
+    expect(result.api_key).toBe('k2')
+    expect(result.site_id).toBe('s2')
   })
 })
 
@@ -140,6 +142,21 @@ describe('unpairDevice', () => {
   it('sends POST and succeeds on 200', async () => {
     mockFetch.mockResolvedValueOnce(ok({}))
     await expect(unpairDevice(DEVICE_ID, API_KEY)).resolves.toBeUndefined()
+  })
+
+  it('sends POST with reason and idempotency key', async () => {
+    mockFetch.mockResolvedValueOnce(ok({}))
+    await unpairDevice(DEVICE_ID, API_KEY, {
+      reason: 'Upgrade',
+      idempotencyKey: 'unpair-x',
+    })
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining(`/devices/device/${DEVICE_ID}/unpair`),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ reason: 'Upgrade', idempotency_key: 'unpair-x' }),
+      }),
+    )
   })
 
   it('succeeds on 404 (device already unpaired)', async () => {

--- a/user_app/src/test/integration.test.tsx
+++ b/user_app/src/test/integration.test.tsx
@@ -23,8 +23,8 @@ describe('App routing', () => {
   })
 
   it('redirects provisioned user from / to dashboard', async () => {
-    localStorage.setItem('homepot_token', 'mock-token')
     localStorage.setItem('homepot_device_id', 'pos-001')
+    sessionStorage.setItem('homepot_api_key', 'test-key')
     mockFetch.mockResolvedValueOnce(
       ok({
         data: {
@@ -40,7 +40,6 @@ describe('App routing', () => {
   })
 
   it('shows device info view at /settings', async () => {
-    localStorage.setItem('homepot_token', 'mock-token')
     localStorage.setItem('homepot_device_id', 'pos-001')
     sessionStorage.setItem('homepot_api_key', 'test-key')
     mockFetch.mockResolvedValueOnce(

--- a/user_app/src/views/ClaimDevice.tsx
+++ b/user_app/src/views/ClaimDevice.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useApp } from '../context/AppContext';
-import { apiBaseUrl } from '../config/api';
 import { credentialStorage } from '../services/credentialStorage';
+import { claimDevice } from '../services/api';
 
 export default function ClaimDevice() {
   const navigate = useNavigate();
@@ -50,26 +50,13 @@ export default function ClaimDevice() {
       const deviceOs = form.deviceOs || navigator.platform || 'Unknown';
       const deviceName = form.deviceName || `Device-${Math.random().toString(36).slice(2, 8)}`;
 
-      const response = await fetch(
-        `${apiBaseUrl}/enrolment-intents/${form.intentId}/claim`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            claim_token: form.claimToken,
-            device_name: deviceName,
-            device_type: form.deviceType,
-            os_details: deviceOs,
-          }),
-        }
-      );
-
-      if (!response.ok) {
-        const errData = await response.json().catch(() => ({}));
-        throw new Error(errData.detail || `Claim failed (${response.status})`);
-      }
-
-      const result = await response.json();
+      const result = await claimDevice({
+        intent_id: form.intentId,
+        claim_token: form.claimToken,
+        device_name: deviceName,
+        device_type: form.deviceType,
+        os_details: deviceOs,
+      });
 
       await credentialStorage.save({
         deviceId: result.device_id,

--- a/user_app/src/views/DeviceInfo.tsx
+++ b/user_app/src/views/DeviceInfo.tsx
@@ -2,8 +2,9 @@ import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import TabBar from '../components/TabBar'
 import { useApp } from '../context/AppContext'
-import { apiBaseUrl } from '../config/api'
 import { credentialStorage } from '../services/credentialStorage'
+import { fetchDevice, unpairDevice, ApiError } from '../services/api'
+import type { DeviceRecord } from '../services/api'
 
 function formatDeviceType(v: string) {
   return v.replace('_', ' ').replace(/\b\w/g, c => c.toUpperCase())
@@ -16,19 +17,6 @@ function formatOs(v: string) {
 interface DnaRow {
   label: string
   value: string
-}
-
-interface DeviceRecord {
-  name: string
-  site_id: string
-  device_type: string
-  mac_address: string
-  local_ip: string
-  wan_ip: string
-  os_details: string
-  firmware_version: string
-  lifecycle_state: string
-  connectivity_state: string
 }
 
 export default function DeviceInfo() {
@@ -54,12 +42,7 @@ export default function DeviceInfo() {
       let backend: DeviceRecord | null = null
       if (deviceId && apiKey) {
         try {
-          const res = await fetch(`${apiBaseUrl}/devices/device/${deviceId}`, {
-            headers: { 'X-Device-ID': deviceId, 'X-API-Key': apiKey },
-          })
-          if (res.ok) {
-            backend = await res.json()
-          }
+          backend = await fetchDevice(deviceId, apiKey)
         } catch {
           // backend unreachable — fall through to local fallbacks
         }
@@ -129,36 +112,24 @@ export default function DeviceInfo() {
     }
 
     try {
-      const res = await fetch(
-        `${apiBaseUrl}/devices/device/${deviceId}/unpair`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            ...(apiKey ? { 'X-Device-ID': deviceId, 'X-API-Key': apiKey } : {}),
-          },
-          body: JSON.stringify({
-            reason: 'User-initiated unpair from device settings',
-            idempotency_key: idempotencyKey,
-          }),
-        },
-      )
-
-      if (res.ok) {
-        setUnpairStatus('confirmed')
-        await credentialStorage.clear()
-        setIsProvisioned(false)
-        navigate('/setup')
-      } else {
-        const body = await res.json().catch(() => ({}))
-        setUnpairError(body.detail || `Server rejected unpair (${res.status})`)
-        setUnpairStatus('error')
-      }
-    } catch {
-      // Network failure — perform local-only reset
+      await unpairDevice(deviceId, apiKey ?? '', {
+        reason: 'User-initiated unpair from device settings',
+        idempotencyKey,
+      })
+      setUnpairStatus('confirmed')
       await credentialStorage.clear()
       setIsProvisioned(false)
-      setUnpairStatus('pending-revocation')
+      navigate('/setup')
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setUnpairError(err.message)
+        setUnpairStatus('error')
+      } else {
+        // Network failure — perform local-only reset
+        await credentialStorage.clear()
+        setIsProvisioned(false)
+        setUnpairStatus('pending-revocation')
+      }
     }
   }
 

--- a/user_app/src/views/HomeDashboard.tsx
+++ b/user_app/src/views/HomeDashboard.tsx
@@ -1,14 +1,9 @@
 import { useState, useEffect, useRef } from 'react'
 import TabBar from '../components/TabBar'
 import GaugeRing from '../components/GaugeRing'
-import { apiBaseUrl } from '../config/api'
 import { credentialStorage } from '../services/credentialStorage'
-
-interface DeviceStatus {
-  lifecycle_state: string
-  connectivity_state: string
-  health_state: string
-}
+import { fetchDeviceStatus } from '../services/api'
+import type { DeviceStatus } from '../services/api'
 
 export default function HomeDashboard() {
   const [deviceName, setDeviceName] = useState('My Device')
@@ -32,20 +27,15 @@ export default function HomeDashboard() {
   useEffect(() => {
     async function fetchStatus() {
       const dId = deviceIdRef.current
-      if (!dId) return
+      const aKey = apiKeyRef.current
+      if (!dId || !aKey) return
       try {
-        const res = await fetch(`${apiBaseUrl}/agent/${dId}/status`, {
-          headers: apiKeyRef.current ? { 'X-Device-ID': dId, 'X-API-Key': apiKeyRef.current } : {},
-        })
-        if (res.ok) {
-          const body = await res.json()
-          setStatus(body.data)
-        }
+        setStatus(await fetchDeviceStatus(dId, aKey))
       } catch {
         // silently degrade
       }
     }
-    if (!deviceIdRef.current) return
+    if (!deviceIdRef.current || !apiKeyRef.current) return
     fetchStatus()
     const interval = setInterval(fetchStatus, 30000)
     return () => clearInterval(interval)

--- a/user_app/src/views/Permissions.tsx
+++ b/user_app/src/views/Permissions.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import TabBar from '../components/TabBar'
-import { apiBaseUrl } from '../config/api'
 import { credentialStorage } from '../services/credentialStorage'
+import { fetchPermissions as fetchPermissionsApi, updatePermissions } from '../services/api'
 
 interface PermissionEntry {
   key: string
@@ -67,15 +67,7 @@ export default function Permissions() {
     setLoading(true)
     setError('')
     try {
-      const res = await fetch(`${apiBaseUrl}/devices/device/${dId}/permissions`, {
-        headers: { 'X-Device-ID': dId, 'X-API-Key': aKey },
-      })
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}))
-        throw new Error(body.detail || 'Failed to fetch permissions')
-      }
-      const body = await res.json()
-      const data = body.data
+      const data = await fetchPermissionsApi(dId, aKey)
       const perms: Record<string, boolean> = data.permissions || {}
       const caps: Record<string, boolean> = data.capabilities || {}
 
@@ -114,15 +106,7 @@ export default function Permissions() {
 
     setSavingKeys(prev => new Set(prev).add(key))
     try {
-      const res = await fetch(`${apiBaseUrl}/devices/device/${dId}/permissions`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json', 'X-Device-ID': dId, 'X-API-Key': aKey },
-        body: JSON.stringify({ permissions: { [key]: enabled } }),
-      })
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}))
-        throw new Error(body.detail || 'Failed to sync permission')
-      }
+      await updatePermissions(dId, aKey, { [key]: enabled })
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Sync failed'
       setError(msg)

--- a/user_app/src/views/SetupWizard.tsx
+++ b/user_app/src/views/SetupWizard.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom'
 import { useApp } from '../context/AppContext'
 import { apiBaseUrl } from '../config/api'
 import { credentialStorage } from '../services/credentialStorage'
+import { bootstrapProvision } from '../services/api'
 
 const EMULATOR_TYPES: { value: string; label: string; os: string; description: string }[] = [
   { value: 'linux_pos', label: 'Linux POS', os: 'Linux 6.8.0 (Debian 12)', description: 'Simulates a Linux-based POS terminal' },
@@ -196,19 +197,7 @@ function ReviewStep({ onBack }: { onBack: () => void }) {
         device_type: deviceType,
         os_details: deviceOs,
       }
-      const response = await fetch(`${apiBaseUrl}/devices/bootstrap-provision`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(reqBody),
-      })
-
-      if (!response.ok) {
-        const err = await response.json().catch(() => ({}))
-        throw new Error(err.detail || 'Provisioning failed. Check the bootstrap key and backend connection.')
-      }
-
-      const data = await response.json()
-      const d = data.data
+      const d = await bootstrapProvision(reqBody)
       if (!d?.device_id || !d?.api_key) throw new Error('Provisioning response did not include device credentials.')
 
       await credentialStorage.save({ deviceId: d.device_id, apiKey: d.api_key, siteId, deviceName: deviceName || 'My Device', deviceType, deviceOs, enrollmentMethod: 'self-enrolled' })
@@ -337,13 +326,13 @@ function EmulatorConfigStep() {
 
 function ModeStep() {
   const navigate = useNavigate()
-  const { useEmulator, setUseEmulator, setEmulatorType } = useApp()
+  const { useEmulator, setUseEmulator, emulatorType, setEmulatorType } = useApp()
   const [mode, setMode] = useState<'real' | 'emulator'>(useEmulator ? 'emulator' : 'real')
 
   const handleNext = () => {
     if (mode === 'emulator') {
       setUseEmulator(true)
-      if (!EMULATOR_TYPES.find(t => t.value === useEmulator)) {
+      if (!EMULATOR_TYPES.find(t => t.value === emulatorType)) {
         setEmulatorType(EMULATOR_TYPES[0].value)
       }
       navigate('/emulator')


### PR DESCRIPTION
## Summary
Refactors the User App to call a single tested service layer instead of duplicating raw `fetch` calls in each view, and fixes two real bugs found while aligning with the backend contract.

### Service-layer fixes (`user_app/src/services/api.ts`)
- **`claimDevice()`**: backend returns a **flat** body (`device_id`/`api_key`/`site_id` at top level), but the service read `json.data` → returned `undefined`. Now reads the flat shape.
- **`updatePermissions()`**: backend PATCH expects `{ permissions: {...} }`, but the service sent the bare map → would have been rejected with 422. Body is now wrapped.
- **`fetchPermissions()`**: backend wraps the result in `data`, but the service returned the envelope. Now unwraps `json.data`.
- Added `ApiError` (with HTTP status) so callers can distinguish server rejection from network failure.
- `unpairDevice()` now accepts optional `reason` + `idempotencyKey` to match the view's existing behaviour.

### Views now use the service layer
`HomeDashboard`, `DeviceInfo`, `Permissions`, `ClaimDevice`, and `SetupWizard` all replaced their inline `fetch` calls (with duplicated header/error handling) with the service functions. Removed now-unused `apiBaseUrl` imports.

### Provisioned-state bug (`AppContext`)
- `isProvisioned` previously read a dead `homepot_token` localStorage key that nothing writes → on reload of an already-provisioned device, the app showed the setup wizard.
- Now resolved from `credentialStorage.isProvisioned()`.
- Fixed a follow-on redirect bug: a `<Navigate>` that fires before the async check completes unmounts itself and strands the user on `/setup`. Added a `provisionedChecked` gate so the root redirect only runs once the storage check finishes.

### Other
- Fixed `ModeStep` comparing a boolean (`useEmulator`) against emulator-type strings (dead branch).
- Tests updated to the correct backend contract; added an unpair idempotency-key test.
- Added a PR-tracker section to `docs/user-app-implementation.md` to keep the User App effort visible.

### Verification
- `tsc -b`, `vite build`, and `vitest run` (38 tests) all green.
- `eslint` reports only the same 6 pre-existing issues as on base.
