### PR TITLE
feat: verify stored device credentials on start and re-enrol on rejection

### DIFF
--- a/user_app/src/context/AppContext.tsx
+++ b/user_app/src/context/AppContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
 import { credentialStorage } from '../services/credentialStorage'
+import { verifyDeviceCredentials } from '../services/api'
 
 interface DeviceInfo {
   deviceId: string
@@ -52,17 +53,27 @@ export function AppProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     let mounted = true
-    credentialStorage
-      .isProvisioned()
-      .then((provisioned) => {
-        if (mounted) {
-          setIsProvisioned(provisioned)
-          setProvisionedChecked(true)
+    async function checkProvisioned(): Promise<void> {
+      const provisioned = await credentialStorage.isProvisioned().catch(() => false)
+      let valid = provisioned
+      if (provisioned) {
+        const [deviceId, apiKey] = await Promise.all([
+          credentialStorage.getDeviceId(),
+          credentialStorage.getApiKey(),
+        ])
+        if (deviceId && apiKey) {
+          valid = await verifyDeviceCredentials(deviceId, apiKey)
+          if (!valid) {
+            await credentialStorage.clear().catch(() => {})
+          }
         }
-      })
-      .catch(() => {
-        if (mounted) setProvisionedChecked(true)
-      })
+      }
+      if (mounted) {
+        setIsProvisioned(valid)
+        setProvisionedChecked(true)
+      }
+    }
+    void checkProvisioned()
     return () => {
       mounted = false
     }

--- a/user_app/src/services/api.ts
+++ b/user_app/src/services/api.ts
@@ -134,6 +134,16 @@ export async function fetchPermissions(deviceId: string, apiKey: string): Promis
   return json.data as PermissionsResponse
 }
 
+export async function verifyDeviceCredentials(deviceId: string, apiKey: string): Promise<boolean> {
+  try {
+    await fetchPermissions(deviceId, apiKey)
+    return true
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 401) return false
+    return true
+  }
+}
+
 export async function updatePermissions(
   deviceId: string,
   apiKey: string,

--- a/user_app/src/test/api.test.ts
+++ b/user_app/src/test/api.test.ts
@@ -5,6 +5,7 @@ import {
   fetchDeviceMetrics,
   fetchPermissions,
   updatePermissions,
+  verifyDeviceCredentials,
   bootstrapProvision,
   claimDevice,
   unpairDevice,
@@ -280,5 +281,40 @@ describe('unpairDevice', () => {
   it('throws on 500', async () => {
     mockFetch.mockResolvedValueOnce(serverError('Server error'))
     await expect(unpairDevice(DEVICE_ID, API_KEY)).rejects.toThrow('Server error')
+  })
+})
+
+describe('verifyDeviceCredentials', () => {
+  it('returns true when credentials are accepted', async () => {
+    mockFetch.mockResolvedValueOnce(
+      ok({ data: { permissions: { root_access: true }, capabilities: { root_access: true } } }),
+    )
+    await expect(verifyDeviceCredentials(DEVICE_ID, API_KEY)).resolves.toBe(true)
+  })
+
+  it('returns false on 401 (invalid device ID)', async () => {
+    mockFetch.mockResolvedValueOnce(
+      Promise.resolve(new Response(JSON.stringify({ detail: 'Invalid Device ID' }), { status: 401 })),
+    )
+    await expect(verifyDeviceCredentials(DEVICE_ID, API_KEY)).resolves.toBe(false)
+  })
+
+  it('returns false on 401 (invalid API key)', async () => {
+    mockFetch.mockResolvedValueOnce(
+      Promise.resolve(new Response(JSON.stringify({ detail: 'Invalid API Key' }), { status: 401 })),
+    )
+    await expect(verifyDeviceCredentials(DEVICE_ID, API_KEY)).resolves.toBe(false)
+  })
+
+  it('returns true on 403 (suspended device, creds still valid)', async () => {
+    mockFetch.mockResolvedValueOnce(
+      Promise.resolve(new Response(JSON.stringify({ detail: "device is in lifecycle state 'suspended'" }), { status: 403 })),
+    )
+    await expect(verifyDeviceCredentials(DEVICE_ID, API_KEY)).resolves.toBe(true)
+  })
+
+  it('returns true on network error (do not clear creds offline)', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network error'))
+    await expect(verifyDeviceCredentials(DEVICE_ID, API_KEY)).resolves.toBe(true)
   })
 })

--- a/user_app/src/test/integration.test.tsx
+++ b/user_app/src/test/integration.test.tsx
@@ -54,6 +54,64 @@ describe('App routing', () => {
     expect(await screen.findByText('SECURE — ONLINE')).toBeInTheDocument()
   })
 
+  it('clears invalid credentials and redirects to setup wizard', async () => {
+    localStorage.setItem('homepot_device_id', 'pos-001')
+    sessionStorage.setItem('homepot_api_key', 'stale-key')
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/permissions')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ detail: 'Invalid Device ID' }), { status: 401 }),
+        )
+      }
+      return ok([])
+    })
+    render(<App />)
+    expect(await screen.findByText('Step 1 of 4')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(localStorage.getItem('homepot_device_id')).toBeNull()
+    })
+    expect(sessionStorage.getItem('homepot_api_key')).toBeNull()
+  })
+
+  it('keeps credentials when backend is unreachable', async () => {
+    localStorage.setItem('homepot_device_id', 'pos-001')
+    sessionStorage.setItem('homepot_api_key', 'test-key')
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/permissions')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ detail: 'Server error' }), { status: 500 }),
+        )
+      }
+      if (url.includes('/pending')) {
+        return ok([])
+      }
+      if (url.includes('/metrics')) {
+        return ok({
+          data: {
+            cpu_percent: 10,
+            memory_percent: 20,
+            disk_percent: 30,
+            network_latency_ms: 5,
+            uptime_seconds: 3600,
+            timestamp: new Date().toISOString(),
+          },
+        })
+      }
+      return ok({
+        data: {
+          lifecycle_state: 'active',
+          connectivity_state: 'online',
+          health_state: 'good',
+          last_heartbeat_at: new Date().toISOString(),
+        },
+      })
+    })
+    render(<App />)
+    expect(await screen.findByText('SECURE — ONLINE')).toBeInTheDocument()
+    expect(localStorage.getItem('homepot_device_id')).toBe('pos-001')
+    expect(sessionStorage.getItem('homepot_api_key')).toBe('test-key')
+  })
+
   it('shows device info view at /settings', async () => {
     localStorage.setItem('homepot_device_id', 'pos-001')
     sessionStorage.setItem('homepot_api_key', 'test-key')

--- a/user_app/src/test/views.test.tsx
+++ b/user_app/src/test/views.test.tsx
@@ -62,8 +62,23 @@ describe('HomeDashboard', () => {
     })
   }
 
+  function routeDeviceApi(status: Promise<Response>, metrics: Promise<Response> = metricsOk(), failStatus = false) {
+    mockFetch.mockImplementation((url: string) => {
+      if (String(url).includes('/permissions')) {
+        return ok({ data: { permissions: {}, capabilities: {} } })
+      }
+      if (String(url).includes('/metrics')) {
+        return metrics
+      }
+      if (String(url).includes('/status')) {
+        return failStatus ? Promise.reject(new Error('Network error')) : status
+      }
+      return ok({ data: [] })
+    })
+  }
+
   it('renders header and gauges', async () => {
-    mockFetch.mockResolvedValueOnce(statusOk()).mockResolvedValueOnce(metricsOk())
+    routeDeviceApi(statusOk())
     renderWithProviders(<HomeDashboard />)
     expect(await screen.findByText('HOMEPOT Agent')).toBeInTheDocument()
     expect(await screen.findByText('SECURE — ONLINE')).toBeInTheDocument()
@@ -73,7 +88,7 @@ describe('HomeDashboard', () => {
   })
 
   it('renders live metrics from backend', async () => {
-    mockFetch.mockResolvedValueOnce(statusOk()).mockResolvedValueOnce(metricsOk())
+    routeDeviceApi(statusOk())
     renderWithProviders(<HomeDashboard />)
     expect(await screen.findByText('42%')).toBeInTheDocument()
     expect(await screen.findByText('61%')).toBeInTheDocument()
@@ -83,7 +98,7 @@ describe('HomeDashboard', () => {
   })
 
   it('renders backend heartbeat timestamp', async () => {
-    mockFetch.mockResolvedValueOnce(statusOk()).mockResolvedValueOnce(metricsOk())
+    routeDeviceApi(statusOk())
     renderWithProviders(<HomeDashboard />)
     expect(await screen.findByText('SECURE — ONLINE')).toBeInTheDocument()
     const expected = new Date('2026-08-03T12:34:56.000Z').toLocaleTimeString('en-GB', {
@@ -95,19 +110,19 @@ describe('HomeDashboard', () => {
   })
 
   it('shows offline state when backend returns offline', async () => {
-    mockFetch.mockResolvedValueOnce(statusOk({ connectivity_state: 'offline', last_heartbeat_at: null })).mockResolvedValueOnce(metricsOk())
+    routeDeviceApi(statusOk({ connectivity_state: 'offline', last_heartbeat_at: null }))
     renderWithProviders(<HomeDashboard />)
     expect(await screen.findByText('OFFLINE')).toBeInTheDocument()
   })
 
   it('shows suspended banner when lifecycle is suspended', async () => {
-    mockFetch.mockResolvedValueOnce(statusOk({ lifecycle_state: 'suspended', connectivity_state: 'offline', last_heartbeat_at: null })).mockResolvedValueOnce(metricsOk())
+    routeDeviceApi(statusOk({ lifecycle_state: 'suspended', connectivity_state: 'offline', last_heartbeat_at: null }))
     renderWithProviders(<HomeDashboard />)
     expect(await screen.findByText('DEVICE SUSPENDED')).toBeInTheDocument()
   })
 
   it('renders TabBar with navigation links', async () => {
-    mockFetch.mockResolvedValueOnce(statusOk()).mockResolvedValueOnce(metricsOk())
+    routeDeviceApi(statusOk())
     renderWithProviders(<HomeDashboard />)
     expect(await screen.findByText('Home')).toBeInTheDocument()
     expect(screen.getByText('Perms')).toBeInTheDocument()
@@ -115,7 +130,7 @@ describe('HomeDashboard', () => {
   })
 
   it('shows unknown state when fetch fails', async () => {
-    mockFetch.mockRejectedValueOnce(new Error('Network error'))
+    routeDeviceApi(statusOk(), metricsOk(), true)
     renderWithProviders(<HomeDashboard />)
     expect(await screen.findByText('HOMEPOT Agent')).toBeInTheDocument()
     expect(await screen.findByText('OFFLINE')).toBeInTheDocument()
@@ -127,22 +142,30 @@ describe('DeviceInfo', () => {
     mockFetch.mockReset()
   })
 
+  function routeDeviceApi(device: unknown, deviceFails = false) {
+    mockFetch.mockImplementation((url: string) => {
+      if (String(url).includes('/permissions')) {
+        return ok({ data: { permissions: {}, capabilities: {} } })
+      }
+      if (deviceFails) return Promise.reject(new Error('Network error'))
+      return ok(device)
+    })
+  }
+
   it('renders DNA table with backend data', async () => {
-    mockFetch.mockResolvedValueOnce(
-      ok({
-        device_id: 'test-device',
-        name: 'Backend Device',
-        site_id: 'site-001',
-        device_type: 'pos_terminal',
-        mac_address: '00:11:22:33:44:55',
-        local_ip: '192.168.1.100',
-        wan_ip: '203.0.113.10',
-        os_details: 'linux',
-        firmware_version: '1.0.0',
-        lifecycle_state: 'active',
-        connectivity_state: 'online',
-      }),
-    )
+    routeDeviceApi({
+      device_id: 'test-device',
+      name: 'Backend Device',
+      site_id: 'site-001',
+      device_type: 'pos_terminal',
+      mac_address: '00:11:22:33:44:55',
+      local_ip: '192.168.1.100',
+      wan_ip: '203.0.113.10',
+      os_details: 'linux',
+      firmware_version: '1.0.0',
+      lifecycle_state: 'active',
+      connectivity_state: 'online',
+    })
     renderWithProviders(<DeviceInfo />)
     expect(await screen.findByText('HOMEPOT Agent')).toBeInTheDocument()
     expect(await screen.findByText('Backend Device')).toBeInTheDocument()
@@ -157,7 +180,7 @@ describe('DeviceInfo', () => {
   it('renders fallback values when backend fetch fails', async () => {
     const credStorageModule = await import('../services/credentialStorage')
     vi.mocked(credStorageModule.credentialStorage.getMetadata).mockResolvedValue(null)
-    mockFetch.mockRejectedValueOnce(new Error('Network error'))
+    routeDeviceApi(null, true)
     renderWithProviders(<DeviceInfo />)
     expect(await screen.findByText('HOMEPOT Agent')).toBeInTheDocument()
     expect(await screen.findByText('My-Device')).toBeInTheDocument()
@@ -166,15 +189,13 @@ describe('DeviceInfo', () => {
   })
 
   it('renders unpair button', async () => {
-    mockFetch.mockResolvedValueOnce(
-      ok({
-        device_id: 'test-device',
-        name: 'Test Device',
-        device_type: 'pos_terminal',
-        os_details: 'linux',
-        lifecycle_state: 'active',
-      }),
-    )
+    routeDeviceApi({
+      device_id: 'test-device',
+      name: 'Test Device',
+      device_type: 'pos_terminal',
+      os_details: 'linux',
+      lifecycle_state: 'active',
+    })
     renderWithProviders(<DeviceInfo />)
     expect(await screen.findByText('HOMEPOT Agent')).toBeInTheDocument()
     expect(await screen.findByText(/Disconnect.*Unpair/)).toBeInTheDocument()


### PR DESCRIPTION
## Summary
Fixes the stale-credential dead-end where the User App stays on /home showing the dashboard as online (status endpoint is unauthenticated) while every device-auth call fails with 401 `Invalid Device ID` after a backend DB reset/recreate.

## Changes
- `api.ts`: new `verifyDeviceCredentials()` — returns `false` only on HTTP 401 (invalid device ID / API key); non-401 failures (403 suspended, network errors) return `true` so offline/suspended devices are never force-re-enrolled.
- `AppContext.tsx`: on startup, after `isProvisioned()` returns true, verifies the stored `deviceId`+`apiKey` against the backend; on rejection it `clear()`s credentials and marks the app unprovisioned so `RootRedirect` sends the user to the Setup Wizard. Verification is skipped when the session-only API key is absent (transient, not a stale credential).
- Tests: `verifyDeviceCredentials` unit coverage (200/401-ID/401-key/403/network), integration test proving 401 → creds cleared + Setup Wizard shown, integration test proving a 500/network does **not** clear creds, and `views.test.tsx` refactored to URL-routed mocks so the new startup verify call is deterministic.

## Verification
- vitest: 64/64 pass
- tsc -b: clean
- eslint: 6 pre-existing issues (unchanged)
- vite build: clean