### PR TITLE
feat: android_pos emulator script

### DIFF
--- a/docs/device-emulators.md
+++ b/docs/device-emulators.md
@@ -28,14 +28,14 @@ The Dashboard immediately shows the emulated device with its mock DNA, online st
 | Emulator | File | OS | Device type |
 |----------|------|----|-------------|
 | Linux POS | `emulators/linux_pos_emulator.py` | Linux | `pos_terminal` |
-| Android POS | — | Android | `pos_terminal` |
+| Android POS | `emulators/android_pos_emulator.py` | Android | `pos_terminal` |
 | Windows POS | — | Windows | `pos_terminal` |
 | macOS POS | — | macOS | `pos_terminal` |
 | iOS | — | iOS | `tablet` |
 | Web Browser | — | Web | `virtual_terminal` |
 | MQTT Sensor | — | Linux | `mobile_scanner` |
 
-Only **Linux POS** is implemented. Each future emulator targets a specific OS and may include OS-specific behaviours (e.g. WNS push on Windows, FCM on Android).
+**Linux POS** and **Android POS** are implemented. Android reuses the parameterized engine from `linux_pos_emulator.py` with Android identity defaults (`Android 14`, mock MAC `02:42:ac:11:00:03`, hostname `android-pos-001`); its OS capability map is derived from the OS string (no root access, but process/filesystem/network monitoring). Each future emulator targets a specific OS and may include OS-specific behaviours (e.g. WNS push on Windows, FCM on Android).
 
 ## How an emulator works
 
@@ -213,7 +213,23 @@ Example:
 
 ## Creating a new emulator
 
-Each emulator is a standalone runnable script. The simplest approach is to copy `linux_pos_emulator.py` and adjust:
+Each emulator is a standalone runnable script. The quickest way to add a new OS is to create a thin script that imports the parameterized engine from `linux_pos_emulator.py` and overrides the identity defaults, exactly like `android_pos_emulator.py`:
+
+```python
+from linux_pos_emulator import LinuxPOSEmulator, main
+
+WINDOWS_DEFAULTS = {
+    "device_name": "windows-pos-emulator-1",
+    "os_details": "Windows 11",
+    "mock_mac": "02:42:ac:11:00:04",
+    "mock_hostname": "windows-pos-001",
+}
+
+if __name__ == "__main__":
+    main(defaults=WINDOWS_DEFAULTS, banner="HOMEPOT Windows POS Emulator")
+```
+
+For OS-specific behaviour beyond identity, copy `linux_pos_emulator.py` and adjust:
 
 1. **Config defaults** — Change the OS details, device type, mock MAC/IP/hostname defaults.
 2. **Simulated metrics** — Override `SimulatedMetrics` for OS-specific metrics (e.g. Android battery level, iOS thermal state).
@@ -228,7 +244,7 @@ emulators/
 ├── __init__.py
 ├── linux_pos_emulator.py       # Linux POS (implemented)
 ├── linux_pos_emulator.json      # Linux POS config example
-├── android_pos_emulator.py      # Android POS (future)
+├── android_pos_emulator.py      # Android POS (implemented; reuses linux engine)
 ├── android_pos_emulator.json    # Android POS config example
 ├── windows_pos_emulator.py      # Windows POS (future)
 └── ...

--- a/emulators/android_pos_emulator.json
+++ b/emulators/android_pos_emulator.json
@@ -1,0 +1,21 @@
+{
+  "backend_url": "http://localhost:8000",
+  "site_id": "site-1",
+  "bootstrap_key": "REPLACE_WITH_GENERATED_KEY",
+  "device_name": "android-pos-emulator-1",
+  "device_type": "pos_terminal",
+  "os_details": "Android 14",
+  "mock_mac": "02:42:ac:11:00:03",
+  "mock_ip": "192.168.1.100",
+  "mock_hostname": "android-pos-001",
+  "mock_firmware": "2.4.1",
+  "heartbeat_interval_seconds": 10,
+  "telemetry_interval_seconds": 15,
+  "command_poll_interval_seconds": 15,
+  "logs_interval_seconds": 15,
+  "audit_interval_seconds": 60,
+  "jobs_interval_seconds": 30,
+  "alerts_interval_seconds": 90,
+  "permission_consent_mode": "auto",
+  "permission_sync_interval_seconds": 20
+}

--- a/emulators/android_pos_emulator.py
+++ b/emulators/android_pos_emulator.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Android POS device emulator.
+
+Simulates an Android POS terminal device for end-to-end testing of the
+Dashboard, User App, and device lifecycle flows without physical hardware.
+
+Reuses the parameterized emulator engine from ``linux_pos_emulator.py`` with
+Android-specific device identity defaults (OS details, mock MAC/hostname).
+
+Usage
+-----
+    python emulators/android_pos_emulator.py --site-id site-it-demo1 --bootstrap-key abc123
+    python emulators/android_pos_emulator.py --config my-device.json
+
+When launched by the User App Electron shell, ``electron/main.ts`` writes the
+Android ``os_details``/``mock_mac`` into the temp config JSON, so the
+config-file path picks up the Android identity automatically.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from linux_pos_emulator import LinuxPOSEmulator, main
+
+ANDROID_DEFAULTS: dict[str, Any] = {
+    "device_name": "android-pos-emulator-1",
+    "os_details": "Android 14",
+    "mock_mac": "02:42:ac:11:00:03",
+    "mock_hostname": "android-pos-001",
+}
+
+
+def android_main(argv: list[str] | None = None) -> None:
+    main(
+        argv,
+        defaults=ANDROID_DEFAULTS,
+        emulator_class=LinuxPOSEmulator,
+        banner="HOMEPOT Android POS Emulator",
+    )
+
+
+if __name__ == "__main__":
+    android_main()

--- a/emulators/android_pos_emulator.py
+++ b/emulators/android_pos_emulator.py
@@ -23,7 +23,9 @@ from typing import Any
 
 try:
     from linux_pos_emulator import (  # type: ignore[import-not-found]
-        LinuxPOSEmulator, main)
+        LinuxPOSEmulator,
+        main,
+    )
 except ModuleNotFoundError:
     from .linux_pos_emulator import LinuxPOSEmulator, main
 

--- a/emulators/android_pos_emulator.py
+++ b/emulators/android_pos_emulator.py
@@ -22,7 +22,8 @@ from __future__ import annotations
 from typing import Any
 
 try:
-    from linux_pos_emulator import LinuxPOSEmulator, main  # type: ignore[import-not-found]
+    from linux_pos_emulator import (  # type: ignore[import-not-found]
+        LinuxPOSEmulator, main)
 except ModuleNotFoundError:
     from .linux_pos_emulator import LinuxPOSEmulator, main
 

--- a/emulators/android_pos_emulator.py
+++ b/emulators/android_pos_emulator.py
@@ -21,7 +21,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from linux_pos_emulator import LinuxPOSEmulator, main
+try:
+    from linux_pos_emulator import LinuxPOSEmulator, main  # type: ignore[import-not-found]
+except ModuleNotFoundError:
+    from .linux_pos_emulator import LinuxPOSEmulator, main
 
 ANDROID_DEFAULTS: dict[str, Any] = {
     "device_name": "android-pos-emulator-1",

--- a/emulators/linux_pos_emulator.py
+++ b/emulators/linux_pos_emulator.py
@@ -273,8 +273,13 @@ def save_credentials(device_name: str, data: dict) -> None:
 class LinuxPOSEmulator:
     """Runs a simulated Linux POS device lifecycle against the backend."""
 
-    def __init__(self, config: EmulatorConfig) -> None:
+    def __init__(
+        self,
+        config: EmulatorConfig,
+        banner: str = "HOMEPOT Linux POS Emulator",
+    ) -> None:
         self.config = config
+        self._banner = banner
         self._device_id: str | None = None
         self._api_key: str | None = None
         self._shutdown_event = asyncio.Event()
@@ -1205,7 +1210,7 @@ class LinuxPOSEmulator:
 
     async def start(self) -> None:
         print(f"\n{'=' * 60}")
-        print("  HOMEPOT Linux POS Emulator")
+        print(f"  {self._banner}")
         print(f"  Device:  {self.config.device_name}")
         print(f"  Backend: {self.config.backend_url}")
         print(
@@ -1261,8 +1266,11 @@ class LinuxPOSEmulator:
 # ---------------------------------------------------------------------------
 
 
-def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+def parse_args(
+    argv: list[str] | None = None, defaults: dict | None = None
+) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="HOMEPOT Linux POS Device Emulator")
+    d = defaults or {}
     parser.add_argument("--config", "-c", type=str, help="Path to JSON config file")
     parser.add_argument(
         "--backend-url", type=str, default=DEFAULT_BACKEND_URL, help="Backend URL"
@@ -1274,19 +1282,34 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--bootstrap-key", type=str, default="", help="Bootstrap key for provisioning"
     )
     parser.add_argument(
-        "--device-name", type=str, default="linux-pos-emulator-1", help="Device name"
+        "--device-name",
+        type=str,
+        default=d.get("device_name", "linux-pos-emulator-1"),
+        help="Device name",
     )
     parser.add_argument(
-        "--mock-mac", type=str, default="02:42:ac:11:00:02", help="Mock MAC address"
+        "--mock-mac",
+        type=str,
+        default=d.get("mock_mac", "02:42:ac:11:00:02"),
+        help="Mock MAC address",
     )
     parser.add_argument(
-        "--mock-ip", type=str, default="192.168.1.100", help="Mock local IP"
+        "--mock-ip",
+        type=str,
+        default=d.get("mock_ip", "192.168.1.100"),
+        help="Mock local IP",
     )
     parser.add_argument(
-        "--mock-hostname", type=str, default="linux-pos-001", help="Mock hostname"
+        "--mock-hostname",
+        type=str,
+        default=d.get("mock_hostname", "linux-pos-001"),
+        help="Mock hostname",
     )
     parser.add_argument(
-        "--mock-firmware", type=str, default="2.4.1", help="Mock firmware version"
+        "--mock-firmware",
+        type=str,
+        default=d.get("mock_firmware", "2.4.1"),
+        help="Mock firmware version",
     )
     parser.add_argument(
         "--heartbeat-interval",
@@ -1356,7 +1379,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def build_config(args: argparse.Namespace) -> EmulatorConfig:
+def build_config(
+    args: argparse.Namespace, defaults: dict | None = None
+) -> EmulatorConfig:
+    d = defaults or {}
     if args.config:
         path = Path(args.config)
         if not path.exists():
@@ -1364,7 +1390,7 @@ def build_config(args: argparse.Namespace) -> EmulatorConfig:
             sys.exit(1)
         with open(path) as f:
             cfg = json.load(f)
-        config = EmulatorConfig.from_dict(cfg)
+        config = EmulatorConfig.from_dict({**d, **cfg})
         config.backend_url = args.backend_url
         if args.site_id:
             config.site_id = args.site_id
@@ -1398,9 +1424,14 @@ def build_config(args: argparse.Namespace) -> EmulatorConfig:
     )
 
 
-def main(argv: list[str] | None = None) -> None:
-    args = parse_args(argv)
-    config = build_config(args)
+def main(
+    argv: list[str] | None = None,
+    defaults: dict | None = None,
+    emulator_class: type[LinuxPOSEmulator] = LinuxPOSEmulator,
+    banner: str = "HOMEPOT Linux POS Emulator",
+) -> None:
+    args = parse_args(argv, defaults)
+    config = build_config(args, defaults)
 
     if not config.site_id or not config.bootstrap_key:
         print("Error: --site-id and --bootstrap-key are required", file=sys.stderr)
@@ -1409,7 +1440,7 @@ def main(argv: list[str] | None = None) -> None:
         )
         sys.exit(1)
 
-    emulator = LinuxPOSEmulator(config)
+    emulator = emulator_class(config, banner=banner)
 
     def _signal_handler() -> None:
         print("\n  Shutting down ...")


### PR DESCRIPTION
## What
Adds the missing `android_pos` emulator the User App offers when a user selects the "Android POS" emulator type in the Setup Wizard (Emulator step).

Previously, `user_app/electron/main.ts` spawns `emulators/{emulatorType}_emulator.py`, but only `linux_pos_emulator.py` existed, so selecting Android POS failed with "Emulator script not found".

## Changes
- `emulators/linux_pos_emulator.py` — parameterized the engine so it can be reused:
  - `LinuxPOSEmulator(config, banner=...)`
  - `parse_args(argv, defaults=None)` and `build_config(args, defaults=None)` (CLI defaults merged under config-file values, CLI still wins)
  - `main(argv, defaults=None, emulator_class=LinuxPOSEmulator, banner=...)`
- `emulators/android_pos_emulator.py` — thin script reusing the Linux engine with `ANDROID_DEFAULTS` (`device_name=android-pos-emulator-1`, `os_details=Android 14`, `mock_mac=02:42:ac:11:00:03`, `mock_hostname=android-pos-001`) and banner "HOMEPOT Android POS Emulator"
- `emulators/android_pos_emulator.json` — sample config mirroring the Linux sample with Android identity
- `docs/device-emulators.md` — implemented-emulators table, directory layout, and a "creating a new emulator" recipe (thin script + defaults) for future Windows/macOS/iOS variants

## Verification
- `py_compile` on both scripts
- Linux defaults unchanged (CLI + config-file paths)
- `derive_os_capabilities("Android 14")` → `{root_access: False, process_monitoring: True, filesystem_access: True, network_monitoring: True}`
- End-to-end smoke: `python emulators/android_pos_emulator.py --config <sample>` boots with the Android banner/DNA and successfully reaches `POST /devices/bootstrap-provision` (returns the expected backend rejection for a bogus key, proving the full startup path)
- `black --check` and `flake8` clean on both files