### PR TITLE
feat: live dashboard telemetry in User App

### DIFF
--- a/backend/src/homepot/app/api/API_v1/Endpoints/AgentTelemetryEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/AgentTelemetryEndpoint.py
@@ -1,4 +1,4 @@
-"""API endpoint for storing agent telemetry metrics."""
+"""API endpoint for storing and retrieving agent telemetry metrics."""
 
 import logging
 from typing import Any, Dict, List, Union
@@ -61,4 +61,39 @@ def save_telemetry(
         raise
     except Exception as e:
         logger.error("Unexpected telemetry error: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/{device_id}/metrics", tags=["Agent"])
+def get_latest_metrics(
+    device_id: str,
+    current_device: Device = Depends(get_current_device),
+    db: Session = Depends(get_db),
+) -> Dict[str, Any]:
+    """Return the latest telemetry metrics for the authenticated device.
+
+    The device authenticates via ``X-Device-ID`` and ``X-API-Key`` headers
+    and can only read its own metrics.
+    """
+    try:
+        if current_device.device_id != device_id:
+            raise HTTPException(
+                status_code=403,
+                detail="Authenticated device can only read its own metrics",
+            )
+
+        service = AgentService(db)
+        result = service.get_latest_metrics(device_id)
+        return {
+            "status": "success",
+            "message": "Latest device metrics fetched successfully",
+            "data": result,
+        }
+    except LookupError as e:
+        logger.error("Metrics lookup failed: %s", e)
+        raise HTTPException(status_code=404, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Unexpected metrics error: %s", e, exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/src/homepot/app/repositories/agent_repository.py
+++ b/backend/src/homepot/app/repositories/agent_repository.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any, Iterable, Optional, cast
 
-from sqlalchemy import select
+from sqlalchemy import desc, select
 from sqlalchemy.orm import Session
 
 from homepot.app.models.AnalyticsModel import DeviceMetrics
@@ -32,6 +32,16 @@ class AgentRepository:
     def get_site_by_site_id(self, site_id: str) -> Optional[Site]:
         """Return a site by business site_id, or None if not found."""
         result = self.db.execute(select(Site).where(Site.site_id == site_id))
+        return result.scalars().first()
+
+    def get_latest_metrics(self, device_pk: int) -> Optional[DeviceMetrics]:
+        """Return the most recent telemetry entry for a device, or None."""
+        result = self.db.execute(
+            select(DeviceMetrics)
+            .where(DeviceMetrics.device_id == device_pk)
+            .order_by(desc(DeviceMetrics.timestamp))
+            .limit(1)
+        )
         return result.scalars().first()
 
     def create_device(

--- a/backend/src/homepot/app/services/agent_service.py
+++ b/backend/src/homepot/app/services/agent_service.py
@@ -472,3 +472,41 @@ class AgentService:
             raise ValueError(f"Invalid device status request: {str(e)}")
         except Exception:
             raise Exception("Failed to fetch device status")
+
+    def get_latest_metrics(self, device_id: str) -> dict:
+        """Return the most recent telemetry metrics for a device, or empty values."""
+        try:
+            device = self.repository.get_device_by_device_id(device_id)
+            if not device or not device.id:
+                raise LookupError(f"Device '{device_id}' not found")
+
+            metric = self.repository.get_latest_metrics(device_pk=int(device.id))
+            if metric is None:
+                return {
+                    "device_id": device.device_id,
+                    "cpu_percent": None,
+                    "memory_percent": None,
+                    "disk_percent": None,
+                    "network_latency_ms": None,
+                    "uptime_seconds": None,
+                    "timestamp": None,
+                }
+
+            extra_raw = metric.extra_metrics
+            extra: Dict[str, Any] = (
+                cast(Dict[str, Any], extra_raw) if isinstance(extra_raw, dict) else {}
+            )
+            return {
+                "device_id": device.device_id,
+                "cpu_percent": metric.cpu_percent,
+                "memory_percent": metric.memory_percent,
+                "disk_percent": metric.disk_percent,
+                "network_latency_ms": metric.network_latency_ms,
+                "uptime_seconds": extra.get("uptime_seconds"),
+                "timestamp": metric.timestamp.isoformat(),
+            }
+
+        except LookupError:
+            raise
+        except Exception:
+            raise Exception("Failed to fetch device metrics")

--- a/backend/tests/test_agent_endpoints.py
+++ b/backend/tests/test_agent_endpoints.py
@@ -195,6 +195,74 @@ def test_telemetry_bulk_is_saved(client: TestClient):
     assert response.json()["data"]["saved_count"] == 2
 
 
+def test_metrics_returns_latest_telemetry(client: TestClient):
+    """GET /api/v1/agent/{device_id}/metrics should return the latest entry."""
+    site = _create_site("site-metrics-latest")
+    api_key = _create_device("metrics-device-1", int(site.id))
+
+    post = client.post(
+        "/api/v1/agent/telemetry",
+        json={
+            "device_id": "metrics-device-1",
+            "cpu_usage": 30.0,
+            "memory_usage": 61.0,
+            "disk_usage": 48.0,
+            "network_latency_ms": 12.5,
+            "uptime_seconds": 3600,
+        },
+        headers=_device_headers("metrics-device-1", api_key),
+    )
+    assert post.status_code == 200
+
+    response = client.get(
+        "/api/v1/agent/metrics-device-1/metrics",
+        headers=_device_headers("metrics-device-1", api_key),
+    )
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["device_id"] == "metrics-device-1"
+    assert data["cpu_percent"] == 30.0
+    assert data["memory_percent"] == 61.0
+    assert data["disk_percent"] == 48.0
+    assert data["network_latency_ms"] == 12.5
+    assert data["uptime_seconds"] == 3600
+    assert data["timestamp"] is not None
+
+
+def test_metrics_returns_empty_values_when_no_telemetry(client: TestClient):
+    """GET metrics should return null fields when no telemetry exists yet."""
+    site = _create_site("site-metrics-empty")
+    api_key = _create_device("metrics-device-2", int(site.id))
+
+    response = client.get(
+        "/api/v1/agent/metrics-device-2/metrics",
+        headers=_device_headers("metrics-device-2", api_key),
+    )
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["cpu_percent"] is None
+    assert data["memory_percent"] is None
+    assert data["uptime_seconds"] is None
+
+
+def test_metrics_rejects_other_devices_and_missing_credentials(client: TestClient):
+    """GET metrics should 403 for another device and 401 without credentials."""
+    site = _create_site("site-metrics-auth")
+    api_key = _create_device("metrics-device-3", int(site.id))
+    _create_device("metrics-device-4", int(site.id), api_key="other-key")
+
+    other = client.get(
+        "/api/v1/agent/metrics-device-4/metrics",
+        headers=_device_headers("metrics-device-3", api_key),
+    )
+    assert other.status_code == 403
+
+    missing = client.get("/api/v1/agent/metrics-device-3/metrics")
+    assert missing.status_code == 401
+
+
 def test_provision_returns_credentials_and_hashes_key(client: TestClient):
     """POST /api/v1/devices/provision should return credentials and persist hash."""
     _create_site("site-provision")

--- a/user_app/src/services/api.ts
+++ b/user_app/src/services/api.ts
@@ -33,6 +33,15 @@ export interface DeviceStatus {
   last_heartbeat_at: string | null
 }
 
+export interface DeviceMetrics {
+  cpu_percent: number | null
+  memory_percent: number | null
+  disk_percent: number | null
+  network_latency_ms: number | null
+  uptime_seconds: number | null
+  timestamp: string | null
+}
+
 interface Headers {
   [key: string]: string
 }
@@ -81,6 +90,21 @@ export async function fetchDeviceStatus(deviceId: string, apiKey: string): Promi
   }
   const json = await res.json()
   return json.data as DeviceStatus
+}
+
+export async function fetchDeviceMetrics(
+  deviceId: string,
+  apiKey: string,
+): Promise<DeviceMetrics> {
+  const res = await fetch(`${apiBaseUrl}/agent/${deviceId}/metrics`, {
+    headers: deviceAuthHeaders(deviceId, apiKey),
+  })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw asApiError(body.detail || `Failed to fetch metrics (${res.status})`, res.status)
+  }
+  const json = await res.json()
+  return json.data as DeviceMetrics
 }
 
 export async function fetchPermissions(deviceId: string, apiKey: string): Promise<PermissionsResponse> {

--- a/user_app/src/test/api.test.ts
+++ b/user_app/src/test/api.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import {
   fetchDevice,
   fetchDeviceStatus,
+  fetchDeviceMetrics,
   fetchPermissions,
   updatePermissions,
   bootstrapProvision,
@@ -72,6 +73,28 @@ describe('fetchDeviceStatus', () => {
   it('throws on error', async () => {
     mockFetch.mockResolvedValueOnce(notFound('Device not found'))
     await expect(fetchDeviceStatus(DEVICE_ID, API_KEY)).rejects.toThrow('Device not found')
+  })
+})
+
+describe('fetchDeviceMetrics', () => {
+  it('returns metrics from nested data field', async () => {
+    const metrics = { cpu_percent: 42, memory_percent: 61, disk_percent: 28, network_latency_ms: 12.5, uptime_seconds: 3725, timestamp: '2026-08-03T12:00:00.000Z' }
+    mockFetch.mockResolvedValueOnce(ok({ data: metrics }))
+    const result = await fetchDeviceMetrics(DEVICE_ID, API_KEY)
+    expect(result.cpu_percent).toBe(42)
+    expect(result.memory_percent).toBe(61)
+    expect(result.disk_percent).toBe(28)
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining(`/agent/${DEVICE_ID}/metrics`),
+      expect.objectContaining({
+        headers: { 'X-Device-ID': DEVICE_ID, 'X-API-Key': API_KEY },
+      }),
+    )
+  })
+
+  it('throws on error', async () => {
+    mockFetch.mockResolvedValueOnce(serverError('Server error'))
+    await expect(fetchDeviceMetrics(DEVICE_ID, API_KEY)).rejects.toThrow('Server error')
   })
 })
 

--- a/user_app/src/test/integration.test.tsx
+++ b/user_app/src/test/integration.test.tsx
@@ -35,6 +35,18 @@ describe('App routing', () => {
         },
       }),
     )
+    mockFetch.mockResolvedValueOnce(
+      ok({
+        data: {
+          cpu_percent: 10,
+          memory_percent: 20,
+          disk_percent: 30,
+          network_latency_ms: 5,
+          uptime_seconds: 3600,
+          timestamp: new Date().toISOString(),
+        },
+      }),
+    )
     render(<App />)
     expect(await screen.findByText('SECURE — ONLINE')).toBeInTheDocument()
   })

--- a/user_app/src/test/views.test.tsx
+++ b/user_app/src/test/views.test.tsx
@@ -35,17 +35,34 @@ describe('HomeDashboard', () => {
     mockFetch.mockReset()
   })
 
+  function statusOk(overrides: Partial<{ lifecycle_state: string; connectivity_state: string; health_state: string; last_heartbeat_at: string | null }> = {}) {
+    return ok({
+      data: {
+        lifecycle_state: 'active',
+        connectivity_state: 'online',
+        health_state: 'good',
+        last_heartbeat_at: '2026-08-03T12:34:56.000Z',
+        ...overrides,
+      },
+    })
+  }
+
+  function metricsOk(overrides: Partial<{ cpu_percent: number | null; memory_percent: number | null; disk_percent: number | null; network_latency_ms: number | null; uptime_seconds: number | null; timestamp: string | null }> = {}) {
+    return ok({
+      data: {
+        cpu_percent: 42,
+        memory_percent: 61,
+        disk_percent: 28,
+        network_latency_ms: 12.5,
+        uptime_seconds: 3725,
+        timestamp: '2026-08-03T12:34:56.000Z',
+        ...overrides,
+      },
+    })
+  }
+
   it('renders header and gauges', async () => {
-    mockFetch.mockResolvedValueOnce(
-      ok({
-        data: {
-          lifecycle_state: 'active',
-          connectivity_state: 'online',
-          health_state: 'good',
-          last_heartbeat_at: new Date().toISOString(),
-        },
-      }),
-    )
+    mockFetch.mockResolvedValueOnce(statusOk()).mockResolvedValueOnce(metricsOk())
     renderWithProviders(<HomeDashboard />)
     expect(await screen.findByText('HOMEPOT Agent')).toBeInTheDocument()
     expect(await screen.findByText('SECURE — ONLINE')).toBeInTheDocument()
@@ -54,47 +71,42 @@ describe('HomeDashboard', () => {
     expect(screen.getByText('Disk')).toBeInTheDocument()
   })
 
+  it('renders live metrics from backend', async () => {
+    mockFetch.mockResolvedValueOnce(statusOk()).mockResolvedValueOnce(metricsOk())
+    renderWithProviders(<HomeDashboard />)
+    expect(await screen.findByText('42%')).toBeInTheDocument()
+    expect(await screen.findByText('61%')).toBeInTheDocument()
+    expect(await screen.findByText('28%')).toBeInTheDocument()
+    expect(screen.getByText('12.5ms')).toBeInTheDocument()
+    expect(screen.getByText('1h 2m')).toBeInTheDocument()
+  })
+
+  it('renders backend heartbeat timestamp', async () => {
+    mockFetch.mockResolvedValueOnce(statusOk()).mockResolvedValueOnce(metricsOk())
+    renderWithProviders(<HomeDashboard />)
+    expect(await screen.findByText('SECURE — ONLINE')).toBeInTheDocument()
+    const expected = new Date('2026-08-03T12:34:56.000Z').toLocaleTimeString('en-GB', {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+    expect(screen.getByText(expected)).toBeInTheDocument()
+  })
+
   it('shows offline state when backend returns offline', async () => {
-    mockFetch.mockResolvedValueOnce(
-      ok({
-        data: {
-          lifecycle_state: 'active',
-          connectivity_state: 'offline',
-          health_state: 'unknown',
-          last_heartbeat_at: null,
-        },
-      }),
-    )
+    mockFetch.mockResolvedValueOnce(statusOk({ connectivity_state: 'offline', last_heartbeat_at: null })).mockResolvedValueOnce(metricsOk())
     renderWithProviders(<HomeDashboard />)
     expect(await screen.findByText('OFFLINE')).toBeInTheDocument()
   })
 
   it('shows suspended banner when lifecycle is suspended', async () => {
-    mockFetch.mockResolvedValueOnce(
-      ok({
-        data: {
-          lifecycle_state: 'suspended',
-          connectivity_state: 'offline',
-          health_state: 'unknown',
-          last_heartbeat_at: null,
-        },
-      }),
-    )
+    mockFetch.mockResolvedValueOnce(statusOk({ lifecycle_state: 'suspended', connectivity_state: 'offline', last_heartbeat_at: null })).mockResolvedValueOnce(metricsOk())
     renderWithProviders(<HomeDashboard />)
     expect(await screen.findByText('DEVICE SUSPENDED')).toBeInTheDocument()
   })
 
   it('renders TabBar with navigation links', async () => {
-    mockFetch.mockResolvedValueOnce(
-      ok({
-        data: {
-          lifecycle_state: 'active',
-          connectivity_state: 'online',
-          health_state: 'good',
-          last_heartbeat_at: new Date().toISOString(),
-        },
-      }),
-    )
+    mockFetch.mockResolvedValueOnce(statusOk()).mockResolvedValueOnce(metricsOk())
     renderWithProviders(<HomeDashboard />)
     expect(await screen.findByText('Home')).toBeInTheDocument()
     expect(screen.getByText('Perms')).toBeInTheDocument()

--- a/user_app/src/views/HomeDashboard.tsx
+++ b/user_app/src/views/HomeDashboard.tsx
@@ -2,13 +2,35 @@ import { useState, useEffect, useRef } from 'react'
 import TabBar from '../components/TabBar'
 import GaugeRing from '../components/GaugeRing'
 import { credentialStorage } from '../services/credentialStorage'
-import { fetchDeviceStatus } from '../services/api'
-import type { DeviceStatus } from '../services/api'
+import { fetchDeviceStatus, fetchDeviceMetrics } from '../services/api'
+import type { DeviceStatus, DeviceMetrics } from '../services/api'
+
+function formatUptime(totalSeconds: number | null): string {
+  if (totalSeconds === null || totalSeconds === undefined) return '—'
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  if (hours === 0) return `${minutes}m`
+  return `${hours}h ${minutes}m`
+}
+
+function formatHeartbeat(iso: string | null): string {
+  if (!iso) return '—'
+  try {
+    return new Date(iso).toLocaleTimeString('en-GB', {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+  } catch {
+    return '—'
+  }
+}
 
 export default function HomeDashboard() {
   const [deviceName, setDeviceName] = useState('My Device')
   const [deviceId, setDeviceId] = useState<string | null>(null)
   const [status, setStatus] = useState<DeviceStatus | null>(null)
+  const [metrics, setMetrics] = useState<DeviceMetrics | null>(null)
   const deviceIdRef = useRef<string | null>(null)
   const apiKeyRef = useRef<string | null>(null)
 
@@ -35,15 +57,34 @@ export default function HomeDashboard() {
         // silently degrade
       }
     }
+    async function fetchMetrics() {
+      const dId = deviceIdRef.current
+      const aKey = apiKeyRef.current
+      if (!dId || !aKey) return
+      try {
+        setMetrics(await fetchDeviceMetrics(dId, aKey))
+      } catch {
+        // silently degrade
+      }
+    }
     if (!deviceIdRef.current || !apiKeyRef.current) return
     fetchStatus()
-    const interval = setInterval(fetchStatus, 30000)
-    return () => clearInterval(interval)
+    fetchMetrics()
+    const statusInterval = setInterval(fetchStatus, 30000)
+    const metricsInterval = setInterval(fetchMetrics, 15000)
+    return () => {
+      clearInterval(statusInterval)
+      clearInterval(metricsInterval)
+    }
   }, [deviceId])
 
   const connectivity = status?.connectivity_state || 'unknown'
   const lifecycle = status?.lifecycle_state || 'unknown'
   const isOnline = connectivity === 'online'
+
+  const cpu = metrics?.cpu_percent ?? 0
+  const mem = metrics?.memory_percent ?? 0
+  const disk = metrics?.disk_percent ?? 0
 
   if (lifecycle === 'unpaired' || lifecycle === 'retired') {
     return (
@@ -117,13 +158,22 @@ export default function HomeDashboard() {
         <div className="px-5 pt-5">
           <p className="text-slate-500 text-xs font-medium mb-3 uppercase tracking-widest">Agent Resource Usage</p>
           <div className="flex justify-around">
-            <GaugeRing label="CPU" value={42} color="#10b981" />
-            <GaugeRing label="Memory" value={61} color="#f59e0b" />
-            <GaugeRing label="Disk" value={28} color="#3b82f6" />
+            <GaugeRing label="CPU" value={cpu} color="#10b981" />
+            <GaugeRing label="Memory" value={mem} color="#f59e0b" />
+            <GaugeRing label="Disk" value={disk} color="#3b82f6" />
           </div>
-          <p className="text-center text-slate-600 text-xs mt-2">
-            Live data available after IPC connection (Phase 3)
-          </p>
+          <div className="mt-3 grid grid-cols-2 gap-2">
+            <div className="bg-slate-700 rounded-lg px-3 py-2 flex items-center justify-between">
+              <span className="text-slate-400 text-xs">Network</span>
+              <span className="text-slate-200 text-xs font-mono">
+                {metrics?.network_latency_ms != null ? `${metrics.network_latency_ms.toFixed(1)}ms` : '—'}
+              </span>
+            </div>
+            <div className="bg-slate-700 rounded-lg px-3 py-2 flex items-center justify-between">
+              <span className="text-slate-400 text-xs">Uptime</span>
+              <span className="text-slate-200 text-xs font-mono">{formatUptime(metrics?.uptime_seconds ?? null)}</span>
+            </div>
+          </div>
         </div>
 
         {/* Heartbeat */}
@@ -134,7 +184,7 @@ export default function HomeDashboard() {
               <span className="text-slate-400 text-xs font-medium">Heartbeat</span>
             </div>
             <span className="text-slate-200 text-xs font-mono">
-              {new Date().toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
+              {formatHeartbeat(status?.last_heartbeat_at ?? null)}
             </span>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Wire the HomeDashboard to real backend telemetry and heartbeat data, closing the gap against the emulator feature set.

### Backend
- Added device-credential-authenticated read endpoint `GET /api/v1/agent/{device_id}/metrics` in `AgentTelemetryEndpoint.py` (mirrors the existing `POST /agent/telemetry` semantics; the operator-only `/devices/device/{id}/metrics` is unusable by device creds).
  - 403 when the authenticated device reads another device; 404 on missing device; 401 on missing device creds.
- `AgentRepository.get_latest_metrics(device_pk)` returns the most recent `DeviceMetrics` row (timestamp desc).
- `AgentService.get_latest_metrics(device_id)` returns the latest row or an all-`None` payload; `uptime_seconds` read from `extra_metrics`.
- Tests: metrics round-trip, empty-values payload, auth mismatches (403/401). 10/10 pass.

### User App
- `DeviceMetrics` type + `fetchDeviceMetrics(deviceId, apiKey)` calling `GET /agent/{device_id}/metrics` with device auth headers.
- `HomeDashboard` polls metrics every 15s (alongside the existing 30s status poll); CPU/Memory/Disk gauges now render real `cpu_percent`/`memory_percent`/`disk_percent`; added Network latency + Uptime stat tiles; heartbeat shows real `last_heartbeat_at` instead of wall-clock time.
- Tests updated: new metrics unit test, live-metrics + heartbeat rendering assertions, integration mock. 42/42 vitest green.

### Quality
- black/isort/flake8 clean on changed files; mypy clean on CI scope (`backend/src/homepot/ ai/ uq/ emulators/`). tsc clean; no new eslint issues (6 pre-existing unchanged).