### PR TITLE
feat: polish User App setup step 1 and add bootstrap key input

### DIFF
--- a/user_app/src/context/AppContext.tsx
+++ b/user_app/src/context/AppContext.tsx
@@ -43,8 +43,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [setupState, setSetupState] = useState<SetupState>({
     siteId: '',
     deviceName: '',
-    deviceType: 'pos_terminal',
-    deviceOs: 'linux',
+    deviceType: '',
+    deviceOs: 'auto',
     bootstrapKey: '',
   })
   const [useEmulator, setUseEmulator] = useState(false)

--- a/user_app/src/test/setupWizard.test.tsx
+++ b/user_app/src/test/setupWizard.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { AppProvider } from '../context/AppContext'
+import SetupWizard from '../views/SetupWizard'
+
+const mockFetch = vi.fn()
+globalThis.fetch = mockFetch
+
+function renderSetup() {
+  return render(
+    <MemoryRouter initialEntries={['/setup']}>
+      <AppProvider>
+        <SetupWizard />
+      </AppProvider>
+    </MemoryRouter>,
+  )
+}
+
+function fillRequiredFields() {
+  fireEvent.change(screen.getByPlaceholderText('Enter your Site ID'), { target: { value: 'site-001' } })
+  fireEvent.change(screen.getByPlaceholderText('Enter your Bootstrap Key'), { target: { value: 'bk-abc123' } })
+  fireEvent.change(screen.getByPlaceholderText('e.g. Device-001'), { target: { value: 'Device-001' } })
+  fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: 'kiosk' } })
+}
+
+afterEach(() => {
+  delete (navigator as { userAgentData?: unknown }).userAgentData
+})
+
+describe('SetupWizard Step 1', () => {
+  it('renders Device Name label with a consistent example placeholder', () => {
+    renderSetup()
+    expect(screen.getByText('Device Name')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('e.g. Device-001')).toBeInTheDocument()
+    expect(screen.queryByText('Hostname')).not.toBeInTheDocument()
+  })
+
+  it('shows a neutral "-" option first in Device Type', () => {
+    renderSetup()
+    const [deviceType] = screen.getAllByRole('combobox')
+    expect(deviceType.value).toBe('')
+    expect(deviceType.options[0].text).toBe('-')
+  })
+
+  it('defaults Operating System to Auto-detect', () => {
+    renderSetup()
+    const [, deviceOs] = screen.getAllByRole('combobox')
+    expect(deviceOs.value).toBe('auto')
+    expect(deviceOs.options[0].text).toBe('Auto-detect')
+  })
+
+  it('keeps Next disabled until device type is selected', () => {
+    renderSetup()
+    const next = screen.getByRole('button', { name: /next/i })
+    expect(next).toBeDisabled()
+    fireEvent.change(screen.getByPlaceholderText('Enter your Site ID'), { target: { value: 'site-001' } })
+    fireEvent.change(screen.getByPlaceholderText('e.g. Device-001'), { target: { value: 'Device-001' } })
+    expect(next).toBeDisabled()
+    fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: 'kiosk' } })
+    expect(next).toBeDisabled()
+    fireEvent.change(screen.getByPlaceholderText('Enter your Bootstrap Key'), { target: { value: 'bk-abc123' } })
+    expect(next).toBeEnabled()
+  })
+
+  it('resolves the auto-detected OS before proceeding', async () => {
+    Object.defineProperty(navigator, 'userAgentData', { value: { platform: 'Android' }, configurable: true })
+    renderSetup()
+    fillRequiredFields()
+    fireEvent.click(screen.getByRole('button', { name: /next/i }))
+    expect(await screen.findByText('Setup Method')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+    const [, deviceOs] = screen.getAllByRole('combobox')
+    expect(deviceOs.value).toBe('android')
+  })
+})

--- a/user_app/src/views/SetupWizard.tsx
+++ b/user_app/src/views/SetupWizard.tsx
@@ -14,6 +14,26 @@ function formatDeviceType(v: string) {
   return v.replace('_', ' ').replace(/\b\w/g, c => c.toUpperCase())
 }
 
+function detectOS(): string {
+  const uaData = (navigator as unknown as { userAgentData?: { platform?: string } }).userAgentData
+  if (uaData?.platform) {
+    const p = uaData.platform.toLowerCase()
+    if (p.includes('android')) return 'android'
+    if (p.includes('iphone') || p.includes('ipad') || p.includes('ios')) return 'ios'
+    if (p.includes('mac')) return 'mac'
+    if (p.includes('win')) return 'windows'
+    if (p.includes('linux')) return 'linux'
+  }
+  const platform = navigator.platform.toLowerCase()
+  const ua = navigator.userAgent.toLowerCase()
+  if (ua.includes('android')) return 'android'
+  if (/iphone|ipad|ipod/.test(ua)) return 'ios'
+  if (platform.includes('mac')) return 'mac'
+  if (platform.includes('win')) return 'windows'
+  if (platform.includes('linux') || ua.includes('cros')) return 'linux'
+  return 'web'
+}
+
 function StepIndicator({ current }: { current: number }) {
   const STEPS = ['Device Setup', 'Method', 'Emulator', 'Complete']
   return (
@@ -50,9 +70,11 @@ function Step1() {
   const [deviceName, setDeviceName] = useState(setupState.deviceName)
   const [deviceType, setDeviceType] = useState(setupState.deviceType)
   const [deviceOs, setDeviceOs] = useState(setupState.deviceOs)
+  const [bootstrapKey, setBootstrapKey] = useState(setupState.bootstrapKey)
 
   const handleNext = () => {
-    setSetupState({ siteId, deviceName, deviceType, deviceOs, bootstrapKey: setupState.bootstrapKey })
+    const resolvedOs = deviceOs === 'auto' ? detectOS() : deviceOs
+    setSetupState({ siteId, deviceName, deviceType, deviceOs: resolvedOs, bootstrapKey })
     navigate('/method')
   }
 
@@ -79,13 +101,27 @@ function Step1() {
 
       <div className="flex flex-col gap-1">
         <label className="text-slate-300 text-sm font-medium">
-          Hostname <span className="text-emerald-500 font-normal">*</span>
+          Bootstrap Key <span className="text-red-400">*</span>
+        </label>
+        <input
+          type="text"
+          value={bootstrapKey}
+          onChange={e => setBootstrapKey(e.target.value)}
+          placeholder="Enter your Bootstrap Key"
+          className="w-full px-3 py-2.5 rounded-lg bg-slate-700 border border-slate-600 text-slate-100 placeholder-slate-500 text-sm focus:outline-none focus:border-emerald-500 transition-colors"
+        />
+        <p className="text-slate-500 text-xs">Provided by your IT administrator.</p>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label className="text-slate-300 text-sm font-medium">
+          Device Name <span className="text-red-400">*</span>
         </label>
         <input
           type="text"
           value={deviceName}
           onChange={e => setDeviceName(e.target.value)}
-          placeholder="e.g. Kasi-Laptop"
+          placeholder="e.g. Device-001"
           className="w-full px-3 py-2.5 rounded-lg bg-slate-700 border border-slate-600 text-slate-100 placeholder-slate-500 text-sm focus:outline-none focus:border-emerald-500 transition-colors"
         />
       </div>
@@ -99,6 +135,7 @@ function Step1() {
           onChange={e => setDeviceType(e.target.value)}
           className="w-full px-3 py-2.5 rounded-lg bg-slate-700 border border-slate-600 text-slate-100 text-sm focus:outline-none focus:border-emerald-500 transition-colors"
         >
+          <option value="">-</option>
           <option value="pos_terminal">POS Terminal</option>
           <option value="virtual_terminal">Virtual Terminal</option>
           <option value="kiosk">Kiosk</option>
@@ -116,6 +153,7 @@ function Step1() {
           onChange={e => setDeviceOs(e.target.value)}
           className="w-full px-3 py-2.5 rounded-lg bg-slate-700 border border-slate-600 text-slate-100 text-sm focus:outline-none focus:border-emerald-500 transition-colors"
         >
+          <option value="auto">Auto-detect</option>
           <option value="windows">Windows</option>
           <option value="linux">Linux</option>
           <option value="mac">macOS</option>
@@ -127,7 +165,7 @@ function Step1() {
 
       <button
         onClick={handleNext}
-        disabled={!siteId.trim() || !deviceName.trim()}
+        disabled={!siteId.trim() || !bootstrapKey.trim() || !deviceName.trim() || !deviceType}
         className="w-full py-3 rounded-lg bg-emerald-600 hover:bg-emerald-500 disabled:bg-slate-700 disabled:text-slate-500 disabled:cursor-not-allowed text-white font-semibold text-sm transition-colors"
       >
         Next →
@@ -227,7 +265,7 @@ function ReviewStep({ onBack }: { onBack: () => void }) {
           <span className="text-slate-200 font-medium">{siteId}</span>
         </div>
         <div className="flex justify-between">
-          <span className="text-slate-400">Hostname</span>
+          <span className="text-slate-400">Device Name</span>
           <span className="text-slate-200 font-medium">{deviceName || '—'}</span>
         </div>
         <div className="flex justify-between">


### PR DESCRIPTION
## What
Reworks the User App setup wizard Step 1 (the first screen a user lands on) and closes the gap that prevented the emulator/real-device provisioning path from working end-to-end.

## Changes
- **Hostname → Device Name** — renamed label; placeholder now `e.g. Device-001` (consistent with `Site ID`/`Device-001`). Review step label updated too.
- **Device Type dropdown** — now starts with a neutral `-` option instead of pre-selecting `POS Terminal`.
- **Operating System auto-detect** — new `Auto-detect` option (default). Resolves the host OS via `navigator.userAgentData.platform` with a `navigator.platform`/`userAgent` fallback before proceeding.
- **Red required-star** — the `*` next to Device Name changed from emerald to `text-red-400` for consistency with the other required fields.
- **Bootstrap Key input (required)** — added as a Step 1 field right after Site ID (matching the technician's handoff card). It flows into `setupState.bootstrapKey` and is now used by both the real-device `bootstrap-provision` call and the emulator config in the review step. Previously the key was never collected, so the Electron emulator path failed with `--site-id and --bootstrap-key are required`.
- **Next button gating** — now requires Site ID, Bootstrap Key, Device Name, and a chosen Device Type.

## Supporting changes
- `AppContext` `setupState` defaults changed from `pos_terminal`/`linux` to empty/`auto` (removes the presumptuous preselects).
- New `setupWizard.test.tsx` covering labels, the `-` option, auto-detect default, Next gating, and OS auto-detection resolution.

## Verification
- vitest: 74/74 passing
- `tsc --noEmit`: clean
- eslint: clean (only the 2 pre-existing baseline issues elsewhere)
- `vite build`: clean