### PR TITLE
feat: complete User App emulator setup flow

### DIFF
--- a/docs/verify-user-app-with-emulator.md
+++ b/docs/verify-user-app-with-emulator.md
@@ -169,8 +169,8 @@ In **Terminal 2**, first start the HOMEPOT **User App** — the device-side UI (
 ./scripts/start-userapp.sh
 ```
 
-Open http://localhost:5174 — the setup wizard opens. Walk through it with the
-handed-off site info: enter the **Site ID**, the **Bootstrap Key**, a
+The **HOMEPOT Agent** Electron window opens with the setup wizard. Walk through
+it with the handed-off site info: enter the **Site ID**, the **Bootstrap Key**, a
 **Device Name**, and pick a device type. As you type the device name, the
 wizard checks live that the name isn't already in use in the site (using
 `POST /devices/check-name`) and blocks proceeding if it is.

--- a/scripts/start-userapp.sh
+++ b/scripts/start-userapp.sh
@@ -134,8 +134,8 @@ if command_exists nvm; then
     nvm use 22 2>/dev/null || true
 fi
 
-print_info "Starting User App server on http://localhost:5174..."
-nohup npm run dev > "$REPO_ROOT/logs/userapp.log" 2>&1 &
+print_info "Starting Electron User App on http://localhost:5174..."
+nohup npm run electron:dev > "$REPO_ROOT/logs/userapp.log" 2>&1 &
 USERAPP_PID=$!
 echo $USERAPP_PID > "$REPO_ROOT/logs/userapp.pid"
 
@@ -173,7 +173,7 @@ echo -e "  ${CYAN}View logs:${NC}  tail -f $REPO_ROOT/logs/userapp.log"
 echo -e "  ${CYAN}Stop app:${NC}   kill \$(cat $REPO_ROOT/logs/userapp.pid)"
 echo ""
 echo -e "${GREEN}Next Steps:${NC}"
-echo -e "  1. User App is ready."
-echo -e "  2. Please open ${BLUE}http://localhost:5174${NC} manually in your browser."
+echo -e "  1. The Electron User App is ready."
+echo -e "  2. Complete setup in the ${BLUE}HOMEPOT Agent${NC} desktop window."
 echo ""
 exit 0

--- a/user_app/electron/main.ts
+++ b/user_app/electron/main.ts
@@ -1,8 +1,11 @@
-import { app, BrowserWindow, ipcMain, Tray, Menu, nativeImage, shell } from 'electron'
+import { app, BrowserWindow, ipcMain, Tray, Menu, nativeImage } from 'electron'
 import path from 'node:path'
 import fs from 'node:fs'
 import os from 'node:os'
 import { spawn, type ChildProcess } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const CREDENTIALS_DIR = path.join(os.homedir(), '.homepot')
 const CREDENTIALS_FILE = path.join(CREDENTIALS_DIR, 'credentials')
@@ -30,7 +33,7 @@ function createWindow() {
     fullscreenable: false,
     title: 'HOMEPOT Agent',
     webPreferences: {
-      preload: path.join(__dirname, 'preload.mjs'),
+      preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: false,
@@ -103,6 +106,7 @@ function readCredentialsFile(): Record<string, string> {
       return JSON.parse(raw)
     }
   } catch {
+    // Invalid or unreadable credentials are treated as absent.
   }
   return {}
 }
@@ -121,6 +125,7 @@ function getOrCreateDeviceIdentity(): { deviceId: string; machineId: string } {
       return JSON.parse(raw)
     }
   } catch {
+    // Invalid or unreadable identity data is replaced below.
   }
 
   const machineId = os.hostname()
@@ -152,6 +157,7 @@ function registerIpcHandlers() {
         fs.unlinkSync(CREDENTIALS_FILE)
       }
     } catch {
+      // Clearing an already unavailable credentials file is idempotent.
     }
     return true
   })
@@ -241,7 +247,7 @@ function registerIpcHandlers() {
       throw new Error(`Emulator script not found: ${emulatorScript}`)
     }
 
-    const pythonExe = findPython()
+    const pythonExe = findPython(projectRoot)
     emulatorProcess = spawn(pythonExe, [emulatorScript, '--config', configPath], {
       cwd: projectRoot,
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -306,10 +312,10 @@ function killEmulator(): void {
   }
 }
 
-function findPython(): string {
+function findPython(projectRoot: string): string {
   const candidates = [
-    path.join(process.cwd(), '.venv', 'bin', 'python3'),
-    path.join(process.cwd(), '.venv', 'Scripts', 'python.exe'),
+    path.join(projectRoot, '.venv', 'bin', 'python3'),
+    path.join(projectRoot, '.venv', 'Scripts', 'python.exe'),
     'python3',
     'python',
   ]
@@ -325,10 +331,20 @@ function findPython(): string {
 }
 
 function getProjectRoot(): string {
-  if (process.env.VITE_DEV_SERVER_URL) {
-    return process.cwd()
+  let candidate = process.env.VITE_DEV_SERVER_URL
+    ? process.cwd()
+    : path.dirname(app.getAppPath())
+
+  while (true) {
+    if (fs.existsSync(path.join(candidate, 'emulators'))) {
+      return candidate
+    }
+    const parent = path.dirname(candidate)
+    if (parent === candidate) {
+      return process.env.VITE_DEV_SERVER_URL ? process.cwd() : path.dirname(app.getAppPath())
+    }
+    candidate = parent
   }
-  return path.dirname(app.getAppPath())
 }
 
 function pollForCredentials(credsPath: string, timeoutMs: number): Promise<Record<string, string> | null> {

--- a/user_app/src/context/AppContext.tsx
+++ b/user_app/src/context/AppContext.tsx
@@ -26,8 +26,8 @@ interface AppContextType {
   provisionedChecked: boolean
   setupState: SetupState
   setSetupState: (state: SetupState) => void
-  useEmulator: boolean
-  setUseEmulator: (val: boolean) => void
+  useEmulator: boolean | null
+  setUseEmulator: (val: boolean | null) => void
   emulatorType: string
   setEmulatorType: (val: string) => void
   isEmulatorRunning: boolean
@@ -47,7 +47,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
     deviceOs: 'auto',
     bootstrapKey: '',
   })
-  const [useEmulator, setUseEmulator] = useState(false)
+  const [useEmulator, setUseEmulator] = useState<boolean | null>(null)
   const [emulatorType, setEmulatorType] = useState('linux_pos')
   const [isEmulatorRunning, setIsEmulatorRunning] = useState(false)
 

--- a/user_app/src/test/setupWizard.test.tsx
+++ b/user_app/src/test/setupWizard.test.tsx
@@ -24,8 +24,12 @@ function setupFetchMock(available = true) {
 }
 
 function renderSetup() {
+  return renderSetupAt('/setup')
+}
+
+function renderSetupAt(path: string) {
   return render(
-    <MemoryRouter initialEntries={['/setup']}>
+    <MemoryRouter initialEntries={[path]}>
       <AppProvider>
         <SetupWizard />
       </AppProvider>
@@ -38,6 +42,24 @@ function fillRequiredFields() {
   fireEvent.change(screen.getByPlaceholderText('Enter your Bootstrap Key'), { target: { value: 'bk-abc123' } })
   fireEvent.change(screen.getByPlaceholderText('e.g. Device-001'), { target: { value: 'Device-001' } })
   fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: 'kiosk' } })
+}
+
+async function proceedToMethod() {
+  fillRequiredFields()
+  expect(await screen.findByText('✓ Site credentials verified')).toBeInTheDocument()
+  expect(await screen.findByText('✓ Name available')).toBeInTheDocument()
+  fireEvent.click(screen.getByRole('button', { name: /next/i }))
+  expect(await screen.findByText('Setup Method')).toBeInTheDocument()
+}
+
+async function proceedToEmulatorReview(profile?: RegExp) {
+  await proceedToMethod()
+  fireEvent.click(screen.getByRole('button', { name: /launch emulated device/i }))
+  fireEvent.click(screen.getByRole('button', { name: /next/i }))
+  expect(await screen.findByText('Configure Emulator')).toBeInTheDocument()
+  if (profile) fireEvent.click(screen.getByRole('button', { name: profile }))
+  fireEvent.click(screen.getByRole('button', { name: /next/i }))
+  expect(await screen.findByText('Review Settings')).toBeInTheDocument()
 }
 
 afterEach(() => {
@@ -189,5 +211,102 @@ describe('SetupWizard Step 1', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Back' }))
     const [, deviceOs] = screen.getAllByRole('combobox') as HTMLSelectElement[]
     expect(deviceOs.value).toBe('linux')
+  })
+})
+
+describe('SetupWizard Method', () => {
+  it('returns direct visits without completed setup data to Step 1', async () => {
+    renderSetupAt('/method')
+    expect(await screen.findByPlaceholderText('Enter your Site ID')).toBeInTheDocument()
+  })
+
+  it('uses verified setup details for a real device without asking for the key again', async () => {
+    renderSetup()
+    await proceedToMethod()
+    const realDevice = screen.getByRole('button', { name: /set up a real device/i })
+    expect(realDevice).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByText('Step 2 of 4')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /next/i })).toBeDisabled()
+    fireEvent.click(realDevice)
+    expect(realDevice).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByText('Step 2 of 3')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /next/i }))
+    expect(await screen.findByText('Review Settings')).toBeInTheDocument()
+    expect(screen.queryByText('Enter bootstrap key')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(await screen.findByText('Setup Method')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /set up a real device/i })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('routes emulator selection to emulator configuration', async () => {
+    renderSetup()
+    await proceedToMethod()
+    const emulator = screen.getByRole('button', { name: /launch emulated device/i })
+    fireEvent.click(emulator)
+    expect(emulator).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByText('Step 2 of 4')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /next/i }))
+    expect(await screen.findByText('Configure Emulator')).toBeInTheDocument()
+  })
+})
+
+describe('SetupWizard Emulator Review', () => {
+  it('returns direct visits without completed setup data to Step 1', async () => {
+    renderSetupAt('/setup/review')
+    expect(await screen.findByPlaceholderText('Enter your Site ID')).toBeInTheDocument()
+  })
+
+  it('shows the selected emulator identity and blocks launch in browser mode', async () => {
+    renderSetup()
+    await proceedToEmulatorReview()
+    expect(screen.getByRole('link', { name: /Device Setup/ })).toHaveAttribute('href', '/setup')
+    expect(screen.getByRole('link', { name: /Method/ })).toHaveAttribute('href', '/method')
+    expect(screen.getByRole('link', { name: /Emulator/ })).toHaveAttribute('href', '/emulator')
+    expect(screen.getByRole('link', { name: /Complete/ })).toHaveAttribute('href', '/setup/review')
+    expect(screen.getByText('Emulator Profile')).toBeInTheDocument()
+    expect(screen.getByText('Linux POS')).toBeInTheDocument()
+    expect(screen.getByText(/Pos Terminal/i)).toBeInTheDocument()
+    expect(screen.getByText('Linux 6.8.0 (Debian 12)')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Launch Emulator' })).toBeDisabled()
+    expect(screen.getByText(/requires the Electron desktop app/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(await screen.findByText('Configure Emulator')).toBeInTheDocument()
+  })
+
+  it('navigates to reached setup pages from the progress links', async () => {
+    renderSetup()
+    await proceedToEmulatorReview()
+    fireEvent.click(screen.getByRole('link', { name: /Method/ }))
+    expect(await screen.findByText('Setup Method')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /launch emulated device/i })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('launches the selected emulator through Electron with verified setup details', async () => {
+    const start = vi.fn().mockResolvedValue({ deviceId: 'pos-001', apiKey: 'api-key-001' })
+    window.electronAPI = {
+      emulator: { start },
+    } as unknown as NonNullable<Window['electronAPI']>
+    renderSetup()
+    await proceedToEmulatorReview()
+    const launch = screen.getByRole('button', { name: 'Launch Emulator' })
+    expect(launch).toBeEnabled()
+    fireEvent.click(launch)
+    await vi.waitFor(() => {
+      expect(start).toHaveBeenCalledWith(expect.objectContaining({
+        emulatorType: 'linux_pos',
+        siteId: 'site-001',
+        bootstrapKey: 'bk-abc123',
+        deviceName: 'Device-001',
+        deviceType: 'pos_terminal',
+      }))
+    })
+  })
+
+  it('shows Android identity when the Android POS profile is selected', async () => {
+    renderSetup()
+    await proceedToEmulatorReview(/Android POS/i)
+    expect(screen.getByText('Android POS')).toBeInTheDocument()
+    expect(screen.getByText(/Pos Terminal/i)).toBeInTheDocument()
+    expect(screen.getByText('Android 14')).toBeInTheDocument()
   })
 })

--- a/user_app/src/views/SetupWizard.tsx
+++ b/user_app/src/views/SetupWizard.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from 'react'
-import { useNavigate, useLocation } from 'react-router-dom'
+import { Link, useNavigate, useLocation } from 'react-router-dom'
 import { useApp } from '../context/AppContext'
 import { apiBaseUrl } from '../config/api'
 import { credentialStorage } from '../services/credentialStorage'
 import { bootstrapProvision, checkDeviceName, verifyBootstrapCredentials } from '../services/api'
 
-const EMULATOR_TYPES: { value: string; label: string; os: string; description: string }[] = [
-  { value: 'linux_pos', label: 'Linux POS', os: 'Linux 6.8.0 (Debian 12)', description: 'Simulates a Linux-based POS terminal' },
-  { value: 'android_pos', label: 'Android POS', os: 'Android 14', description: 'Simulates an Android POS tablet' },
+const EMULATOR_TYPES: { value: string; label: string; deviceType: string; os: string; description: string }[] = [
+  { value: 'linux_pos', label: 'Linux POS', deviceType: 'pos_terminal', os: 'Linux 6.8.0 (Debian 12)', description: 'Simulates a Linux-based POS terminal' },
+  { value: 'android_pos', label: 'Android POS', deviceType: 'pos_terminal', os: 'Android 14', description: 'Simulates an Android POS tablet' },
 ]
 
 function formatDeviceType(v: string) {
@@ -53,13 +53,14 @@ async function detectOS(): Promise<string> {
   return detectBrowserOS()
 }
 
-function StepIndicator({ current }: { current: number }) {
-  const STEPS = ['Device Setup', 'Method', 'Emulator', 'Complete']
+type SetupStep = { label: string; path?: string }
+
+function StepIndicator({ current, steps }: { current: number; steps: SetupStep[] }) {
   return (
-    <div className="flex items-center justify-center gap-2 w-full">
-      {STEPS.map((label, i) => (
-        <div key={label} className="flex items-center gap-2">
-          <div className="flex flex-col items-center gap-1">
+    <nav aria-label="Setup progress" className="flex items-center justify-center gap-2 w-full">
+      {steps.map((step, i) => {
+        const content = (
+          <>
             <div className={`w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold border-2 transition-colors ${
               i < current
                 ? 'bg-emerald-500 border-emerald-500 text-white'
@@ -70,15 +71,33 @@ function StepIndicator({ current }: { current: number }) {
               {i < current ? '✓' : i + 1}
             </div>
             <span className={`text-xs ${i === current ? 'text-emerald-400' : 'text-slate-500'}`}>
-              {label}
+              {step.label}
             </span>
+          </>
+        )
+        const reached = i <= current
+        return (
+          <div key={step.label} className="flex items-center gap-2">
+            {reached && step.path ? (
+              <Link
+                to={step.path}
+                aria-current={i === current ? 'step' : undefined}
+                className="flex flex-col items-center gap-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+              >
+                {content}
+              </Link>
+            ) : (
+              <div className="flex flex-col items-center gap-1" aria-disabled="true">
+                {content}
+              </div>
+            )}
+            {i < steps.length - 1 && (
+              <div className={`w-10 h-0.5 mb-4 ${i < current ? 'bg-emerald-500' : 'bg-slate-700'}`} />
+            )}
           </div>
-          {i < STEPS.length - 1 && (
-            <div className={`w-10 h-0.5 mb-4 ${i < current ? 'bg-emerald-500' : 'bg-slate-700'}`} />
-          )}
-        </div>
-      ))}
-    </div>
+        )
+      })}
+    </nav>
   )
 }
 
@@ -287,12 +306,17 @@ function ReviewStep({ onBack }: { onBack: () => void }) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
   const isDev = import.meta.env.DEV
+  const selectedEmulator = EMULATOR_TYPES.find(t => t.value === emulatorType)
+  const emulatorAvailable = Boolean(window.electronAPI?.emulator)
 
   async function handleComplete() {
     setLoading(true)
     setError('')
     try {
-      if (useEmulator && window.electronAPI?.emulator) {
+      if (useEmulator) {
+        if (!window.electronAPI?.emulator) {
+          throw new Error('Emulator launch requires the Electron desktop app.')
+        }
         const config = {
           emulatorType,
           backendUrl: apiBaseUrl.replace('/api/v1', ''),
@@ -367,6 +391,16 @@ function ReviewStep({ onBack }: { onBack: () => void }) {
 
       <div className="w-full bg-slate-700 rounded-lg p-3 text-left text-sm space-y-1">
         <div className="flex justify-between">
+          <span className="text-slate-400">Setup Method</span>
+          <span className="text-slate-200 font-medium">{useEmulator ? 'Emulator' : 'Physical device'}</span>
+        </div>
+        {useEmulator && (
+          <div className="flex justify-between">
+            <span className="text-slate-400">Emulator Profile</span>
+            <span className="text-slate-200 font-medium">{selectedEmulator?.label ?? emulatorType}</span>
+          </div>
+        )}
+        <div className="flex justify-between">
           <span className="text-slate-400">Site ID</span>
           <span className="text-slate-200 font-medium">{siteId}</span>
         </div>
@@ -394,16 +428,21 @@ function ReviewStep({ onBack }: { onBack: () => void }) {
         </button>
         <button
           onClick={handleComplete}
-          disabled={loading}
+          disabled={loading || (useEmulator === true && !emulatorAvailable)}
           className="flex-[2] py-3 rounded-lg bg-emerald-600 hover:bg-emerald-500 disabled:opacity-60 text-white font-semibold text-sm transition-colors flex items-center justify-center gap-2"
         >
           {loading ? (
-            <><span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />Provisioning...</>
+            <><span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />{useEmulator ? 'Launching...' : 'Provisioning...'}</>
           ) : (
-            'Complete Setup'
+            useEmulator ? 'Launch Emulator' : 'Complete Setup'
           )}
         </button>
       </div>
+      {useEmulator && !emulatorAvailable && (
+        <p className="w-full text-left text-xs text-amber-400">
+          Emulator launch requires the Electron desktop app. Browser mode cannot start a local emulator process.
+        </p>
+      )}
       {error && <p className="w-full text-left text-xs text-red-400">{error}</p>}
     </div>
   )
@@ -416,7 +455,7 @@ function EmulatorConfigStep() {
 
   const handleNext = () => {
     setUseEmulator(true)
-    setSetupState({ ...setupState, deviceOs: selected.os })
+    setSetupState({ ...setupState, deviceType: selected.deviceType, deviceOs: selected.os })
     navigate('/setup/review')
   }
 
@@ -471,18 +510,16 @@ function EmulatorConfigStep() {
 function ModeStep() {
   const navigate = useNavigate()
   const { useEmulator, setUseEmulator, emulatorType, setEmulatorType } = useApp()
-  const [mode, setMode] = useState<'real' | 'emulator'>(useEmulator ? 'emulator' : 'real')
 
   const handleNext = () => {
-    if (mode === 'emulator') {
-      setUseEmulator(true)
+    if (useEmulator === null) return
+    if (useEmulator) {
       if (!EMULATOR_TYPES.find(t => t.value === emulatorType)) {
         setEmulatorType(EMULATOR_TYPES[0].value)
       }
       navigate('/emulator')
     } else {
-      setUseEmulator(false)
-      navigate('/signin')
+      navigate('/setup/review')
     }
   }
 
@@ -495,27 +532,29 @@ function ModeStep() {
 
       <div className="flex flex-col gap-3">
         <button
-          onClick={() => setMode('real')}
+          onClick={() => setUseEmulator(false)}
+          aria-pressed={useEmulator === false}
           className={`w-full text-left px-4 py-4 rounded-lg border-2 transition-colors ${
-            mode === 'real' ? 'border-emerald-500 bg-slate-700' : 'border-slate-600 bg-slate-700/50 hover:border-slate-500'
+            useEmulator === false ? 'border-emerald-500 bg-slate-700' : 'border-slate-600 bg-slate-700/50 hover:border-slate-500'
           }`}
         >
           <div className="flex items-center justify-between">
             <span className="text-slate-200 font-medium text-sm">Set up a real device</span>
-            {mode === 'real' && <span className="text-emerald-400 text-sm">✓</span>}
+            {useEmulator === false && <span className="text-emerald-400 text-sm">✓</span>}
           </div>
-          <p className="text-slate-400 text-xs mt-1">Provision a physical device using a bootstrap key.</p>
+          <p className="text-slate-400 text-xs mt-1">Provision this physical device with the verified setup details.</p>
         </button>
 
         <button
-          onClick={() => setMode('emulator')}
+          onClick={() => setUseEmulator(true)}
+          aria-pressed={useEmulator === true}
           className={`w-full text-left px-4 py-4 rounded-lg border-2 transition-colors ${
-            mode === 'emulator' ? 'border-emerald-500 bg-slate-700' : 'border-slate-600 bg-slate-700/50 hover:border-slate-500'
+            useEmulator ? 'border-emerald-500 bg-slate-700' : 'border-slate-600 bg-slate-700/50 hover:border-slate-500'
           }`}
         >
           <div className="flex items-center justify-between">
             <span className="text-slate-200 font-medium text-sm">Launch emulated device</span>
-            {mode === 'emulator' && <span className="text-emerald-400 text-sm">✓</span>}
+            {useEmulator && <span className="text-emerald-400 text-sm">✓</span>}
           </div>
           <p className="text-slate-400 text-xs mt-1">Start a simulated device for development and testing.</p>
         </button>
@@ -530,7 +569,8 @@ function ModeStep() {
         </button>
         <button
           onClick={handleNext}
-          className="flex-[2] py-3 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white font-semibold text-sm transition-colors"
+          disabled={useEmulator === null}
+          className="flex-[2] py-3 rounded-lg bg-emerald-600 hover:bg-emerald-500 disabled:bg-slate-700 disabled:text-slate-500 disabled:cursor-not-allowed text-white font-semibold text-sm transition-colors"
         >
           Next →
         </button>
@@ -542,24 +582,64 @@ function ModeStep() {
 export default function SetupWizard() {
   const navigate = useNavigate()
   const location = useLocation()
+  const { setupState, useEmulator } = useApp()
   const isReview = location.pathname === '/setup/review'
   const isEmulatorConfig = location.pathname === '/emulator'
   const isMode = location.pathname === '/method'
+  const requiresSetup = isMode || isEmulatorConfig || isReview
+  const requiresMethod = isEmulatorConfig || isReview
+  const setupComplete = Boolean(
+    setupState.siteId.trim()
+    && setupState.bootstrapKey.trim()
+    && setupState.deviceName.trim()
+    && setupState.deviceType
+    && setupState.deviceOs,
+  )
+
+  useEffect(() => {
+    if (requiresSetup && !setupComplete) {
+      navigate('/setup', { replace: true })
+    } else if (requiresMethod && (useEmulator === null || (isEmulatorConfig && !useEmulator))) {
+      navigate('/method', { replace: true })
+    }
+  }, [isEmulatorConfig, navigate, requiresMethod, requiresSetup, setupComplete, useEmulator])
 
   let stepIndex = 0
   if (isMode) stepIndex = 1
   else if (isEmulatorConfig) stepIndex = 2
-  else if (isReview) stepIndex = 3
+  else if (isReview) stepIndex = useEmulator ? 3 : 2
 
-  const maxSteps = 4
-  const totalSteps = maxSteps
+  const steps = useEmulator === true
+    ? [
+        { label: 'Device Setup', path: '/setup' },
+        { label: 'Method', path: '/method' },
+        { label: 'Emulator', path: '/emulator' },
+        { label: 'Complete', path: '/setup/review' },
+      ]
+    : useEmulator === false
+      ? [
+          { label: 'Device Setup', path: '/setup' },
+          { label: 'Method', path: '/method' },
+          { label: 'Complete', path: '/setup/review' },
+        ]
+      : [
+          { label: 'Device Setup', path: '/setup' },
+          { label: 'Method', path: '/method' },
+          { label: 'Configuration' },
+          { label: 'Complete' },
+        ]
 
   function renderStep() {
-    if (isReview) return <ReviewStep onBack={() => navigate(isEmulatorConfig ? '/emulator' : '/setup')} />
+    if (isReview) return <ReviewStep onBack={() => navigate(useEmulator ? '/emulator' : '/method')} />
     if (isEmulatorConfig) return <EmulatorConfigStep />
     if (isMode) return <ModeStep />
     return <Step1 />
   }
+
+  if (
+    (requiresSetup && !setupComplete)
+    || (requiresMethod && (useEmulator === null || (isEmulatorConfig && !useEmulator)))
+  ) return null
 
   return (
     <div className="min-h-screen bg-slate-900 flex items-center justify-center p-4 font-sans">
@@ -570,7 +650,7 @@ export default function SetupWizard() {
           <p className="text-slate-500 text-xs">Device Setup</p>
         </div>
 
-        <StepIndicator current={stepIndex} />
+        <StepIndicator current={stepIndex} steps={steps} />
 
         <div className="border-t border-slate-700 pt-4">
           {!isReview && !isMode && !isEmulatorConfig && (
@@ -590,7 +670,7 @@ export default function SetupWizard() {
         </div>
 
         <p className="text-center text-slate-600 text-xs">
-          Step {stepIndex + 1} of {totalSteps}
+          Step {stepIndex + 1} of {steps.length}
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- require an explicit physical-device or emulator setup method and guard incomplete direct-route access
- make reached setup progress steps URL-addressable while preventing future-step bypasses
- show the selected method and canonical emulator identity on Review
- launch Linux and Android POS emulators through the Electron IPC bridge
- fix Electron ESM startup, preload loading, repository-root discovery, and virtualenv resolution
- start the Electron app from `start-userapp.sh` and update the emulator verification runbook

## Validation

- `VITE_ELECTRON=true npx vite build`
- `npm test` (90 passed)
- ESLint passed for `electron/main.ts`, `SetupWizard.tsx`, and `setupWizard.test.tsx`
- `bash -n scripts/start-userapp.sh`
- `git diff --check`
- manually verified Linux POS provisioning, DNA registration, permissions, heartbeat, and telemetry

## Note

`AppContext.tsx` still triggers the repository's existing `react-refresh/only-export-components` warning because it exports both `AppProvider` and `useApp`; this change only makes `useEmulator` nullable to represent an unselected method.