### PR TITLE
feat: permission request consent flow in User App

### DIFF
--- a/user_app/src/App.tsx
+++ b/user_app/src/App.tsx
@@ -2,6 +2,7 @@ import { type ReactNode } from 'react'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { AppProvider, useApp } from './context/AppContext'
 import ErrorBoundary from './components/ErrorBoundary'
+import PermissionConsentPrompt from './components/PermissionConsentPrompt'
 import SetupWizard from './views/SetupWizard'
 import SignIn from './views/SignIn'
 import HomeDashboard from './views/HomeDashboard'
@@ -23,6 +24,7 @@ export default function App() {
   return (
     <BrowserRouter>
       <AppProvider>
+        <PermissionConsentPrompt />
         <Routes>
           <Route path="/" element={<Wrapped><RootRedirect /></Wrapped>} />
           <Route path="/setup" element={<Wrapped><SetupWizard /></Wrapped>} />

--- a/user_app/src/components/PermissionConsentPrompt.tsx
+++ b/user_app/src/components/PermissionConsentPrompt.tsx
@@ -1,0 +1,164 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { credentialStorage } from '../services/credentialStorage'
+import {
+  fetchPendingCommands,
+  ackCommand,
+  updatePermissions,
+  updateCommandStatus,
+  reportPermissionAudit,
+} from '../services/api'
+import type { PendingCommand } from '../services/api'
+
+const PERMISSION_LABELS: Record<string, string> = {
+  root_access: 'Root / Full Access',
+  process_monitoring: 'Process Monitoring',
+  filesystem_access: 'File System Access',
+  network_monitoring: 'Network Monitoring',
+}
+
+function permissionLabel(permission: string): string {
+  return PERMISSION_LABELS[permission] ?? permission
+}
+
+export default function PermissionConsentPrompt() {
+  const [request, setRequest] = useState<PendingCommand | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState('')
+
+  const deviceIdRef = useRef<string | null>(null)
+  const apiKeyRef = useRef<string | null>(null)
+  const requestRef = useRef<PendingCommand | null>(null)
+  const handledRef = useRef<Set<string>>(new Set())
+
+  const data = request?.payload?.data as Record<string, unknown> | undefined
+  const permission = typeof data?.permission === 'string' ? data.permission : ''
+  const action = typeof data?.action === 'string' ? data.action : 'grant'
+  const requestedBy = typeof data?.requested_by === 'string' ? data.requested_by : 'HOMEPOT operator'
+  const isRevoke = action === 'revoke'
+
+  const poll = useCallback(async () => {
+    const dId = deviceIdRef.current
+    const aKey = apiKeyRef.current
+    if (!dId || !aKey || requestRef.current) return
+    try {
+      const commands = await fetchPendingCommands(dId, aKey)
+      if (requestRef.current) return
+      const cmd = commands.find(
+        c => c.command_type === 'request_permission' && !handledRef.current.has(c.command_id),
+      )
+      if (!cmd) return
+      await ackCommand(dId, aKey, cmd.command_id)
+      if (requestRef.current) return
+      setRequest(cmd)
+      requestRef.current = cmd
+    } catch {
+      // silently degrade until next poll
+    }
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function ensureCreds(): Promise<boolean> {
+      const [did, key] = await Promise.all([
+        credentialStorage.getDeviceId(),
+        credentialStorage.getApiKey(),
+      ])
+      if (did) deviceIdRef.current = did
+      if (key) apiKeyRef.current = key
+      return Boolean(deviceIdRef.current && apiKeyRef.current)
+    }
+
+    async function run() {
+      if (cancelled) return
+      if (!deviceIdRef.current || !apiKeyRef.current) {
+        if (!(await ensureCreds()) || cancelled) return
+      }
+      await poll()
+    }
+
+    run()
+    const interval = setInterval(run, 10000)
+    return () => {
+      cancelled = true
+      clearInterval(interval)
+    }
+  }, [poll])
+
+  async function respond(decision: 'accept' | 'deny') {
+    const cmd = request
+    const dId = deviceIdRef.current
+    const aKey = apiKeyRef.current
+    if (!cmd || !dId || !aKey) return
+
+    setBusy(true)
+    setError('')
+    try {
+      const granted = decision === 'accept' ? !isRevoke : isRevoke
+      await updatePermissions(dId, aKey, { [permission]: granted })
+      await reportPermissionAudit(dId, aKey, { permission, granted, requestedBy, action })
+      await updateCommandStatus(dId, aKey, cmd.command_id, 'completed', {
+        permission,
+        action,
+        granted,
+        message: granted
+          ? `Permission '${permission}' granted by device owner`
+          : `Permission '${permission}' denied by device owner`,
+      })
+      handledRef.current.add(cmd.command_id)
+      setRequest(null)
+      requestRef.current = null
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to respond to permission request')
+      setBusy(false)
+    }
+  }
+
+  if (!request) return null
+
+  const title = isRevoke ? 'Revoke access requested' : 'Permission request'
+  const body = isRevoke
+    ? `${requestedBy} is requesting to revoke "${permissionLabel(permission)}".`
+    : `${requestedBy} is requesting access to "${permissionLabel(permission)}".`
+  const acceptLabel = isRevoke ? 'Approve revocation' : 'Allow'
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/60 flex items-center justify-center p-4 font-sans">
+      <div className="w-full max-w-sm bg-slate-800 rounded-2xl shadow-2xl border border-slate-600 p-6">
+        <div className="flex items-center gap-2 mb-3">
+          <span className="text-xl">🔐</span>
+          <h2 className="text-slate-100 font-bold text-base">{title}</h2>
+        </div>
+        <p className="text-slate-300 text-sm leading-relaxed">{body}</p>
+        <p className="text-slate-500 text-xs mt-2">
+          You can review and adjust permissions any time under Permissions.
+        </p>
+
+        {error && (
+          <div className="mt-3 bg-red-950 border border-red-800 rounded-lg px-3 py-2">
+            <p className="text-xs text-red-300">{error}</p>
+          </div>
+        )}
+
+        <div className="flex gap-3 mt-5">
+          <button
+            onClick={() => respond('deny')}
+            disabled={busy}
+            className="flex-1 py-2.5 rounded-lg border border-slate-600 text-slate-300 text-sm font-medium disabled:opacity-50"
+          >
+            Deny
+          </button>
+          <button
+            onClick={() => respond('accept')}
+            disabled={busy}
+            className={`flex-1 py-2.5 rounded-lg text-sm font-medium disabled:opacity-50 ${
+              isRevoke ? 'bg-orange-500 text-white' : 'bg-emerald-500 text-white'
+            }`}
+          >
+            {busy ? '…' : acceptLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/user_app/src/services/api.ts
+++ b/user_app/src/services/api.ts
@@ -42,6 +42,21 @@ export interface DeviceMetrics {
   timestamp: string | null
 }
 
+export interface PendingCommand {
+  command_id: string
+  command_type: string
+  payload: Record<string, unknown> | null
+  status: string
+  created_at: string
+}
+
+export interface PermissionRequestResult {
+  permission: string
+  action: string
+  granted: boolean
+  message: string
+}
+
 interface Headers {
   [key: string]: string
 }
@@ -195,5 +210,79 @@ export async function unpairDevice(
   if (!res.ok && res.status !== 404) {
     const body = await res.json().catch(() => ({}))
     throw asApiError(body.detail || `Unpair failed (${res.status})`, res.status)
+  }
+}
+
+export async function fetchPendingCommands(
+  deviceId: string,
+  apiKey: string,
+): Promise<PendingCommand[]> {
+  const res = await fetch(`${apiBaseUrl}/devices/pending`, {
+    headers: deviceAuthHeaders(deviceId, apiKey),
+  })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw asApiError(body.detail || `Failed to fetch pending commands (${res.status})`, res.status)
+  }
+  return res.json()
+}
+
+export async function ackCommand(
+  deviceId: string,
+  apiKey: string,
+  commandId: string,
+): Promise<void> {
+  const res = await fetch(`${apiBaseUrl}/devices/${deviceId}/commands/${commandId}/ack`, {
+    method: 'POST',
+    headers: deviceAuthHeaders(deviceId, apiKey),
+  })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw asApiError(body.detail || `Failed to acknowledge command (${res.status})`, res.status)
+  }
+}
+
+export async function updateCommandStatus(
+  deviceId: string,
+  apiKey: string,
+  commandId: string,
+  status: string,
+  result: PermissionRequestResult,
+): Promise<void> {
+  const res = await fetch(`${apiBaseUrl}/devices/${commandId}/status`, {
+    method: 'PUT',
+    headers: { ...deviceAuthHeaders(deviceId, apiKey), 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status, result }),
+  })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw asApiError(body.detail || `Failed to update command status (${res.status})`, res.status)
+  }
+}
+
+export async function reportPermissionAudit(
+  deviceId: string,
+  apiKey: string,
+  payload: {
+    permission: string
+    granted: boolean
+    requestedBy: string
+    action: string
+  },
+): Promise<void> {
+  const verb = payload.granted ? 'granted' : 'denied'
+  const res = await fetch(`${apiBaseUrl}/agent/audit`, {
+    method: 'POST',
+    headers: { ...deviceAuthHeaders(deviceId, apiKey), 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      device_id: deviceId,
+      event_type: 'permission_change',
+      description: `Permission '${payload.permission}' ${verb} (${payload.action}) by ${payload.requestedBy}`,
+      timestamp: new Date().toISOString(),
+    }),
+  })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw asApiError(body.detail || `Failed to report audit event (${res.status})`, res.status)
   }
 }

--- a/user_app/src/test/api.test.ts
+++ b/user_app/src/test/api.test.ts
@@ -8,6 +8,10 @@ import {
   bootstrapProvision,
   claimDevice,
   unpairDevice,
+  fetchPendingCommands,
+  ackCommand,
+  updateCommandStatus,
+  reportPermissionAudit,
 } from '../services/api'
 
 const mockFetch = vi.fn()
@@ -95,6 +99,92 @@ describe('fetchDeviceMetrics', () => {
   it('throws on error', async () => {
     mockFetch.mockResolvedValueOnce(serverError('Server error'))
     await expect(fetchDeviceMetrics(DEVICE_ID, API_KEY)).rejects.toThrow('Server error')
+  })
+})
+
+describe('fetchPendingCommands', () => {
+  it('returns pending commands array directly', async () => {
+    const commands = [{ command_id: 'c1', command_type: 'request_permission', payload: null, status: 'pending', created_at: '2026-08-03T10:00:00.000Z' }]
+    mockFetch.mockResolvedValueOnce(ok(commands))
+    const result = await fetchPendingCommands(DEVICE_ID, API_KEY)
+    expect(result).toHaveLength(1)
+    expect(result[0].command_type).toBe('request_permission')
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/devices/pending'),
+      expect.objectContaining({
+        headers: { 'X-Device-ID': DEVICE_ID, 'X-API-Key': API_KEY },
+      }),
+    )
+  })
+
+  it('throws on error', async () => {
+    mockFetch.mockResolvedValueOnce(serverError('Server error'))
+    await expect(fetchPendingCommands(DEVICE_ID, API_KEY)).rejects.toThrow('Server error')
+  })
+})
+
+describe('ackCommand', () => {
+  it('POSTs to the ack endpoint', async () => {
+    mockFetch.mockResolvedValueOnce(ok({}))
+    await ackCommand(DEVICE_ID, API_KEY, 'c1')
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining(`/devices/${DEVICE_ID}/commands/c1/ack`),
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+
+  it('throws on error', async () => {
+    mockFetch.mockResolvedValueOnce(serverError('Server error'))
+    await expect(ackCommand(DEVICE_ID, API_KEY, 'c1')).rejects.toThrow('Server error')
+  })
+})
+
+describe('updateCommandStatus', () => {
+  it('PUTs status and result', async () => {
+    mockFetch.mockResolvedValueOnce(ok({}))
+    const result = { permission: 'root_access', action: 'grant', granted: true, message: 'ok' }
+    await updateCommandStatus(DEVICE_ID, API_KEY, 'c1', 'completed', result)
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/devices/c1/status'),
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ status: 'completed', result }),
+      }),
+    )
+  })
+
+  it('throws on error', async () => {
+    mockFetch.mockResolvedValueOnce(serverError('Server error'))
+    await expect(updateCommandStatus(DEVICE_ID, API_KEY, 'c1', 'completed', { permission: 'root_access', action: 'grant', granted: true, message: 'ok' })).rejects.toThrow('Server error')
+  })
+})
+
+describe('reportPermissionAudit', () => {
+  it('POSTs a permission_change audit event', async () => {
+    mockFetch.mockResolvedValueOnce(ok({}))
+    await reportPermissionAudit(DEVICE_ID, API_KEY, {
+      permission: 'root_access',
+      granted: true,
+      requestedBy: 'admin@example.com',
+      action: 'grant',
+    })
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/agent/audit'),
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
+      }),
+    )
+    const call = mockFetch.mock.calls.find(([, init]) => init?.method === 'POST')
+    const body = JSON.parse(String(call![1].body))
+    expect(body.event_type).toBe('permission_change')
+    expect(body.device_id).toBe(DEVICE_ID)
+    expect(body.description).toContain("Permission 'root_access' granted")
+  })
+
+  it('throws on error', async () => {
+    mockFetch.mockResolvedValueOnce(serverError('Server error'))
+    await expect(reportPermissionAudit(DEVICE_ID, API_KEY, { permission: 'root_access', granted: true, requestedBy: 'admin', action: 'grant' })).rejects.toThrow('Server error')
   })
 })
 

--- a/user_app/src/test/integration.test.tsx
+++ b/user_app/src/test/integration.test.tsx
@@ -25,28 +25,31 @@ describe('App routing', () => {
   it('redirects provisioned user from / to dashboard', async () => {
     localStorage.setItem('homepot_device_id', 'pos-001')
     sessionStorage.setItem('homepot_api_key', 'test-key')
-    mockFetch.mockResolvedValueOnce(
-      ok({
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/pending')) {
+        return ok([])
+      }
+      if (url.includes('/metrics')) {
+        return ok({
+          data: {
+            cpu_percent: 10,
+            memory_percent: 20,
+            disk_percent: 30,
+            network_latency_ms: 5,
+            uptime_seconds: 3600,
+            timestamp: new Date().toISOString(),
+          },
+        })
+      }
+      return ok({
         data: {
           lifecycle_state: 'active',
           connectivity_state: 'online',
           health_state: 'good',
           last_heartbeat_at: new Date().toISOString(),
         },
-      }),
-    )
-    mockFetch.mockResolvedValueOnce(
-      ok({
-        data: {
-          cpu_percent: 10,
-          memory_percent: 20,
-          disk_percent: 30,
-          network_latency_ms: 5,
-          uptime_seconds: 3600,
-          timestamp: new Date().toISOString(),
-        },
-      }),
-    )
+      })
+    })
     render(<App />)
     expect(await screen.findByText('SECURE — ONLINE')).toBeInTheDocument()
   })
@@ -54,8 +57,11 @@ describe('App routing', () => {
   it('shows device info view at /settings', async () => {
     localStorage.setItem('homepot_device_id', 'pos-001')
     sessionStorage.setItem('homepot_api_key', 'test-key')
-    mockFetch.mockResolvedValueOnce(
-      ok({
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/pending')) {
+        return ok([])
+      }
+      return ok({
         device_id: 'pos-001',
         name: 'Test POS',
         site_id: 'site-alpha',
@@ -67,8 +73,8 @@ describe('App routing', () => {
         firmware_version: '2.0.0',
         lifecycle_state: 'active',
         connectivity_state: 'online',
-      }),
-    )
+      })
+    })
     window.history.pushState({}, '', '/settings')
     render(<App />)
     await waitFor(() => {

--- a/user_app/src/test/permissionConsent.test.tsx
+++ b/user_app/src/test/permissionConsent.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import PermissionConsentPrompt from '../components/PermissionConsentPrompt'
+
+const mockFetch = vi.fn()
+globalThis.fetch = mockFetch
+
+vi.mock('../services/credentialStorage', () => ({
+  credentialStorage: {
+    getDeviceId: vi.fn().mockResolvedValue('test-device'),
+    getApiKey: vi.fn().mockResolvedValue('test-key'),
+  },
+}))
+
+function ok(body: unknown) {
+  return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }))
+}
+
+const pendingCommand = {
+  command_id: 'cmd-1',
+  command_type: 'request_permission',
+  payload: {
+    data: { permission: 'root_access', action: 'grant', requested_by: 'admin@example.com' },
+  },
+  status: 'pending',
+  created_at: '2026-08-03T10:00:00.000Z',
+}
+
+describe('PermissionConsentPrompt', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+
+  it('shows a prompt when a request_permission command is pending', async () => {
+    mockFetch
+      .mockResolvedValueOnce(ok([pendingCommand])) // GET /pending
+      .mockResolvedValueOnce(ok({})) // ack
+    render(<PermissionConsentPrompt />)
+    expect(await screen.findByText('Permission request')).toBeInTheDocument()
+    expect(screen.getByText(/admin@example\.com/)).toBeInTheDocument()
+    expect(screen.getByText(/Root \/ Full Access/)).toBeInTheDocument()
+    expect(screen.getByText('Allow')).toBeInTheDocument()
+    expect(screen.getByText('Deny')).toBeInTheDocument()
+  })
+
+  it('does not render when no request_permission command is pending', async () => {
+    mockFetch
+      .mockResolvedValueOnce(ok([])) // GET /pending
+    render(<PermissionConsentPrompt />)
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled()
+    })
+    expect(screen.queryByText('Permission request')).not.toBeInTheDocument()
+  })
+
+  it('grants the permission on accept', async () => {
+    mockFetch
+      .mockResolvedValueOnce(ok([pendingCommand])) // GET /pending
+      .mockResolvedValueOnce(ok({})) // ack
+      .mockResolvedValueOnce(ok({})) // PATCH permissions
+      .mockResolvedValueOnce(ok({})) // audit
+      .mockResolvedValueOnce(ok({})) // PUT status
+    render(<PermissionConsentPrompt />)
+    fireEvent.click(await screen.findByText('Allow'))
+
+    await waitFor(() => {
+      const patch = mockFetch.mock.calls.find(([, init]) => init?.method === 'PATCH')
+      expect(patch).toBeTruthy()
+      expect(JSON.parse(String(patch![1].body))).toEqual({ permissions: { root_access: true } })
+    })
+    await waitFor(() => {
+      const put = mockFetch.mock.calls.find(([, init]) => init?.method === 'PUT')
+      expect(put).toBeTruthy()
+      const body = JSON.parse(String(put![1].body))
+      expect(body.status).toBe('completed')
+      expect(body.result).toEqual({
+        permission: 'root_access',
+        action: 'grant',
+        granted: true,
+        message: "Permission 'root_access' granted by device owner",
+      })
+    })
+    await waitFor(() => {
+      expect(screen.queryByText('Permission request')).not.toBeInTheDocument()
+    })
+  })
+
+  it('denies the permission on deny', async () => {
+    mockFetch
+      .mockResolvedValueOnce(ok([pendingCommand])) // GET /pending
+      .mockResolvedValueOnce(ok({})) // ack
+      .mockResolvedValueOnce(ok({})) // PATCH permissions
+      .mockResolvedValueOnce(ok({})) // audit
+      .mockResolvedValueOnce(ok({})) // PUT status
+    render(<PermissionConsentPrompt />)
+    fireEvent.click(await screen.findByText('Deny'))
+
+    await waitFor(() => {
+      const patch = mockFetch.mock.calls.find(([, init]) => init?.method === 'PATCH')
+      expect(patch).toBeTruthy()
+      expect(JSON.parse(String(patch![1].body))).toEqual({ permissions: { root_access: false } })
+    })
+    await waitFor(() => {
+      const put = mockFetch.mock.calls.find(([, init]) => init?.method === 'PUT')
+      const body = JSON.parse(String(put![1].body))
+      expect(body.result.granted).toBe(false)
+    })
+  })
+
+  it('shows a revoke prompt for revoke actions', async () => {
+    const revokeCommand = {
+      ...pendingCommand,
+      payload: {
+        data: { permission: 'process_monitoring', action: 'revoke', requested_by: 'admin@example.com' },
+      },
+    }
+    mockFetch
+      .mockResolvedValueOnce(ok([revokeCommand])) // GET /pending
+      .mockResolvedValueOnce(ok({})) // ack
+    render(<PermissionConsentPrompt />)
+    expect(await screen.findByText('Revoke access requested')).toBeInTheDocument()
+    expect(screen.getByText('Approve revocation')).toBeInTheDocument()
+  })
+})

--- a/user_app/src/test/views.test.tsx
+++ b/user_app/src/test/views.test.tsx
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { AppProvider } from '../context/AppContext'
 import HomeDashboard from '../views/HomeDashboard'
 import DeviceInfo from '../views/DeviceInfo'
+import Permissions from '../views/Permissions'
 
 const mockFetch = vi.fn()
 globalThis.fetch = mockFetch
@@ -177,5 +178,57 @@ describe('DeviceInfo', () => {
     renderWithProviders(<DeviceInfo />)
     expect(await screen.findByText('HOMEPOT Agent')).toBeInTheDocument()
     expect(await screen.findByText(/Disconnect.*Unpair/)).toBeInTheDocument()
+  })
+})
+
+describe('Permissions', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('shows override notice when server permissions change externally', async () => {
+    mockFetch.mockImplementation(() =>
+      ok({
+        data: {
+          permissions: { root_access: true },
+          capabilities: { root_access: true },
+        },
+      }),
+    )
+    renderWithProviders(<Permissions />)
+    await vi.advanceTimersByTimeAsync(100) // creds-ready interval fires initial load
+    expect(await screen.findByText('Permissions & Access Control')).toBeInTheDocument()
+
+    mockFetch.mockImplementation(() =>
+      ok({
+        data: {
+          permissions: { root_access: false },
+          capabilities: { root_access: true },
+        },
+      }),
+    )
+    await vi.advanceTimersByTimeAsync(15000) // background refresh detects change
+    expect(await screen.findByText(/operator or administrator has updated/)).toBeInTheDocument()
+  })
+
+  it('does not show override notice when permissions are unchanged', async () => {
+    mockFetch.mockImplementation(() =>
+      ok({
+        data: {
+          permissions: { root_access: true },
+          capabilities: { root_access: true },
+        },
+      }),
+    )
+    renderWithProviders(<Permissions />)
+    await vi.advanceTimersByTimeAsync(100)
+    expect(await screen.findByText('Permissions & Access Control')).toBeInTheDocument()
+    await vi.advanceTimersByTimeAsync(15000)
+    expect(screen.queryByText(/operator or administrator has updated/)).not.toBeInTheDocument()
   })
 })

--- a/user_app/src/views/Permissions.tsx
+++ b/user_app/src/views/Permissions.tsx
@@ -43,6 +43,7 @@ export default function Permissions() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [savingKeys, setSavingKeys] = useState<Set<string>>(new Set())
+  const [overrideNotice, setOverrideNotice] = useState(false)
 
   const deviceIdRef = useRef<string | null>(null)
   const apiKeyRef = useRef<string | null>(null)
@@ -59,13 +60,15 @@ export default function Permissions() {
     })
   }, [])
 
-  const fetchPermissions = useCallback(async () => {
+  const fetchPermissions = useCallback(async (silent = false) => {
     const dId = deviceIdRef.current
     const aKey = apiKeyRef.current
     if (!dId || !aKey) return
 
-    setLoading(true)
-    setError('')
+    if (!silent) {
+      setLoading(true)
+      setError('')
+    }
     try {
       const data = await fetchPermissionsApi(dId, aKey)
       const perms: Record<string, boolean> = data.permissions || {}
@@ -76,26 +79,42 @@ export default function Permissions() {
         enabled: perms[def.key] ?? false,
         supported: caps[def.key] ?? false,
       }))
+
+      if (silent) {
+        const current = latestPermissionsRef.current
+        const changedExternally =
+          current.length > 0 &&
+          entries.some((entry, index) => {
+            const prev = current[index]
+            return prev && prev.enabled !== entry.enabled
+          })
+        if (changedExternally) setOverrideNotice(true)
+      }
+
       setPermissions(entries)
       latestPermissionsRef.current = entries
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load permissions')
+      if (!silent) {
+        setError(err instanceof Error ? err.message : 'Failed to load permissions')
+      }
     } finally {
-      setLoading(false)
+      if (!silent) setLoading(false)
     }
   }, [])
 
   useEffect(() => {
-    if (deviceIdRef.current && apiKeyRef.current) {
-      fetchPermissions()
-    } else {
-      const interval = setInterval(() => {
-        if (deviceIdRef.current && apiKeyRef.current) {
-          clearInterval(interval)
-          fetchPermissions()
-        }
-      }, 100)
-      return () => clearInterval(interval)
+    const credsReady = setInterval(() => {
+      if (deviceIdRef.current && apiKeyRef.current) {
+        clearInterval(credsReady)
+        fetchPermissions()
+      }
+    }, 100)
+    const refresh = setInterval(() => {
+      fetchPermissions(true)
+    }, 15000)
+    return () => {
+      clearInterval(credsReady)
+      clearInterval(refresh)
     }
   }, [fetchPermissions])
 
@@ -125,6 +144,7 @@ export default function Permissions() {
   }, [])
 
   function handleToggle(key: string) {
+    setOverrideNotice(false)
     setPermissions(prev => {
       const next = prev.map(p => (p.key === key ? { ...p, enabled: !p.enabled } : p))
       latestPermissionsRef.current = next
@@ -182,6 +202,19 @@ export default function Permissions() {
             Control what the Admin Dashboard can access on this device.
           </p>
         </div>
+
+        {/* Operator/admin override notice */}
+        {overrideNotice && (
+          <div className="px-5 pt-3">
+            <div className="bg-amber-950 border border-amber-800 rounded-lg px-4 py-2.5 flex items-start gap-2">
+              <span className="text-amber-400 text-sm shrink-0">⚠</span>
+              <p className="text-xs text-amber-300">
+                An operator or administrator has updated this device's permissions. Review
+                and adjust if needed.
+              </p>
+            </div>
+          </div>
+        )}
 
         {/* Error banner */}
         {error && (


### PR DESCRIPTION
## Summary

Add the device-owner consent prompt for operator `request_permission` push commands, mirroring the emulator flow from #254. The User App now acts as the consent UI: it polls pending commands, shows an accept/deny prompt, and reports the decision back through the command lifecycle.

### Consent prompt (`PermissionConsentPrompt.tsx`, wired globally in `App.tsx`)
- Polls `GET /devices/pending` every 10s (device-credential auth).
- When a `request_permission` command is found, ACKs it and shows a modal: operator, permission name, action (grant vs revoke).
- On **Allow**: PATCHes the permission grant, posts a `permission_change` audit event (`POST /agent/audit`), and completes the command via `PUT /devices/{id}/status` with `{granted: true, ...}`.
- On **Deny**: same sequence with `granted: false`. Revoke requests invert the copy and buttons (Approve revocation / Deny).
- Handles error (keeps prompt open), busy state, and de-dupes already-handled command IDs.

### Admin-override awareness (`Permissions.tsx`)
- Permissions view now refreshes silently every 15s; when the server values change without a local toggle (operator/admin override or consent result), it shows an amber notice. Notice clears when the user toggles.

### Services (`api.ts`)
- `fetchPendingCommands`, `ackCommand`, `updateCommandStatus`, `reportPermissionAudit` + `PendingCommand`/`PermissionRequestResult` types.

### Tests
- `permissionConsent.test.tsx`: prompt render, no-op when empty, allow→grant PATCH/status, deny→deny PATCH/status, revoke copy.
- `api.test.ts`: 4 new service suites.
- `views.test.tsx`: override-notice detection (fake timers) + no-notice-when-unchanged.
- Integration tests switched to URL-based fetch mocks (global prompt now also calls `/pending`).
- 57/57 vitest green; tsc clean; no new eslint issues (6 pre-existing unchanged); vite build passes.

No backend changes required — the command/permission/audit endpoints already exist and are device-auth.