### PR TITLE
feat: detect duplicate device names and add dev emulator bootstrap key

### DIFF
--- a/backend/src/homepot/app/api/API_v1/Endpoints/DeviceBootstrapProvisionEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DeviceBootstrapProvisionEndpoint.py
@@ -14,6 +14,8 @@ from homepot.app.auth_utils import verify_bootstrap_key
 from homepot.app.schemas.bootstrap import (
     BootstrapProvisionRequest,
     BootstrapProvisionResponse,
+    DeviceNameCheckRequest,
+    DeviceNameCheckResponse,
 )
 from homepot.app.services.agent_service import AgentService
 from homepot.database import get_db
@@ -44,13 +46,16 @@ def bootstrap_provision_device(
         if not site:
             raise HTTPException(status_code=404, detail="Site not found")
 
-        if not site.bootstrap_key_hash:
-            raise HTTPException(
-                status_code=401,
-                detail="Site does not have a bootstrap key configured",
-            )
-
-        if not verify_bootstrap_key(payload.bootstrap_key, site):
+        if not verify_bootstrap_key(
+            payload.bootstrap_key,
+            site,
+            allow_dev_key=payload.provisioning_source == "emulator",
+        ):
+            if not site.bootstrap_key_hash:
+                raise HTTPException(
+                    status_code=401,
+                    detail="Site does not have a bootstrap key configured",
+                )
             raise HTTPException(status_code=401, detail="Invalid bootstrap key")
 
         service = AgentService(db)
@@ -69,3 +74,34 @@ def bootstrap_provision_device(
     except Exception as e:
         logger.error("Unexpected bootstrap provision error: %s", e, exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/check-name",
+    tags=["Devices"],
+    response_model=Dict[str, Any],
+)
+def check_device_name(
+    payload: DeviceNameCheckRequest,
+    db: Session = Depends(get_db),
+) -> Dict[str, Any]:
+    """Check whether a device name is available in a site.
+
+    Authenticated by the site bootstrap key, mirroring the provisioning
+    endpoint so the User App can surface inline feedback before a device is
+    actually enrolled.
+    """
+    site = db.query(Site).filter(Site.site_id == payload.site_id).first()
+    if not site:
+        raise HTTPException(status_code=404, detail="Site not found")
+
+    if not verify_bootstrap_key(payload.bootstrap_key, site, allow_dev_key=True):
+        raise HTTPException(status_code=401, detail="Invalid bootstrap key")
+
+    service = AgentService(db)
+    available = service.device_name_available(payload.site_id, payload.device_name)
+    response_data = DeviceNameCheckResponse(available=available)
+    return {
+        "status": "success",
+        "data": response_data.model_dump(),
+    }

--- a/backend/src/homepot/app/auth_utils.py
+++ b/backend/src/homepot/app/auth_utils.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 import logging
 import os
 from pathlib import Path
+import secrets
 from typing import Any, Dict, Optional, cast
 
 from dotenv import load_dotenv
@@ -302,13 +303,36 @@ async def get_current_device(
     return device
 
 
-def verify_bootstrap_key(
-    bootstrap_key: str, site: "Site", pwd_context: CryptContext = pwd_context
-) -> bool:
-    """Verify a plaintext bootstrap key against the site's stored hash."""
-    if not site.bootstrap_key_hash:
+def is_dev_bootstrap_key(bootstrap_key: str) -> bool:
+    """Return True if the key is the well-known dev key.
+
+    The dev key is only honoured outside the production environment, so it
+    can never be used to enrol a device against a real deployment.
+    """
+    from homepot.config import get_settings
+
+    settings = get_settings()
+    if settings.environment == "production" or not settings.dev_bootstrap_key:
         return False
-    return cast(bool, pwd_context.verify(bootstrap_key, site.bootstrap_key_hash))  # type: ignore[arg-type]
+    return secrets.compare_digest(bootstrap_key, settings.dev_bootstrap_key)
+
+
+def verify_bootstrap_key(
+    bootstrap_key: str,
+    site: "Site",
+    pwd_context: CryptContext = pwd_context,
+    allow_dev_key: bool = False,
+) -> bool:
+    """Verify a plaintext bootstrap key against the site's stored hash.
+
+    When ``allow_dev_key`` is set, the well-known dev key is also accepted
+    (outside production) for simulated/emulator enrolment.
+    """
+    if site.bootstrap_key_hash and pwd_context.verify(
+        bootstrap_key, site.bootstrap_key_hash  # type: ignore[arg-type]
+    ):
+        return True
+    return bool(allow_dev_key and is_dev_bootstrap_key(bootstrap_key))
 
 
 def exchange_google_code(code: str) -> dict:

--- a/backend/src/homepot/app/repositories/agent_repository.py
+++ b/backend/src/homepot/app/repositories/agent_repository.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any, Iterable, Optional, cast
 
-from sqlalchemy import desc, select
+from sqlalchemy import desc, func, select
 from sqlalchemy.orm import Session
 
 from homepot.app.models.AnalyticsModel import DeviceMetrics
@@ -33,6 +33,27 @@ class AgentRepository:
         """Return a site by business site_id, or None if not found."""
         result = self.db.execute(select(Site).where(Site.site_id == site_id))
         return result.scalars().first()
+
+    def device_name_exists_in_site(self, site_pk: int, name: str) -> bool:
+        """Return True if a live device in the site already uses this name.
+
+        Matching is case-insensitive and whitespace-trimmed. Retired and
+        unpaired devices are excluded so names can be reused after a device
+        is decommissioned.
+        """
+        active_states = [
+            LifecycleState.PENDING.value,
+            LifecycleState.ACTIVE.value,
+            LifecycleState.SUSPENDED.value,
+        ]
+        result = self.db.execute(
+            select(Device).where(
+                Device.site_id == site_pk,
+                func.lower(Device.name) == name.strip().lower(),
+                Device.lifecycle_state.in_(active_states),
+            )
+        )
+        return result.scalars().first() is not None
 
     def get_latest_metrics(self, device_pk: int) -> Optional[DeviceMetrics]:
         """Return the most recent telemetry entry for a device, or None."""

--- a/backend/src/homepot/app/schemas/bootstrap.py
+++ b/backend/src/homepot/app/schemas/bootstrap.py
@@ -64,3 +64,27 @@ class BootstrapKeyResponse(BaseModel):
 
     bootstrap_key: str
     message: str
+
+
+class DeviceNameCheckRequest(BaseModel):
+    """Request schema for checking device-name availability in a site."""
+
+    site_id: str = Field(..., min_length=1, description="Business site ID")
+    bootstrap_key: str = Field(..., min_length=1, description="Site bootstrap key")
+    device_name: str = Field(..., min_length=1, description="Candidate device name")
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "site_id": "site-001",
+                "bootstrap_key": "abc123def456",
+                "device_name": "Kitchen POS A",
+            }
+        }
+    )
+
+
+class DeviceNameCheckResponse(BaseModel):
+    """Response schema for a device-name availability check."""
+
+    available: bool

--- a/backend/src/homepot/app/services/agent_service.py
+++ b/backend/src/homepot/app/services/agent_service.py
@@ -350,10 +350,17 @@ class AgentService:
             device_id = f"{payload.device_type}-{secrets.token_hex(4)}"
             api_key = secrets.token_urlsafe(32)
 
+            requested_name = (payload.device_name or "").strip() or device_id
+            if self.repository.device_name_exists_in_site(int(site.id), requested_name):
+                raise ValueError(
+                    f"Device name '{requested_name}' is already in use in site "
+                    f"'{payload.site_id}'. Choose a different device name."
+                )
+
             is_emulator = payload.provisioning_source == "emulator"
             created = self.repository.create_device(
                 device_id=device_id,
-                name=payload.device_name or device_id,
+                name=requested_name,
                 device_type=payload.device_type,
                 site_pk=int(site.id),
                 mac_address=None,
@@ -433,6 +440,15 @@ class AgentService:
             raise ValueError(f"Invalid bootstrap provision request: {str(e)}")
         except Exception:
             raise Exception("Failed to bootstrap provision device")
+
+    def device_name_available(self, site_id: str, name: str) -> bool:
+        """Return True if the name is not used by a live device in the site."""
+        site = self.repository.get_site_by_site_id(site_id)
+        if not site or not site.id:
+            raise LookupError(f"Site '{site_id}' not found")
+        return not self.repository.device_name_exists_in_site(
+            int(site.id), name.strip()
+        )
 
     def get_device_status(self, device_id: str) -> dict:
         """Return lifecycle, connectivity, and health state for a device."""

--- a/backend/src/homepot/config.py
+++ b/backend/src/homepot/config.py
@@ -176,6 +176,10 @@ class Settings(BaseSettings):
         default=True,
         description="Enable simulated device agents on startup (set False for dev server with real devices)",
     )
+    dev_bootstrap_key: str = Field(
+        default="homepot-dev-emulator-key",
+        description="Well-known bootstrap key accepted for simulated/emulator devices (never in production)",
+    )
 
     # Server configuration
     host: str = Field(default="0.0.0.0", description="Server host")  # nosec B104

--- a/backend/tests/test_dev_server_smoke.py
+++ b/backend/tests/test_dev_server_smoke.py
@@ -345,3 +345,192 @@ class TestDevServerSmoke:
         assert resp.status_code == 200, resp.text
         device = resp.json()
         assert device["is_simulated"] is False
+
+
+# ===================================================================
+# Bootstrap provisioning — duplicate names + dev emulator key
+# ===================================================================
+
+
+def _generate_bootstrap_key(client: TestClient, site_id: str = "smoke-site-001") -> str:
+    headers = _auth_header("admin@smoke.test")
+    resp = client.post(f"/api/v1/sites/{site_id}/bootstrap-key", headers=headers)
+    assert resp.status_code == 200, resp.text
+    return resp.json()["data"]["bootstrap_key"]
+
+
+class TestBootstrapProvisionDuplicateNames:
+    """Duplicate device names within a site must be detected."""
+
+    def test_check_name_rejects_invalid_key(
+        self, client: TestClient, seeded_db: Any
+    ) -> None:
+        """check-name requires a valid bootstrap key."""
+        _generate_bootstrap_key(client)
+        resp = client.post(
+            "/api/v1/devices/check-name",
+            json={
+                "site_id": "smoke-site-001",
+                "bootstrap_key": "not-the-key",
+                "device_name": "Device-001",
+            },
+        )
+        assert resp.status_code == 401, resp.text
+
+    def test_check_name_and_duplicate_provision_rejection(
+        self, client: TestClient, seeded_db: Any
+    ) -> None:
+        """A name used by a live device is reported and provisioning is blocked."""
+        key = _generate_bootstrap_key(client)
+
+        resp = client.post(
+            "/api/v1/devices/check-name",
+            json={
+                "site_id": "smoke-site-001",
+                "bootstrap_key": key,
+                "device_name": "Device-001",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"]["available"] is True
+
+        resp = client.post(
+            "/api/v1/devices/bootstrap-provision",
+            json={
+                "site_id": "smoke-site-001",
+                "bootstrap_key": key,
+                "device_name": "Device-001",
+                "device_type": "pos_terminal",
+                "os_details": "Linux",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+        # Case-insensitive match
+        resp = client.post(
+            "/api/v1/devices/check-name",
+            json={
+                "site_id": "smoke-site-001",
+                "bootstrap_key": key,
+                "device_name": "device-001",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"]["available"] is False
+
+        resp = client.post(
+            "/api/v1/devices/bootstrap-provision",
+            json={
+                "site_id": "smoke-site-001",
+                "bootstrap_key": key,
+                "device_name": "Device-001",
+                "device_type": "pos_terminal",
+                "os_details": "Linux",
+            },
+        )
+        assert resp.status_code == 400, resp.text
+        assert "already in use" in resp.json()["detail"]
+
+    def test_same_name_allowed_in_another_site(
+        self, client: TestClient, seeded_db: Any
+    ) -> None:
+        """Duplicate names are only rejected within the same site."""
+        headers = _auth_header("admin@smoke.test")
+        resp = client.post(
+            "/api/v1/sites/",
+            json={"site_id": "smoke-site-002", "name": "Smoke Site 2"},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+
+        key1 = _generate_bootstrap_key(client, "smoke-site-001")
+        key2 = _generate_bootstrap_key(client, "smoke-site-002")
+
+        for site_id, key in (
+            ("smoke-site-001", key1),
+            ("smoke-site-002", key2),
+        ):
+            resp = client.post(
+                "/api/v1/devices/bootstrap-provision",
+                json={
+                    "site_id": site_id,
+                    "bootstrap_key": key,
+                    "device_name": "Device-001",
+                    "device_type": "pos_terminal",
+                    "os_details": "Linux",
+                },
+            )
+            assert resp.status_code == 200, resp.text
+
+
+class TestDevEmulatorBootstrapKey:
+    """The well-known dev key works for emulator provisioning outside production."""
+
+    def test_emulator_dev_key_provisions_in_development(
+        self, client: TestClient, seeded_db: Any
+    ) -> None:
+        """Emulator provisioning accepts the dev key (even without a site hash)."""
+        resp = client.post(
+            "/api/v1/devices/bootstrap-provision",
+            json={
+                "site_id": "smoke-site-001",
+                "bootstrap_key": "homepot-dev-emulator-key",
+                "device_name": "Dev-Emu-1",
+                "device_type": "pos_terminal",
+                "os_details": "Android 14",
+                "provisioning_source": "emulator",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"]["device_id"]
+
+    def test_dev_key_rejected_for_physical_device(
+        self, client: TestClient, seeded_db: Any
+    ) -> None:
+        """The dev key cannot enrol a real (non-emulator) device."""
+        resp = client.post(
+            "/api/v1/devices/bootstrap-provision",
+            json={
+                "site_id": "smoke-site-001",
+                "bootstrap_key": "homepot-dev-emulator-key",
+                "device_name": "Dev-Emu-2",
+                "device_type": "pos_terminal",
+                "os_details": "Linux",
+            },
+        )
+        assert resp.status_code == 401, resp.text
+
+    def test_dev_key_rejected_in_production(
+        self, client: TestClient, seeded_db: Any, monkeypatch: Any
+    ) -> None:
+        """The dev key is never honoured in the production environment."""
+        from homepot.config import get_settings
+
+        monkeypatch.setattr(get_settings(), "environment", "production")
+        resp = client.post(
+            "/api/v1/devices/bootstrap-provision",
+            json={
+                "site_id": "smoke-site-001",
+                "bootstrap_key": "homepot-dev-emulator-key",
+                "device_name": "Dev-Emu-3",
+                "device_type": "pos_terminal",
+                "os_details": "Android 14",
+                "provisioning_source": "emulator",
+            },
+        )
+        assert resp.status_code == 401, resp.text
+
+    def test_check_name_accepts_dev_key(
+        self, client: TestClient, seeded_db: Any
+    ) -> None:
+        """The inline availability check accepts the dev key."""
+        resp = client.post(
+            "/api/v1/devices/check-name",
+            json={
+                "site_id": "smoke-site-001",
+                "bootstrap_key": "homepot-dev-emulator-key",
+                "device_name": "Dev-Emu-4",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"]["available"] is True

--- a/docs/verify-user-app-with-emulator.md
+++ b/docs/verify-user-app-with-emulator.md
@@ -133,6 +133,11 @@ Expected response: `200` with `{"message": "...", "site_id": "site-it-demo1", ..
 
 ## Step 2 — Technician: generate a bootstrap key
 
+> **Dev shortcut:** for emulator testing you can skip generating a key and use
+> the well-known dev key `homepot-dev-emulator-key`. It is accepted **only**
+> outside production and **only** for simulated/emulator devices
+> (`provisioning_source=emulator`), so real devices still need a real key.
+
 **Option A — via the Dashboard UI (recommended):** open the Site detail page for
 the site just created and click **Bootstrap Key**. In the dialog, click
 **Generate Bootstrap Key** — the key is shown once, with a copy button.
@@ -173,7 +178,10 @@ In **Terminal 2**, first start the HOMEPOT **User App** — the device-side UI (
 ```
 
 Open http://localhost:5174 — the setup wizard opens. Walk through it with the
-handed-off site info: enter the **Site ID**, a hostname, and pick a device type.
+handed-off site info: enter the **Site ID**, the **Bootstrap Key**, a
+**Device Name**, and pick a device type. As you type the device name, the
+wizard checks live that the name isn't already in use in the site (using
+`POST /devices/check-name`) and blocks proceeding if it is.
 
 > **Note:** in dev mode the wizard simulates completion with local dev
 > credentials and does **not** call the backend. The actual backend-facing
@@ -288,8 +296,9 @@ Back in **Terminal 1** / the Dashboard browser:
 
 | Symptom | Cause / fix |
 |---------|-------------|
+| "Device name ... already in use" (400) | A live device in the site already uses that name (case-insensitive). Pick a different name, or retire/unpair the old device first. |
 | Device never appears on the Dashboard | Bootstrap key typo, or wrong `--site-id`. The key is single-use-ish — generate a new one in Step 2. |
-| Emulator re-provisions but Dashboard shows the old device | Stale credentials file — delete `~/.homepot/emulators/<device_name>.json` and re-run. |
+| Emulator re-provisions but Dashboard shows the old device | Stale credentials file — delete `~/.homepot/emulators/<device_name>.json` and re-run **with a different `--device-name`** (the old name is still registered and the duplicate check will reject it). |
 | `health_state` shows `error` on a healthy device | The legacy simulator was enabled (`ENABLE_AGENT_SIMULATION=true`). Restart the backend with it disabled (Step 0). |
 | Two emulators clash on one machine | Use different `--device-name` values (each gets its own credentials file). |
 | Dashboard frontend can't reach the backend | Confirm the backend is up and CORS is configured; `curl http://localhost:8000/` should return `{"message":"I Am Alive"}`. |

--- a/user_app/src/context/AppContext.tsx
+++ b/user_app/src/context/AppContext.tsx
@@ -43,8 +43,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [setupState, setSetupState] = useState<SetupState>({
     siteId: '',
     deviceName: '',
-    deviceType: 'pos_terminal',
-    deviceOs: 'linux',
+    deviceType: '',
+    deviceOs: 'auto',
     bootstrapKey: '',
   })
   const [useEmulator, setUseEmulator] = useState(false)

--- a/user_app/src/services/api.ts
+++ b/user_app/src/services/api.ts
@@ -190,6 +190,24 @@ export async function bootstrapProvision(body: {
   return json.data
 }
 
+export async function checkDeviceName(body: {
+  site_id: string
+  bootstrap_key: string
+  device_name: string
+}): Promise<{ available: boolean }> {
+  const res = await fetch(`${apiBaseUrl}/devices/check-name`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}))
+    throw asApiError(err.detail || `Name check failed (${res.status})`, res.status)
+  }
+  const json = await res.json()
+  return json.data
+}
+
 export async function claimDevice(body: {
   intent_id: string
   claim_token: string

--- a/user_app/src/test/setupWizard.test.tsx
+++ b/user_app/src/test/setupWizard.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { AppProvider } from '../context/AppContext'
+import SetupWizard from '../views/SetupWizard'
+
+const mockFetch = vi.fn()
+globalThis.fetch = mockFetch
+
+function renderSetup() {
+  return render(
+    <MemoryRouter initialEntries={['/setup']}>
+      <AppProvider>
+        <SetupWizard />
+      </AppProvider>
+    </MemoryRouter>,
+  )
+}
+
+function fillRequiredFields() {
+  fireEvent.change(screen.getByPlaceholderText('Enter your Site ID'), { target: { value: 'site-001' } })
+  fireEvent.change(screen.getByPlaceholderText('Enter your Bootstrap Key'), { target: { value: 'bk-abc123' } })
+  fireEvent.change(screen.getByPlaceholderText('e.g. Device-001'), { target: { value: 'Device-001' } })
+  fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: 'kiosk' } })
+}
+
+afterEach(() => {
+  delete (navigator as { userAgentData?: unknown }).userAgentData
+})
+
+describe('SetupWizard Step 1', () => {
+  it('renders Device Name label with a consistent example placeholder', () => {
+    renderSetup()
+    expect(screen.getByText('Device Name')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('e.g. Device-001')).toBeInTheDocument()
+    expect(screen.queryByText('Hostname')).not.toBeInTheDocument()
+  })
+
+  it('shows a neutral "-" option first in Device Type', () => {
+    renderSetup()
+    const [deviceType] = screen.getAllByRole('combobox')
+    expect(deviceType.value).toBe('')
+    expect(deviceType.options[0].text).toBe('-')
+  })
+
+  it('defaults Operating System to Auto-detect', () => {
+    renderSetup()
+    const [, deviceOs] = screen.getAllByRole('combobox')
+    expect(deviceOs.value).toBe('auto')
+    expect(deviceOs.options[0].text).toBe('Auto-detect')
+  })
+
+  it('keeps Next disabled until device type is selected', () => {
+    renderSetup()
+    const next = screen.getByRole('button', { name: /next/i })
+    expect(next).toBeDisabled()
+    fireEvent.change(screen.getByPlaceholderText('Enter your Site ID'), { target: { value: 'site-001' } })
+    fireEvent.change(screen.getByPlaceholderText('e.g. Device-001'), { target: { value: 'Device-001' } })
+    expect(next).toBeDisabled()
+    fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: 'kiosk' } })
+    expect(next).toBeDisabled()
+    fireEvent.change(screen.getByPlaceholderText('Enter your Bootstrap Key'), { target: { value: 'bk-abc123' } })
+    expect(next).toBeEnabled()
+  })
+
+  it('resolves the auto-detected OS before proceeding', async () => {
+    Object.defineProperty(navigator, 'userAgentData', { value: { platform: 'Android' }, configurable: true })
+    renderSetup()
+    fillRequiredFields()
+    fireEvent.click(screen.getByRole('button', { name: /next/i }))
+    expect(await screen.findByText('Setup Method')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+    const [, deviceOs] = screen.getAllByRole('combobox')
+    expect(deviceOs.value).toBe('android')
+  })
+})

--- a/user_app/src/test/setupWizard.test.tsx
+++ b/user_app/src/test/setupWizard.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { AppProvider } from '../context/AppContext'
@@ -6,6 +6,17 @@ import SetupWizard from '../views/SetupWizard'
 
 const mockFetch = vi.fn()
 globalThis.fetch = mockFetch
+
+function setupFetchMock(available = true) {
+  mockFetch.mockImplementation((url: string) => {
+    if (String(url).includes('/check-name')) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ data: { available } }), { status: 200 }),
+      )
+    }
+    return Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))
+  })
+}
 
 function renderSetup() {
   return render(
@@ -26,6 +37,11 @@ function fillRequiredFields() {
 
 afterEach(() => {
   delete (navigator as { userAgentData?: unknown }).userAgentData
+})
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  setupFetchMock(true)
 })
 
 describe('SetupWizard Step 1', () => {
@@ -61,6 +77,32 @@ describe('SetupWizard Step 1', () => {
     expect(next).toBeDisabled()
     fireEvent.change(screen.getByPlaceholderText('Enter your Bootstrap Key'), { target: { value: 'bk-abc123' } })
     expect(next).toBeEnabled()
+  })
+
+  it('shows the dev key hint for emulator testing', () => {
+    renderSetup()
+    expect(screen.getByText(/homepot-dev-emulator-key/)).toBeInTheDocument()
+  })
+
+  it('shows name availability feedback', async () => {
+    renderSetup()
+    fireEvent.change(screen.getByPlaceholderText('Enter your Site ID'), { target: { value: 'site-001' } })
+    fireEvent.change(screen.getByPlaceholderText('Enter your Bootstrap Key'), { target: { value: 'bk-abc123' } })
+    fireEvent.change(screen.getByPlaceholderText('e.g. Device-001'), { target: { value: 'Device-001' } })
+    expect(await screen.findByText('✓ Name available')).toBeInTheDocument()
+  })
+
+  it('blocks Next when the device name is already in use', async () => {
+    setupFetchMock(false)
+    renderSetup()
+    const next = screen.getByRole('button', { name: /next/i })
+    fireEvent.change(screen.getByPlaceholderText('Enter your Site ID'), { target: { value: 'site-001' } })
+    fireEvent.change(screen.getByPlaceholderText('Enter your Bootstrap Key'), { target: { value: 'bk-abc123' } })
+    fireEvent.change(screen.getByPlaceholderText('e.g. Device-001'), { target: { value: 'Device-001' } })
+    fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: 'kiosk' } })
+    expect(next).toBeEnabled()
+    expect(await screen.findByText(/already in use/)).toBeInTheDocument()
+    expect(next).toBeDisabled()
   })
 
   it('resolves the auto-detected OS before proceeding', async () => {

--- a/user_app/src/views/SetupWizard.tsx
+++ b/user_app/src/views/SetupWizard.tsx
@@ -14,6 +14,26 @@ function formatDeviceType(v: string) {
   return v.replace('_', ' ').replace(/\b\w/g, c => c.toUpperCase())
 }
 
+function detectOS(): string {
+  const uaData = (navigator as unknown as { userAgentData?: { platform?: string } }).userAgentData
+  if (uaData?.platform) {
+    const p = uaData.platform.toLowerCase()
+    if (p.includes('android')) return 'android'
+    if (p.includes('iphone') || p.includes('ipad') || p.includes('ios')) return 'ios'
+    if (p.includes('mac')) return 'mac'
+    if (p.includes('win')) return 'windows'
+    if (p.includes('linux')) return 'linux'
+  }
+  const platform = navigator.platform.toLowerCase()
+  const ua = navigator.userAgent.toLowerCase()
+  if (ua.includes('android')) return 'android'
+  if (/iphone|ipad|ipod/.test(ua)) return 'ios'
+  if (platform.includes('mac')) return 'mac'
+  if (platform.includes('win')) return 'windows'
+  if (platform.includes('linux') || ua.includes('cros')) return 'linux'
+  return 'web'
+}
+
 function StepIndicator({ current }: { current: number }) {
   const STEPS = ['Device Setup', 'Method', 'Emulator', 'Complete']
   return (
@@ -50,9 +70,11 @@ function Step1() {
   const [deviceName, setDeviceName] = useState(setupState.deviceName)
   const [deviceType, setDeviceType] = useState(setupState.deviceType)
   const [deviceOs, setDeviceOs] = useState(setupState.deviceOs)
+  const [bootstrapKey, setBootstrapKey] = useState(setupState.bootstrapKey)
 
   const handleNext = () => {
-    setSetupState({ siteId, deviceName, deviceType, deviceOs, bootstrapKey: setupState.bootstrapKey })
+    const resolvedOs = deviceOs === 'auto' ? detectOS() : deviceOs
+    setSetupState({ siteId, deviceName, deviceType, deviceOs: resolvedOs, bootstrapKey })
     navigate('/method')
   }
 
@@ -79,13 +101,27 @@ function Step1() {
 
       <div className="flex flex-col gap-1">
         <label className="text-slate-300 text-sm font-medium">
-          Hostname <span className="text-emerald-500 font-normal">*</span>
+          Bootstrap Key <span className="text-red-400">*</span>
+        </label>
+        <input
+          type="text"
+          value={bootstrapKey}
+          onChange={e => setBootstrapKey(e.target.value)}
+          placeholder="Enter your Bootstrap Key"
+          className="w-full px-3 py-2.5 rounded-lg bg-slate-700 border border-slate-600 text-slate-100 placeholder-slate-500 text-sm focus:outline-none focus:border-emerald-500 transition-colors"
+        />
+        <p className="text-slate-500 text-xs">Provided by your IT administrator.</p>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label className="text-slate-300 text-sm font-medium">
+          Device Name <span className="text-red-400">*</span>
         </label>
         <input
           type="text"
           value={deviceName}
           onChange={e => setDeviceName(e.target.value)}
-          placeholder="e.g. Kasi-Laptop"
+          placeholder="e.g. Device-001"
           className="w-full px-3 py-2.5 rounded-lg bg-slate-700 border border-slate-600 text-slate-100 placeholder-slate-500 text-sm focus:outline-none focus:border-emerald-500 transition-colors"
         />
       </div>
@@ -99,6 +135,7 @@ function Step1() {
           onChange={e => setDeviceType(e.target.value)}
           className="w-full px-3 py-2.5 rounded-lg bg-slate-700 border border-slate-600 text-slate-100 text-sm focus:outline-none focus:border-emerald-500 transition-colors"
         >
+          <option value="">-</option>
           <option value="pos_terminal">POS Terminal</option>
           <option value="virtual_terminal">Virtual Terminal</option>
           <option value="kiosk">Kiosk</option>
@@ -116,6 +153,7 @@ function Step1() {
           onChange={e => setDeviceOs(e.target.value)}
           className="w-full px-3 py-2.5 rounded-lg bg-slate-700 border border-slate-600 text-slate-100 text-sm focus:outline-none focus:border-emerald-500 transition-colors"
         >
+          <option value="auto">Auto-detect</option>
           <option value="windows">Windows</option>
           <option value="linux">Linux</option>
           <option value="mac">macOS</option>
@@ -127,7 +165,7 @@ function Step1() {
 
       <button
         onClick={handleNext}
-        disabled={!siteId.trim() || !deviceName.trim()}
+        disabled={!siteId.trim() || !bootstrapKey.trim() || !deviceName.trim() || !deviceType}
         className="w-full py-3 rounded-lg bg-emerald-600 hover:bg-emerald-500 disabled:bg-slate-700 disabled:text-slate-500 disabled:cursor-not-allowed text-white font-semibold text-sm transition-colors"
       >
         Next →
@@ -227,7 +265,7 @@ function ReviewStep({ onBack }: { onBack: () => void }) {
           <span className="text-slate-200 font-medium">{siteId}</span>
         </div>
         <div className="flex justify-between">
-          <span className="text-slate-400">Hostname</span>
+          <span className="text-slate-400">Device Name</span>
           <span className="text-slate-200 font-medium">{deviceName || '—'}</span>
         </div>
         <div className="flex justify-between">

--- a/user_app/src/views/SetupWizard.tsx
+++ b/user_app/src/views/SetupWizard.tsx
@@ -1,9 +1,9 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useApp } from '../context/AppContext'
 import { apiBaseUrl } from '../config/api'
 import { credentialStorage } from '../services/credentialStorage'
-import { bootstrapProvision } from '../services/api'
+import { bootstrapProvision, checkDeviceName } from '../services/api'
 
 const EMULATOR_TYPES: { value: string; label: string; os: string; description: string }[] = [
   { value: 'linux_pos', label: 'Linux POS', os: 'Linux 6.8.0 (Debian 12)', description: 'Simulates a Linux-based POS terminal' },
@@ -71,6 +71,31 @@ function Step1() {
   const [deviceType, setDeviceType] = useState(setupState.deviceType)
   const [deviceOs, setDeviceOs] = useState(setupState.deviceOs)
   const [bootstrapKey, setBootstrapKey] = useState(setupState.bootstrapKey)
+  const [nameStatus, setNameStatus] = useState<'idle' | 'checking' | 'available' | 'taken'>('idle')
+
+  useEffect(() => {
+    if (!siteId.trim() || !bootstrapKey.trim() || !deviceName.trim()) {
+      return
+    }
+    let cancelled = false
+    const timer = setTimeout(async () => {
+      setNameStatus('checking')
+      try {
+        const res = await checkDeviceName({
+          site_id: siteId.trim(),
+          bootstrap_key: bootstrapKey.trim(),
+          device_name: deviceName.trim(),
+        })
+        if (!cancelled) setNameStatus(res.available ? 'available' : 'taken')
+      } catch {
+        if (!cancelled) setNameStatus('idle')
+      }
+    }, 500)
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [siteId, bootstrapKey, deviceName])
 
   const handleNext = () => {
     const resolvedOs = deviceOs === 'auto' ? detectOS() : deviceOs
@@ -92,7 +117,10 @@ function Step1() {
         <input
           type="text"
           value={siteId}
-          onChange={e => setSiteId(e.target.value)}
+          onChange={e => {
+            setSiteId(e.target.value)
+            if (!e.target.value.trim()) setNameStatus('idle')
+          }}
           placeholder="Enter your Site ID"
           className="w-full px-3 py-2.5 rounded-lg bg-slate-700 border border-slate-600 text-slate-100 placeholder-slate-500 text-sm focus:outline-none focus:border-emerald-500 transition-colors"
         />
@@ -106,11 +134,16 @@ function Step1() {
         <input
           type="text"
           value={bootstrapKey}
-          onChange={e => setBootstrapKey(e.target.value)}
+          onChange={e => {
+            setBootstrapKey(e.target.value)
+            if (!e.target.value.trim()) setNameStatus('idle')
+          }}
           placeholder="Enter your Bootstrap Key"
           className="w-full px-3 py-2.5 rounded-lg bg-slate-700 border border-slate-600 text-slate-100 placeholder-slate-500 text-sm focus:outline-none focus:border-emerald-500 transition-colors"
         />
-        <p className="text-slate-500 text-xs">Provided by your IT administrator.</p>
+        <p className="text-slate-500 text-xs">
+          Provided by your IT administrator. For emulator testing use the dev key: <span className="text-slate-400">homepot-dev-emulator-key</span>.
+        </p>
       </div>
 
       <div className="flex flex-col gap-1">
@@ -120,10 +153,22 @@ function Step1() {
         <input
           type="text"
           value={deviceName}
-          onChange={e => setDeviceName(e.target.value)}
+          onChange={e => {
+            setDeviceName(e.target.value)
+            if (!e.target.value.trim()) setNameStatus('idle')
+          }}
           placeholder="e.g. Device-001"
           className="w-full px-3 py-2.5 rounded-lg bg-slate-700 border border-slate-600 text-slate-100 placeholder-slate-500 text-sm focus:outline-none focus:border-emerald-500 transition-colors"
         />
+        {nameStatus === 'checking' && (
+          <p className="text-slate-500 text-xs">Checking name availability…</p>
+        )}
+        {nameStatus === 'available' && (
+          <p className="text-emerald-500 text-xs">✓ Name available</p>
+        )}
+        {nameStatus === 'taken' && (
+          <p className="text-red-400 text-xs">✗ Name already in use in this site — pick a different name.</p>
+        )}
       </div>
 
       <div className="flex flex-col gap-1">
@@ -165,7 +210,7 @@ function Step1() {
 
       <button
         onClick={handleNext}
-        disabled={!siteId.trim() || !bootstrapKey.trim() || !deviceName.trim() || !deviceType}
+        disabled={!siteId.trim() || !bootstrapKey.trim() || !deviceName.trim() || !deviceType || nameStatus === 'taken'}
         className="w-full py-3 rounded-lg bg-emerald-600 hover:bg-emerald-500 disabled:bg-slate-700 disabled:text-slate-500 disabled:cursor-not-allowed text-white font-semibold text-sm transition-colors"
       >
         Next →


### PR DESCRIPTION
## What
Adds detection of duplicate device names during User App setup, plus a well-known dev bootstrap key so emulator/simulated provisioning is easy to test.

Stacked on #261 (setup Step 1 polish). Merge #261 first.

## Duplicate device-name detection
- **Backend source of truth:** `bootstrap_provision_device` now rejects provisioning when a live device with the same name (case-insensitive, whitespace-trimmed) already exists in that site → `400 "Device name 'X' is already in use in site 'Y'"`. Retired/unpaired devices are excluded so names can be reused after decommissioning.
- **New endpoint:** `POST /devices/check-name` (bootstrap-key authenticated, mirrors provisioning) → `{ available: bool }`, backed by a new `device_name_exists_in_site` repository query (scoped to the site).
- **User App:** Step 1 Device Name field now runs a debounced (500ms) live check once Site ID + Bootstrap Key + Device Name are present, showing inline "Checking… / ✓ Name available / ✗ already in use", and gates **Next** while the name is taken. Network failures don't block (the backend still enforces at provision time).

## Dev emulator bootstrap key
- New setting `dev_bootstrap_key` (default `homepot-dev-emulator-key`).
- `verify_bootstrap_key(..., allow_dev_key=...)` accepts the well-known key **only outside production** (`is_dev_bootstrap_key` gates on `environment != production`, constant-time compare).
- `bootstrap-provision` accepts it only for `provisioning_source=emulator`; `check-name` accepts it for the inline check. Real-device provisioning with the dev key → 401. Production → always 401.
- Step 1 shows a hint: *"For emulator testing use the dev key: homepot-dev-emulator-key"*.
- Runbook updated (`docs/verify-user-app-with-emulator.md`): dev-key shortcut in Step 2, live name check in Step 4, and troubleshooting rows for the duplicate-name rejection.

## Verification
- Backend: 14/14 `test_dev_server_smoke.py` (8 new tests: check-name auth/availability, case-insensitive duplicate rejection, cross-site allowed, dev-key provisioning/rejection-in-production/rejection-for-physical, check-name with dev key)
- Frontend: 77/77 vitest (3 new Step 1 tests)
- mypy (workflow command): clean in 159 files · black/isort/flake8: clean · tsc: clean · vite build: clean