### PR TITLE
feat: verify User App bootstrap credentials

### DIFF
--- a/backend/src/homepot/app/api/API_v1/Endpoints/DeviceBootstrapProvisionEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DeviceBootstrapProvisionEndpoint.py
@@ -7,22 +7,53 @@ devices to self-enrol without a user login session.
 import logging
 from typing import Any, Dict
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 
 from homepot.app.auth_utils import verify_bootstrap_key
 from homepot.app.schemas.bootstrap import (
     BootstrapProvisionRequest,
     BootstrapProvisionResponse,
+    BootstrapVerificationRequest,
+    BootstrapVerificationResponse,
     DeviceNameCheckRequest,
     DeviceNameCheckResponse,
 )
 from homepot.app.services.agent_service import AgentService
+from homepot.app.utils.limiter import limiter
 from homepot.database import get_db
 from homepot.models import Site
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+
+@router.post(
+    "/verify-bootstrap",
+    tags=["Devices"],
+    response_model=Dict[str, Any],
+)
+@limiter.limit("10/minute")
+def verify_bootstrap_credentials(
+    payload: BootstrapVerificationRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+) -> Dict[str, Any]:
+    """Verify a site/bootstrap-key pair without revealing which value failed."""
+    site = db.query(Site).filter(Site.site_id == payload.site_id).first()
+    verified = bool(
+        site
+        and verify_bootstrap_key(
+            payload.bootstrap_key,
+            site,
+            allow_dev_key=True,
+        )
+    )
+    response_data = BootstrapVerificationResponse(verified=verified)
+    return {
+        "status": "success",
+        "data": response_data.model_dump(),
+    }
 
 
 @router.post(

--- a/backend/src/homepot/app/schemas/bootstrap.py
+++ b/backend/src/homepot/app/schemas/bootstrap.py
@@ -66,6 +66,19 @@ class BootstrapKeyResponse(BaseModel):
     message: str
 
 
+class BootstrapVerificationRequest(BaseModel):
+    """Request schema for the non-mutating pre-enrolment handshake."""
+
+    site_id: str = Field(..., min_length=1, description="Business site ID")
+    bootstrap_key: str = Field(..., min_length=1, description="Site bootstrap key")
+
+
+class BootstrapVerificationResponse(BaseModel):
+    """Generic result that does not reveal which credential was invalid."""
+
+    verified: bool
+
+
 class DeviceNameCheckRequest(BaseModel):
     """Request schema for checking device-name availability in a site."""
 

--- a/backend/tests/test_dev_server_smoke.py
+++ b/backend/tests/test_dev_server_smoke.py
@@ -362,6 +362,33 @@ def _generate_bootstrap_key(client: TestClient, site_id: str = "smoke-site-001")
 class TestBootstrapProvisionDuplicateNames:
     """Duplicate device names within a site must be detected."""
 
+    def test_verify_bootstrap_credentials_returns_generic_result(
+        self, client: TestClient, seeded_db: Any
+    ) -> None:
+        """The handshake verifies the pair without exposing which value failed."""
+        key = _generate_bootstrap_key(client)
+
+        valid = client.post(
+            "/api/v1/devices/verify-bootstrap",
+            json={"site_id": "smoke-site-001", "bootstrap_key": key},
+        )
+        assert valid.status_code == 200, valid.text
+        assert valid.json()["data"]["verified"] is True
+
+        invalid_key = client.post(
+            "/api/v1/devices/verify-bootstrap",
+            json={"site_id": "smoke-site-001", "bootstrap_key": "wrong-key"},
+        )
+        assert invalid_key.status_code == 200, invalid_key.text
+        assert invalid_key.json()["data"]["verified"] is False
+
+        invalid_site = client.post(
+            "/api/v1/devices/verify-bootstrap",
+            json={"site_id": "unknown-site", "bootstrap_key": key},
+        )
+        assert invalid_site.status_code == 200, invalid_site.text
+        assert invalid_site.json()["data"]["verified"] is False
+
     def test_check_name_rejects_invalid_key(
         self, client: TestClient, seeded_db: Any
     ) -> None:
@@ -465,6 +492,20 @@ class TestBootstrapProvisionDuplicateNames:
 
 class TestDevEmulatorBootstrapKey:
     """The well-known dev key works for emulator provisioning outside production."""
+
+    def test_verify_bootstrap_accepts_dev_key(
+        self, client: TestClient, seeded_db: Any
+    ) -> None:
+        """The pre-enrolment handshake accepts the configured non-production key."""
+        resp = client.post(
+            "/api/v1/devices/verify-bootstrap",
+            json={
+                "site_id": "smoke-site-001",
+                "bootstrap_key": "homepot-dev-emulator-key",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"]["verified"] is True
 
     def test_emulator_dev_key_provisions_in_development(
         self, client: TestClient, seeded_db: Any

--- a/docs/device-emulators.md
+++ b/docs/device-emulators.md
@@ -266,9 +266,24 @@ Credentials live at `~/.homepot/emulators/<device_name>.json` with `0600` permis
 
 Emulators can run multiple instances simultaneously by using different `device_name` values (each gets its own credentials file and provisions independently).
 
-## User App integration (design sketch)
+## User App integration
 
 The emulator can be spawned and managed directly from the User App's Electron shell, giving developers the full "real device" experience — the setup wizard provisions a device, the emulator starts as a background process, and the User App shows/manages it just like a physical device.
+
+This integration is implemented for the Linux POS and Android POS emulators.
+Run the Electron workflow with `cd user_app && npm run electron:dev`; the
+browser-only server at `http://localhost:5174` can perform the setup handshake
+but cannot spawn an emulator process.
+
+Before mode selection, Setup Step 1 performs the pre-enrolment handshake:
+
+1. Site ID entry prompts for the administrator-provided bootstrap key.
+2. The Site ID/key pair is verified together through
+  `POST /devices/verify-bootstrap`; invalid pairs receive one generic result.
+3. Device-name availability is checked within the verified site through
+  `POST /devices/check-name`.
+4. **Next** is enabled only after site credentials are verified, the device
+  name is available, and the local required fields are complete.
 
 ### Architecture
 
@@ -299,7 +314,7 @@ User App (Electron)
   └──────────────────────────────┘
 ```
 
-### New IPC handlers (Electron main)
+### IPC handlers (Electron main)
 
 | Channel | Direction | Purpose |
 |---------|-----------|---------|
@@ -307,7 +322,7 @@ User App (Electron)
 | `emulator:stop` | Renderer → Main | Kill the emulator child process |
 | `emulator:status` | Renderer → Main | Return `{running: bool, pid, device_id}` |
 
-### SetupWizard flow change
+### SetupWizard flow
 
 1. **Step 1** (existing): Site ID, hostname, device type, OS
 2. **Step 2** (new): Mode selection — "Real device" (current flow) or **"Launch emulator"**
@@ -392,14 +407,13 @@ interface EmulatorStartConfig {
 └─────────────────────────────────────────┘
 ```
 
-### Implementation order
+### Implementation status
 
-1. Add `emulator:start`, `emulator:stop`, `emulator:status` IPC handlers to `electron/main.ts`
-2. Expose emulator channels in `electron/preload.ts`
-3. Update `SetupWizard.tsx` — add mode selection step and emulator type picker
-4. Add `EmulatorStartConfig` type to `credentialStorage.ts` or a new types file
-5. Update `AppContext.tsx` — add emulator state (`isEmulatorRunning`, `emulatorType`)
-6. Wire ReviewStep to call `window.electronAPI.emulator.start()` instead of the dev-mode mock path
+1. `emulator:start`, `emulator:stop`, and `emulator:status` IPC handlers are implemented in `electron/main.ts`.
+2. Emulator channels are exposed through `electron/preload.ts`.
+3. `SetupWizard.tsx` includes mode selection and Linux/Android emulator type selection.
+4. `AppContext.tsx` tracks emulator mode, type, and runtime state.
+5. Review completion calls `window.electronAPI.emulator.start()` in Electron emulator mode.
 
 ## Related documentation
 

--- a/docs/verify-user-app-with-emulator.md
+++ b/docs/verify-user-app-with-emulator.md
@@ -109,25 +109,17 @@ Open http://localhost:5173 and log in. A seeded admin exists:
 | Location | `localhost` |
 | Description | *(optional)* |
 
-**Option B — via the API**:
+Record the following values for the User App Setup wizard used later in this
+runbook. The Site ID must match the site created above, and the bootstrap key
+must be the key generated for that site in Step 2.
 
-```bash
-# login, capture the bearer token
-TOKEN=$(curl -s -X POST http://localhost:8000/api/v1/auth/login \
-  -H 'Content-Type: application/json' \
-  -d '{"email":"admin@homepot.com","password":"homepot_dev_password"}' \
-  | python3 -c 'import sys,json;print(json.load(sys.stdin)["data"]["access_token"])')
-
-# create the site
-curl -X POST http://localhost:8000/api/v1/sites/ \
-  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
-  -d '{
-    "site_id": "site-it-demo1",
-    "name": "Demo Site 1",
-    "description": "Created by technician",
-    "location": "localhost"
-  }'
-```
+| Setup field | Value for this runbook |
+| ----------- | ---------------------- |
+| Site ID | `site-it-demo1` |
+| Bootstrap Key | The generated key from Step 2, or `homepot-dev-emulator-key` for development-only emulator testing |
+| Device Name | A unique name such as `demo-linux-pos-1` |
+| Device Type | `POS Terminal` |
+| Operating System | `Auto-detect` — this initially identifies the machine running the User App; selecting Linux POS later replaces it with the emulator OS |
 
 Expected response: `200` with `{"message": "...", "site_id": "site-it-demo1", ...}`.
 
@@ -182,6 +174,44 @@ handed-off site info: enter the **Site ID**, the **Bootstrap Key**, a
 **Device Name**, and pick a device type. As you type the device name, the
 wizard checks live that the name isn't already in use in the site (using
 `POST /devices/check-name`) and blocks proceeding if it is.
+
+Setup Step 1 uses a non-mutating pre-enrolment handshake:
+
+1. Entering a Site ID prompts the user to enter the administrator-provided
+  bootstrap key. The app does not reveal whether the Site ID exists by itself.
+2. Once both values are present, `POST /devices/verify-bootstrap` verifies the
+  pair and returns only a generic verified/not-verified result. The device-name
+  field remains locked until this succeeds.
+3. The unlocked device-name field calls `POST /devices/check-name`. **Next**
+  remains disabled until the name is confirmed available and the other
+  required fields are complete.
+
+Changing the Site ID or bootstrap key clears both verification results and
+locks the device-name field again. Changing the device name clears its previous
+availability result immediately. Final provisioning repeats all authoritative
+checks because the setup handshake does not reserve a name.
+
+### Known validation gap — real-device OS detection
+
+This runbook validates an emulated Linux device; it does not yet validate OS
+detection on physical devices. In the Electron User App, **Auto-detect** uses
+the native device-DNA bridge and falls back to browser platform information
+only when that bridge is unavailable. Therefore, seeing **Windows** while the
+User App runs on a Windows workstation is correct. After **Launch emulated
+device** and **Linux POS** are selected, the review screen and provisioning
+payload must instead show `Linux 6.8.0 (Debian 12)`. Android POS must similarly
+show `Android 14`.
+
+Track physical-device verification separately before calling real-device setup
+validated:
+
+- Run the packaged Electron User App on supported Windows and Linux devices.
+- Confirm **Auto-detect** resolves to the physical device's OS on the review
+  screen and in the backend `os_details` value.
+- Confirm explicitly selecting an OS still overrides auto-detection.
+- Add equivalent checks when native Android, iOS, or other OS clients are
+  implemented. The current emulator launcher supports only Linux POS and
+  Android POS identities.
 
 > **Note:** in dev mode the wizard simulates completion with local dev
 > credentials and does **not** call the backend. The actual backend-facing

--- a/user_app/src/services/api.ts
+++ b/user_app/src/services/api.ts
@@ -190,6 +190,23 @@ export async function bootstrapProvision(body: {
   return json.data
 }
 
+export async function verifyBootstrapCredentials(body: {
+  site_id: string
+  bootstrap_key: string
+}): Promise<{ verified: boolean }> {
+  const res = await fetch(`${apiBaseUrl}/devices/verify-bootstrap`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}))
+    throw asApiError(err.detail || `Site verification failed (${res.status})`, res.status)
+  }
+  const json = await res.json()
+  return json.data
+}
+
 export async function checkDeviceName(body: {
   site_id: string
   bootstrap_key: string

--- a/user_app/src/test/api.test.ts
+++ b/user_app/src/test/api.test.ts
@@ -7,6 +7,7 @@ import {
   updatePermissions,
   verifyDeviceCredentials,
   bootstrapProvision,
+  verifyBootstrapCredentials,
   claimDevice,
   unpairDevice,
   fetchPendingCommands,
@@ -254,6 +255,31 @@ describe('bootstrapProvision', () => {
     })
     expect(result.device_id).toBe('d1')
     expect(result.api_key).toBe('k1')
+  })
+})
+
+describe('verifyBootstrapCredentials', () => {
+  it('POSTs the Site ID/key pair and returns the generic result', async () => {
+    mockFetch.mockResolvedValueOnce(ok({ data: { verified: true } }))
+    await expect(verifyBootstrapCredentials({
+      site_id: 'site-001',
+      bootstrap_key: 'bk-123',
+    })).resolves.toEqual({ verified: true })
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/devices/verify-bootstrap'),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ site_id: 'site-001', bootstrap_key: 'bk-123' }),
+      }),
+    )
+  })
+
+  it('throws when verification is unavailable', async () => {
+    mockFetch.mockResolvedValueOnce(serverError('Unavailable'))
+    await expect(verifyBootstrapCredentials({
+      site_id: 'site-001',
+      bootstrap_key: 'bk-123',
+    })).rejects.toThrow('Unavailable')
   })
 })
 

--- a/user_app/src/test/setupWizard.test.tsx
+++ b/user_app/src/test/setupWizard.test.tsx
@@ -9,6 +9,11 @@ globalThis.fetch = mockFetch
 
 function setupFetchMock(available = true) {
   mockFetch.mockImplementation((url: string) => {
+    if (String(url).includes('/verify-bootstrap')) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ data: { verified: true } }), { status: 200 }),
+      )
+    }
     if (String(url).includes('/check-name')) {
       return Promise.resolve(
         new Response(JSON.stringify({ data: { available } }), { status: 200 }),
@@ -37,6 +42,7 @@ function fillRequiredFields() {
 
 afterEach(() => {
   delete (navigator as { userAgentData?: unknown }).userAgentData
+  delete window.electronAPI
 })
 
 beforeEach(() => {
@@ -54,28 +60,34 @@ describe('SetupWizard Step 1', () => {
 
   it('shows a neutral "-" option first in Device Type', () => {
     renderSetup()
-    const [deviceType] = screen.getAllByRole('combobox')
+    const [deviceType] = screen.getAllByRole('combobox') as HTMLSelectElement[]
     expect(deviceType.value).toBe('')
     expect(deviceType.options[0].text).toBe('-')
   })
 
   it('defaults Operating System to Auto-detect', () => {
     renderSetup()
-    const [, deviceOs] = screen.getAllByRole('combobox')
+    const [, deviceOs] = screen.getAllByRole('combobox') as HTMLSelectElement[]
     expect(deviceOs.value).toBe('auto')
     expect(deviceOs.options[0].text).toBe('Auto-detect')
   })
 
-  it('keeps Next disabled until device type is selected', () => {
+  it('keeps Next disabled until credentials and name are verified', async () => {
     renderSetup()
     const next = screen.getByRole('button', { name: /next/i })
     expect(next).toBeDisabled()
     fireEvent.change(screen.getByPlaceholderText('Enter your Site ID'), { target: { value: 'site-001' } })
+    expect(screen.getByText(/enter the bootstrap key provided/i)).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('e.g. Device-001')).toBeDisabled()
+    fireEvent.change(screen.getByPlaceholderText('Enter your Bootstrap Key'), { target: { value: 'bk-abc123' } })
+    expect(next).toBeDisabled()
+    expect(await screen.findByText('✓ Site credentials verified')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('e.g. Device-001')).toBeEnabled()
     fireEvent.change(screen.getByPlaceholderText('e.g. Device-001'), { target: { value: 'Device-001' } })
     expect(next).toBeDisabled()
     fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: 'kiosk' } })
     expect(next).toBeDisabled()
-    fireEvent.change(screen.getByPlaceholderText('Enter your Bootstrap Key'), { target: { value: 'bk-abc123' } })
+    expect(await screen.findByText('✓ Name available')).toBeInTheDocument()
     expect(next).toBeEnabled()
   })
 
@@ -88,6 +100,7 @@ describe('SetupWizard Step 1', () => {
     renderSetup()
     fireEvent.change(screen.getByPlaceholderText('Enter your Site ID'), { target: { value: 'site-001' } })
     fireEvent.change(screen.getByPlaceholderText('Enter your Bootstrap Key'), { target: { value: 'bk-abc123' } })
+    expect(await screen.findByText('✓ Site credentials verified')).toBeInTheDocument()
     fireEvent.change(screen.getByPlaceholderText('e.g. Device-001'), { target: { value: 'Device-001' } })
     expect(await screen.findByText('✓ Name available')).toBeInTheDocument()
   })
@@ -98,21 +111,83 @@ describe('SetupWizard Step 1', () => {
     const next = screen.getByRole('button', { name: /next/i })
     fireEvent.change(screen.getByPlaceholderText('Enter your Site ID'), { target: { value: 'site-001' } })
     fireEvent.change(screen.getByPlaceholderText('Enter your Bootstrap Key'), { target: { value: 'bk-abc123' } })
+    expect(await screen.findByText('✓ Site credentials verified')).toBeInTheDocument()
     fireEvent.change(screen.getByPlaceholderText('e.g. Device-001'), { target: { value: 'Device-001' } })
     fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: 'kiosk' } })
-    expect(next).toBeEnabled()
+    expect(next).toBeDisabled()
     expect(await screen.findByText(/already in use/)).toBeInTheDocument()
     expect(next).toBeDisabled()
+  })
+
+  it('keeps the name locked when site credentials are invalid', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (String(url).includes('/verify-bootstrap')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ data: { verified: false } }), { status: 200 }),
+        )
+      }
+      return Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))
+    })
+    renderSetup()
+    fireEvent.change(screen.getByPlaceholderText('Enter your Site ID'), { target: { value: 'site-001' } })
+    fireEvent.change(screen.getByPlaceholderText('Enter your Bootstrap Key'), { target: { value: 'wrong-key' } })
+    expect(await screen.findByText(/Site ID or bootstrap key is incorrect/)).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('e.g. Device-001')).toBeDisabled()
+    expect(screen.getByRole('button', { name: /next/i })).toBeDisabled()
+  })
+
+  it('clears downstream verification when site credentials change', async () => {
+    renderSetup()
+    fillRequiredFields()
+    expect(await screen.findByText('✓ Site credentials verified')).toBeInTheDocument()
+    expect(await screen.findByText('✓ Name available')).toBeInTheDocument()
+    fireEvent.change(screen.getByPlaceholderText('Enter your Site ID'), { target: { value: 'site-002' } })
+    expect(screen.queryByText('✓ Site credentials verified')).not.toBeInTheDocument()
+    expect(screen.queryByText('✓ Name available')).not.toBeInTheDocument()
+    expect(screen.getByPlaceholderText('e.g. Device-001')).toBeDisabled()
+    expect(screen.getByRole('button', { name: /next/i })).toBeDisabled()
   })
 
   it('resolves the auto-detected OS before proceeding', async () => {
     Object.defineProperty(navigator, 'userAgentData', { value: { platform: 'Android' }, configurable: true })
     renderSetup()
-    fillRequiredFields()
+    fireEvent.change(screen.getByPlaceholderText('Enter your Site ID'), { target: { value: 'site-001' } })
+    fireEvent.change(screen.getByPlaceholderText('Enter your Bootstrap Key'), { target: { value: 'bk-abc123' } })
+    expect(await screen.findByText('✓ Site credentials verified')).toBeInTheDocument()
+    fireEvent.change(screen.getByPlaceholderText('e.g. Device-001'), { target: { value: 'Device-001' } })
+    fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: 'kiosk' } })
+    expect(await screen.findByText('✓ Name available')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /next/i }))
     expect(await screen.findByText('Setup Method')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Back' }))
-    const [, deviceOs] = screen.getAllByRole('combobox')
+    const [, deviceOs] = screen.getAllByRole('combobox') as HTMLSelectElement[]
     expect(deviceOs.value).toBe('android')
+  })
+
+  it('prefers the native Electron OS over browser detection', async () => {
+    Object.defineProperty(navigator, 'userAgentData', { value: { platform: 'Windows' }, configurable: true })
+    window.electronAPI = {
+      device: {
+        dna: vi.fn().mockResolvedValue({
+          hostname: 'device-001',
+          platform: 'linux',
+          release: '6.8.0',
+          mac: '00:00:00:00:00:00',
+          ip: '127.0.0.1',
+        }),
+      },
+    } as unknown as NonNullable<Window['electronAPI']>
+    renderSetup()
+    fireEvent.change(screen.getByPlaceholderText('Enter your Site ID'), { target: { value: 'site-001' } })
+    fireEvent.change(screen.getByPlaceholderText('Enter your Bootstrap Key'), { target: { value: 'bk-abc123' } })
+    expect(await screen.findByText('✓ Site credentials verified')).toBeInTheDocument()
+    fireEvent.change(screen.getByPlaceholderText('e.g. Device-001'), { target: { value: 'Device-001' } })
+    fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: 'kiosk' } })
+    expect(await screen.findByText('✓ Name available')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /next/i }))
+    expect(await screen.findByText('Setup Method')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+    const [, deviceOs] = screen.getAllByRole('combobox') as HTMLSelectElement[]
+    expect(deviceOs.value).toBe('linux')
   })
 })

--- a/user_app/src/views/SetupWizard.tsx
+++ b/user_app/src/views/SetupWizard.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom'
 import { useApp } from '../context/AppContext'
 import { apiBaseUrl } from '../config/api'
 import { credentialStorage } from '../services/credentialStorage'
-import { bootstrapProvision, checkDeviceName } from '../services/api'
+import { bootstrapProvision, checkDeviceName, verifyBootstrapCredentials } from '../services/api'
 
 const EMULATOR_TYPES: { value: string; label: string; os: string; description: string }[] = [
   { value: 'linux_pos', label: 'Linux POS', os: 'Linux 6.8.0 (Debian 12)', description: 'Simulates a Linux-based POS terminal' },
@@ -14,24 +14,43 @@ function formatDeviceType(v: string) {
   return v.replace('_', ' ').replace(/\b\w/g, c => c.toUpperCase())
 }
 
-function detectOS(): string {
+function normalizeOS(platform: string): string | null {
+  const value = platform.toLowerCase()
+  if (value.includes('android')) return 'android'
+  if (value.includes('iphone') || value.includes('ipad') || value.includes('ios')) return 'ios'
+  if (value.includes('darwin') || value.includes('mac')) return 'mac'
+  if (value.includes('win')) return 'windows'
+  if (value.includes('linux')) return 'linux'
+  return null
+}
+
+function detectBrowserOS(): string {
   const uaData = (navigator as unknown as { userAgentData?: { platform?: string } }).userAgentData
   if (uaData?.platform) {
-    const p = uaData.platform.toLowerCase()
-    if (p.includes('android')) return 'android'
-    if (p.includes('iphone') || p.includes('ipad') || p.includes('ios')) return 'ios'
-    if (p.includes('mac')) return 'mac'
-    if (p.includes('win')) return 'windows'
-    if (p.includes('linux')) return 'linux'
+    const detected = normalizeOS(uaData.platform)
+    if (detected) return detected
   }
   const platform = navigator.platform.toLowerCase()
   const ua = navigator.userAgent.toLowerCase()
   if (ua.includes('android')) return 'android'
   if (/iphone|ipad|ipod/.test(ua)) return 'ios'
-  if (platform.includes('mac')) return 'mac'
-  if (platform.includes('win')) return 'windows'
-  if (platform.includes('linux') || ua.includes('cros')) return 'linux'
+  const detected = normalizeOS(platform)
+  if (detected) return detected
+  if (ua.includes('cros')) return 'linux'
   return 'web'
+}
+
+async function detectOS(): Promise<string> {
+  try {
+    const nativePlatform = (await window.electronAPI?.device.dna())?.platform
+    if (nativePlatform) {
+      const detected = normalizeOS(nativePlatform)
+      if (detected) return detected
+    }
+  } catch {
+    // Fall back to browser detection if the native bridge is unavailable.
+  }
+  return detectBrowserOS()
 }
 
 function StepIndicator({ current }: { current: number }) {
@@ -71,12 +90,32 @@ function Step1() {
   const [deviceType, setDeviceType] = useState(setupState.deviceType)
   const [deviceOs, setDeviceOs] = useState(setupState.deviceOs)
   const [bootstrapKey, setBootstrapKey] = useState(setupState.bootstrapKey)
+  const [credentialStatus, setCredentialStatus] = useState<'idle' | 'checking' | 'verified' | 'invalid' | 'unavailable'>('idle')
   const [nameStatus, setNameStatus] = useState<'idle' | 'checking' | 'available' | 'taken'>('idle')
 
   useEffect(() => {
-    if (!siteId.trim() || !bootstrapKey.trim() || !deviceName.trim()) {
-      return
+    if (!siteId.trim() || !bootstrapKey.trim()) return
+    let cancelled = false
+    const timer = setTimeout(async () => {
+      setCredentialStatus('checking')
+      try {
+        const res = await verifyBootstrapCredentials({
+          site_id: siteId.trim(),
+          bootstrap_key: bootstrapKey.trim(),
+        })
+        if (!cancelled) setCredentialStatus(res.verified ? 'verified' : 'invalid')
+      } catch {
+        if (!cancelled) setCredentialStatus('unavailable')
+      }
+    }, 500)
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
     }
+  }, [siteId, bootstrapKey])
+
+  useEffect(() => {
+    if (credentialStatus !== 'verified' || !deviceName.trim()) return
     let cancelled = false
     const timer = setTimeout(async () => {
       setNameStatus('checking')
@@ -95,10 +134,10 @@ function Step1() {
       cancelled = true
       clearTimeout(timer)
     }
-  }, [siteId, bootstrapKey, deviceName])
+  }, [credentialStatus, siteId, bootstrapKey, deviceName])
 
-  const handleNext = () => {
-    const resolvedOs = deviceOs === 'auto' ? detectOS() : deviceOs
+  const handleNext = async () => {
+    const resolvedOs = deviceOs === 'auto' ? await detectOS() : deviceOs
     setSetupState({ siteId, deviceName, deviceType, deviceOs: resolvedOs, bootstrapKey })
     navigate('/method')
   }
@@ -119,12 +158,17 @@ function Step1() {
           value={siteId}
           onChange={e => {
             setSiteId(e.target.value)
-            if (!e.target.value.trim()) setNameStatus('idle')
+            setCredentialStatus('idle')
+            setNameStatus('idle')
           }}
           placeholder="Enter your Site ID"
           className="w-full px-3 py-2.5 rounded-lg bg-slate-700 border border-slate-600 text-slate-100 placeholder-slate-500 text-sm focus:outline-none focus:border-emerald-500 transition-colors"
         />
-        <p className="text-slate-500 text-xs">Provided by your IT administrator.</p>
+        <p className="text-slate-500 text-xs">
+          {siteId.trim()
+            ? 'Enter the bootstrap key provided by your administrator to verify this site.'
+            : 'Provided by your IT administrator.'}
+        </p>
       </div>
 
       <div className="flex flex-col gap-1">
@@ -136,7 +180,8 @@ function Step1() {
           value={bootstrapKey}
           onChange={e => {
             setBootstrapKey(e.target.value)
-            if (!e.target.value.trim()) setNameStatus('idle')
+            setCredentialStatus('idle')
+            setNameStatus('idle')
           }}
           placeholder="Enter your Bootstrap Key"
           className="w-full px-3 py-2.5 rounded-lg bg-slate-700 border border-slate-600 text-slate-100 placeholder-slate-500 text-sm focus:outline-none focus:border-emerald-500 transition-colors"
@@ -144,6 +189,18 @@ function Step1() {
         <p className="text-slate-500 text-xs">
           Provided by your IT administrator. For emulator testing use the dev key: <span className="text-slate-400">homepot-dev-emulator-key</span>.
         </p>
+        {credentialStatus === 'checking' && (
+          <p className="text-slate-500 text-xs">Checking site credentials...</p>
+        )}
+        {credentialStatus === 'verified' && (
+          <p className="text-emerald-500 text-xs">✓ Site credentials verified</p>
+        )}
+        {credentialStatus === 'invalid' && (
+          <p className="text-red-400 text-xs">✗ Site ID or bootstrap key is incorrect.</p>
+        )}
+        {credentialStatus === 'unavailable' && (
+          <p className="text-amber-400 text-xs">Unable to verify site credentials. Please try again.</p>
+        )}
       </div>
 
       <div className="flex flex-col gap-1">
@@ -155,11 +212,15 @@ function Step1() {
           value={deviceName}
           onChange={e => {
             setDeviceName(e.target.value)
-            if (!e.target.value.trim()) setNameStatus('idle')
+            setNameStatus('idle')
           }}
           placeholder="e.g. Device-001"
+          disabled={credentialStatus !== 'verified'}
           className="w-full px-3 py-2.5 rounded-lg bg-slate-700 border border-slate-600 text-slate-100 placeholder-slate-500 text-sm focus:outline-none focus:border-emerald-500 transition-colors"
         />
+        {credentialStatus !== 'verified' && (
+          <p className="text-slate-500 text-xs">Verify the Site ID and bootstrap key first.</p>
+        )}
         {nameStatus === 'checking' && (
           <p className="text-slate-500 text-xs">Checking name availability…</p>
         )}
@@ -210,7 +271,7 @@ function Step1() {
 
       <button
         onClick={handleNext}
-        disabled={!siteId.trim() || !bootstrapKey.trim() || !deviceName.trim() || !deviceType || nameStatus === 'taken'}
+        disabled={credentialStatus !== 'verified' || nameStatus !== 'available' || !deviceType}
         className="w-full py-3 rounded-lg bg-emerald-600 hover:bg-emerald-500 disabled:bg-slate-700 disabled:text-slate-500 disabled:cursor-not-allowed text-white font-semibold text-sm transition-colors"
       >
         Next →


### PR DESCRIPTION
## Summary

- add a generic, rate-limited pre-enrolment endpoint that verifies the Site ID/bootstrap-key pair without exposing which value failed
- gate User App Setup progression on verified credentials and confirmed device-name availability
- clear stale verification state when credentials or device names change
- prefer Electron native device DNA for OS detection, with browser detection as a fallback
- document emulator setup values, OS identity behavior, and the remaining physical-device validation gap

## Validation

- `pytest backend/tests/test_dev_server_smoke.py -q` (16 passed)
- `cd user_app && npm run build`
- `cd user_app && npm test` (82 passed)
- `git diff --check`

## Out of scope

The Method page at `/method` will be inspected and tested in a separate follow-up PR.