### PR TITLE
fix: harden User App emulator lifecycle and local diagnostics

### DIFF
--- a/frontend/jsconfig.json
+++ b/frontend/jsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   }
 }

--- a/scripts/start-userapp.sh
+++ b/scripts/start-userapp.sh
@@ -21,6 +21,9 @@ NC='\033[0m'
 # Get script directory and repository root
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+PID_FILE="$REPO_ROOT/logs/userapp.pid"
+LOG_FILE="$REPO_ROOT/logs/userapp.log"
+ELECTRON_BIN="$REPO_ROOT/user_app/node_modules/electron/dist/electron"
 
 echo -e "${CYAN}╔════════════════════════════════════════════════════════════════╗${NC}"
 echo -e "${CYAN}║                                                                ║${NC}"
@@ -61,6 +64,13 @@ port_in_use() {
     lsof -Pi :$1 -sTCP:LISTEN -t >/dev/null 2>&1
 }
 
+userapp_ready() {
+    local pid=$1
+    ps -p "$pid" >/dev/null 2>&1 \
+        && port_in_use 5174 \
+        && pgrep -g "$pid" -f "^$ELECTRON_BIN .* \\.$" >/dev/null 2>&1
+}
+
 ################################################################################
 # Prerequisites Check
 ################################################################################
@@ -81,18 +91,42 @@ if ! command_exists npm; then
 fi
 print_success "npm found: $(npm --version)"
 
+for command in lsof pgrep setsid; do
+    if ! command_exists "$command"; then
+        print_error "$command is required to manage the Electron User App lifecycle"
+        exit 1
+    fi
+done
+
 ################################################################################
 # Port Availability Check
 ################################################################################
 
 print_step "Checking port availability..."
 
+if [ -f "$PID_FILE" ]; then
+    EXISTING_PID="$(cat "$PID_FILE" 2>/dev/null || true)"
+    if [[ "$EXISTING_PID" =~ ^[0-9]+$ ]] && userapp_ready "$EXISTING_PID"; then
+        print_success "Electron User App is already running (PID: $EXISTING_PID)"
+        exit 0
+    fi
+    print_warning "Cleaning an incomplete or stale User App process"
+    "$SCRIPT_DIR/stop-userapp.sh" >/dev/null 2>&1 || true
+fi
+
+# Clean Electron shells left by launchers from before process-group tracking.
+LEGACY_ELECTRON_PIDS="$(pgrep -f "^$ELECTRON_BIN --no-sandbox \\.$" || true)"
+if [ -n "$LEGACY_ELECTRON_PIDS" ]; then
+    print_warning "Cleaning stale Electron process(es): $LEGACY_ELECTRON_PIDS"
+    kill $LEGACY_ELECTRON_PIDS 2>/dev/null || true
+fi
+
 if port_in_use 5174; then
     print_warning "Port 5174 is already in use"
     read -p "Kill existing process and continue? (y/N): " -n 1 -r
     echo
     if [[ $REPLY =~ ^[Yy]$ ]]; then
-        lsof -ti:5174 | xargs kill -9 2>/dev/null || true
+        lsof -ti:5174 | xargs kill 2>/dev/null || true
         sleep 1
         print_success "Killed existing process on port 5174"
     else
@@ -135,19 +169,27 @@ if command_exists nvm; then
 fi
 
 print_info "Starting Electron User App on http://localhost:5174..."
-nohup npm run electron:dev > "$REPO_ROOT/logs/userapp.log" 2>&1 &
+nohup setsid npm run electron:dev > "$LOG_FILE" 2>&1 &
 USERAPP_PID=$!
-echo $USERAPP_PID > "$REPO_ROOT/logs/userapp.pid"
+echo "$USERAPP_PID" > "$PID_FILE"
 
-# Wait for server to start
-sleep 3
+# Wait for Vite and the Electron main process, not only the npm wrapper.
+for _ in {1..30}; do
+    if userapp_ready "$USERAPP_PID"; then
+        break
+    fi
+    if ! ps -p "$USERAPP_PID" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.5
+done
 
-# Check if server started successfully
-if ps -p $USERAPP_PID > /dev/null; then
+if userapp_ready "$USERAPP_PID"; then
     print_success "User App started successfully (PID: $USERAPP_PID)"
 else
     print_error "User App failed to start"
-    print_info "Check logs: $REPO_ROOT/logs/userapp.log"
+    print_info "Check logs: $LOG_FILE"
+    "$SCRIPT_DIR/stop-userapp.sh" >/dev/null 2>&1 || true
     exit 1
 fi
 
@@ -166,11 +208,11 @@ echo -e "${GREEN}Process ID:${NC}"
 echo -e "  User App: $USERAPP_PID"
 echo ""
 echo -e "${GREEN}Log File:${NC}"
-echo -e "  User App: $REPO_ROOT/logs/userapp.log"
+echo -e "  User App: $LOG_FILE"
 echo ""
 echo -e "${YELLOW}Quick Commands:${NC}"
-echo -e "  ${CYAN}View logs:${NC}  tail -f $REPO_ROOT/logs/userapp.log"
-echo -e "  ${CYAN}Stop app:${NC}   kill \$(cat $REPO_ROOT/logs/userapp.pid)"
+echo -e "  ${CYAN}View logs:${NC}  tail -f $LOG_FILE"
+echo -e "  ${CYAN}Stop app:${NC}   $SCRIPT_DIR/stop-userapp.sh"
 echo ""
 echo -e "${GREEN}Next Steps:${NC}"
 echo -e "  1. The Electron User App is ready."

--- a/scripts/stop-userapp.sh
+++ b/scripts/stop-userapp.sh
@@ -18,38 +18,51 @@ NC='\033[0m'
 # Get script directory and repository root
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+PID_FILE="$REPO_ROOT/logs/userapp.pid"
+ELECTRON_BIN="$REPO_ROOT/user_app/node_modules/electron/dist/electron"
 
 echo -e "${CYAN}Stopping HOMEPOT User App...${NC}\n"
 
-# Function to kill process by PID file
-kill_by_pidfile() {
-    local pidfile=$1
-    local service=$2
-    
-    if [ -f "$pidfile" ]; then
-        local pid=$(cat "$pidfile")
-        if ps -p $pid > /dev/null 2>&1; then
-            kill $pid 2>/dev/null
-            sleep 1
-            if ps -p $pid > /dev/null 2>&1; then
-                kill -9 $pid 2>/dev/null
+if [ -f "$PID_FILE" ]; then
+    USERAPP_PID="$(cat "$PID_FILE" 2>/dev/null || true)"
+    if [[ "$USERAPP_PID" =~ ^[0-9]+$ ]] && ps -p "$USERAPP_PID" >/dev/null 2>&1; then
+        USERAPP_PGID="$(ps -o pgid= -p "$USERAPP_PID" | tr -d ' ')"
+        if [ "$USERAPP_PGID" = "$USERAPP_PID" ]; then
+            kill -TERM -- "-$USERAPP_PGID" 2>/dev/null || true
+            for _ in {1..20}; do
+                ps -p "$USERAPP_PID" >/dev/null 2>&1 || break
+                sleep 0.25
+            done
+            if ps -p "$USERAPP_PID" >/dev/null 2>&1; then
+                kill -KILL -- "-$USERAPP_PGID" 2>/dev/null || true
             fi
-            echo -e "${GREEN}✓${NC} Stopped $service (PID: $pid)"
+            echo -e "${GREEN}✓${NC} Stopped User App process group (PID: $USERAPP_PID)"
         else
-            echo -e "${YELLOW}⚠${NC} $service was not running (stale PID file)"
+            kill "$USERAPP_PID" 2>/dev/null || true
+            echo -e "${GREEN}✓${NC} Stopped legacy User App wrapper (PID: $USERAPP_PID)"
         fi
-        rm -f "$pidfile"
     else
-        echo -e "${YELLOW}⚠${NC} No PID file found for $service"
+        echo -e "${YELLOW}⚠${NC} User App was not running (stale PID file)"
     fi
-}
+    rm -f "$PID_FILE"
+else
+    echo -e "${YELLOW}⚠${NC} No PID file found for User App"
+fi
 
-# Stop User App using PID file
-kill_by_pidfile "$REPO_ROOT/logs/userapp.pid" "userapp"
+# Compatibility cleanup for processes started before process-group tracking.
+LEGACY_ELECTRON_PIDS="$(pgrep -f "^$ELECTRON_BIN --no-sandbox \\.$" || true)"
+if [ -n "$LEGACY_ELECTRON_PIDS" ]; then
+    kill $LEGACY_ELECTRON_PIDS 2>/dev/null || true
+fi
+
+LEGACY_EMULATOR_PIDS="$(pgrep -f "^$REPO_ROOT/.venv/bin/python3 $REPO_ROOT/emulators/(linux_pos|android_pos)_emulator.py --config $HOME/.homepot/emulators/.*-config.json$" || true)"
+if [ -n "$LEGACY_EMULATOR_PIDS" ]; then
+    kill $LEGACY_EMULATOR_PIDS 2>/dev/null || true
+fi
 
 # Fallback: kill anything running on port 5174
 if lsof -Pi :5174 -sTCP:LISTEN -t >/dev/null 2>&1; then
-    lsof -ti:5174 | xargs kill -9 2>/dev/null
+    lsof -ti:5174 | xargs kill 2>/dev/null
     echo -e "${GREEN}✓${NC} Killed remaining processes on port 5174"
 fi
 

--- a/user_app/electron/main.ts
+++ b/user_app/electron/main.ts
@@ -11,11 +11,27 @@ const CREDENTIALS_DIR = path.join(os.homedir(), '.homepot')
 const CREDENTIALS_FILE = path.join(CREDENTIALS_DIR, 'credentials')
 const IDENTITY_FILE = path.join(CREDENTIALS_DIR, 'identity')
 const EMULATOR_DIR = path.join(CREDENTIALS_DIR, 'emulators')
+const hasSingleInstanceLock = app.requestSingleInstanceLock()
 
 let mainWindow: BrowserWindow | null = null
 let tray: Tray | null = null
 let emulatorProcess: ChildProcess | null = null
 let emulatorDeviceId: string | null = null
+
+interface EmulatorFileConfig {
+  emulator_type?: string
+  device_name?: string
+  os_details?: string
+}
+
+if (!hasSingleInstanceLock) {
+  app.quit()
+}
+
+app.on('second-instance', () => {
+  mainWindow?.show()
+  mainWindow?.focus()
+})
 
 function getAssetPath(...segments: string[]): string {
   const dir = __dirname
@@ -214,6 +230,7 @@ function registerIpcHandlers() {
     }
 
     const tempConfig = {
+      emulator_type: config.emulatorType,
       backend_url: config.backendUrl,
       site_id: config.siteId,
       bootstrap_key: config.bootstrapKey,
@@ -241,34 +258,7 @@ function registerIpcHandlers() {
       fs.unlinkSync(credsPath)
     }
 
-    const projectRoot = getProjectRoot()
-    const emulatorScript = path.join(projectRoot, 'emulators', `${config.emulatorType}_emulator.py`)
-    if (!fs.existsSync(emulatorScript)) {
-      throw new Error(`Emulator script not found: ${emulatorScript}`)
-    }
-
-    const pythonExe = findPython(projectRoot)
-    emulatorProcess = spawn(pythonExe, [emulatorScript, '--config', configPath], {
-      cwd: projectRoot,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    })
-
-    emulatorProcess.stdout?.on('data', (data: Buffer) => {
-      const lines = data.toString().split('\n').filter(Boolean)
-      for (const line of lines) {
-        console.log(`[emulator] ${line}`)
-      }
-    })
-
-    emulatorProcess.stderr?.on('data', (data: Buffer) => {
-      console.error(`[emulator:err] ${data.toString().trim()}`)
-    })
-
-    emulatorProcess.on('exit', (code) => {
-      console.log(`[emulator] exited with code ${code}`)
-      emulatorProcess = null
-      emulatorDeviceId = null
-    })
+    startEmulatorProcess(config.emulatorType, configPath)
 
     const creds = await pollForCredentials(credsPath, 30_000)
     if (!creds) {
@@ -296,19 +286,80 @@ function registerIpcHandlers() {
 
 function killEmulator(): void {
   if (!emulatorProcess) return
+  const processToKill = emulatorProcess
   try {
-    emulatorProcess.kill('SIGTERM')
-    const killed = emulatorProcess.killed
+    processToKill.kill('SIGTERM')
+    const killed = processToKill.killed
     emulatorProcess = null
     emulatorDeviceId = null
     if (!killed) {
       setTimeout(() => {
-        try { emulatorProcess?.kill('SIGKILL') } catch { /* ignore */ }
+        try { processToKill.kill('SIGKILL') } catch { /* ignore */ }
       }, 3000)
     }
   } catch {
     emulatorProcess = null
     emulatorDeviceId = null
+  }
+}
+
+function startEmulatorProcess(emulatorType: string, configPath: string): void {
+  const projectRoot = getProjectRoot()
+  const emulatorScript = path.join(projectRoot, 'emulators', `${emulatorType}_emulator.py`)
+  if (!fs.existsSync(emulatorScript)) {
+    throw new Error(`Emulator script not found: ${emulatorScript}`)
+  }
+
+  const pythonExe = findPython(projectRoot)
+  const child = spawn(pythonExe, [emulatorScript, '--config', configPath], {
+    cwd: projectRoot,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  emulatorProcess = child
+
+  child.stdout?.on('data', (data: Buffer) => {
+    const lines = data.toString().split('\n').filter(Boolean)
+    for (const line of lines) {
+      console.log(`[emulator] ${line}`)
+    }
+  })
+
+  child.stderr?.on('data', (data: Buffer) => {
+    console.error(`[emulator:err] ${data.toString().trim()}`)
+  })
+
+  child.on('exit', (code) => {
+    console.log(`[emulator] exited with code ${code}`)
+    if (emulatorProcess === child) {
+      emulatorProcess = null
+      emulatorDeviceId = null
+    }
+  })
+}
+
+function resumePersistedEmulator(): void {
+  const credentials = readCredentialsFile()
+  const deviceName = credentials.device_name
+  if (credentials.enrollment_method !== 'emulated' || !credentials.device_id || !deviceName) {
+    return
+  }
+
+  const configPath = path.join(EMULATOR_DIR, `${deviceName}-config.json`)
+  const emulatorCredentialsPath = path.join(EMULATOR_DIR, `${deviceName}.json`)
+  if (!fs.existsSync(configPath) || !fs.existsSync(emulatorCredentialsPath)) {
+    console.warn(`[emulator] Cannot resume ${deviceName}: saved config or credentials are missing`)
+    return
+  }
+
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as EmulatorFileConfig
+    const emulatorType = config.emulator_type
+      ?? (config.os_details?.toLowerCase().includes('android') ? 'android_pos' : 'linux_pos')
+    startEmulatorProcess(emulatorType, configPath)
+    emulatorDeviceId = credentials.device_id
+    console.log(`[emulator] Resumed ${deviceName} (${emulatorDeviceId})`)
+  } catch (error) {
+    console.error(`[emulator] Failed to resume ${deviceName}:`, error)
   }
 }
 
@@ -371,7 +422,9 @@ function pollForCredentials(credsPath: string, timeoutMs: number): Promise<Recor
 }
 
 app.whenReady().then(() => {
+  if (!hasSingleInstanceLock) return
   registerIpcHandlers()
+  resumePersistedEmulator()
   createWindow()
   createTray()
 

--- a/user_app/electron/main.ts
+++ b/user_app/electron/main.ts
@@ -11,6 +11,7 @@ const CREDENTIALS_DIR = path.join(os.homedir(), '.homepot')
 const CREDENTIALS_FILE = path.join(CREDENTIALS_DIR, 'credentials')
 const IDENTITY_FILE = path.join(CREDENTIALS_DIR, 'identity')
 const EMULATOR_DIR = path.join(CREDENTIALS_DIR, 'emulators')
+const MAX_APP_LOG_ENTRIES = 15
 const hasSingleInstanceLock = app.requestSingleInstanceLock()
 
 let mainWindow: BrowserWindow | null = null
@@ -24,11 +25,54 @@ interface EmulatorFileConfig {
   os_details?: string
 }
 
+interface AppLogEntry {
+  id: string
+  timestamp: string
+  level: 'info' | 'warning' | 'error'
+  category: string
+  message: string
+}
+
+function getAppLogFile(): string {
+  return path.join(app.getPath('userData'), 'app-events.json')
+}
+
+function readAppLog(): AppLogEntry[] {
+  try {
+    const data = JSON.parse(fs.readFileSync(getAppLogFile(), 'utf-8'))
+    return Array.isArray(data) ? data.slice(-MAX_APP_LOG_ENTRIES) : []
+  } catch {
+    return []
+  }
+}
+
+function recordAppEvent(level: AppLogEntry['level'], category: string, message: string): void {
+  try {
+    const logFile = getAppLogFile()
+    fs.mkdirSync(path.dirname(logFile), { recursive: true, mode: 0o700 })
+    const entries = [
+      ...readAppLog(),
+      {
+        id: crypto.randomUUID(),
+        timestamp: new Date().toISOString(),
+        level,
+        category,
+        message,
+      },
+    ].slice(-MAX_APP_LOG_ENTRIES)
+    fs.writeFileSync(logFile, JSON.stringify(entries, null, 2), { mode: 0o600 })
+    fs.chmodSync(logFile, 0o600)
+  } catch (error) {
+    console.error('[app-log] Failed to write event:', error)
+  }
+}
+
 if (!hasSingleInstanceLock) {
   app.quit()
 }
 
 app.on('second-instance', () => {
+  recordAppEvent('warning', 'application', 'Another launch was redirected to the running application')
   mainWindow?.show()
   mainWindow?.focus()
 })
@@ -62,6 +106,13 @@ function createWindow() {
   } else {
     mainWindow.loadFile(path.join(__dirname, '../dist/index.html'))
   }
+
+  mainWindow.webContents.on('did-finish-load', () => {
+    recordAppEvent('info', 'application', 'User interface ready')
+  })
+  mainWindow.webContents.on('render-process-gone', (_event, details) => {
+    recordAppEvent('error', 'application', `User interface stopped unexpectedly (${details.reason})`)
+  })
 
   mainWindow.on('close', (event) => {
     if (tray) {
@@ -154,6 +205,7 @@ function getOrCreateDeviceIdentity(): { deviceId: string; machineId: string } {
 function registerIpcHandlers() {
   ipcMain.handle('credentials:save', (_event, data: Record<string, string>) => {
     writeCredentialsFile(data)
+    recordAppEvent('info', 'setup', 'Device setup completed successfully')
     return true
   })
 
@@ -215,6 +267,11 @@ function registerIpcHandlers() {
     return app.getVersion()
   })
 
+  ipcMain.handle('app:getRecentLogs', (_event, requestedLimit = MAX_APP_LOG_ENTRIES) => {
+    const limit = Math.max(1, Math.min(MAX_APP_LOG_ENTRIES, Number(requestedLimit) || MAX_APP_LOG_ENTRIES))
+    return readAppLog().slice(-limit).reverse()
+  })
+
   ipcMain.handle('emulator:start', async (_event, config: {
     emulatorType: string
     backendUrl: string
@@ -225,6 +282,7 @@ function registerIpcHandlers() {
     mockIp?: string
     mockHostname?: string
   }) => {
+    recordAppEvent('info', 'emulator', `Starting ${config.emulatorType} device emulator`)
     if (emulatorProcess) {
       killEmulator()
     }
@@ -258,15 +316,22 @@ function registerIpcHandlers() {
       fs.unlinkSync(credsPath)
     }
 
-    startEmulatorProcess(config.emulatorType, configPath)
+    try {
+      startEmulatorProcess(config.emulatorType, configPath)
+    } catch (error) {
+      recordAppEvent('error', 'emulator', `Device emulator failed to start: ${error instanceof Error ? error.message : 'unknown error'}`)
+      throw error
+    }
 
     const creds = await pollForCredentials(credsPath, 30_000)
     if (!creds) {
       killEmulator()
+      recordAppEvent('error', 'setup', 'Device emulator setup timed out')
       throw new Error('Emulator did not provision within 30 seconds')
     }
 
     emulatorDeviceId = creds.device_id
+    recordAppEvent('info', 'emulator', 'Device emulator started successfully')
     return { deviceId: creds.device_id, apiKey: creds.api_key }
   })
 
@@ -286,6 +351,7 @@ function registerIpcHandlers() {
 
 function killEmulator(): void {
   if (!emulatorProcess) return
+  recordAppEvent('info', 'emulator', 'Stopping device emulator')
   const processToKill = emulatorProcess
   try {
     processToKill.kill('SIGTERM')
@@ -328,8 +394,13 @@ function startEmulatorProcess(emulatorType: string, configPath: string): void {
     console.error(`[emulator:err] ${data.toString().trim()}`)
   })
 
+  child.on('error', (error) => {
+    recordAppEvent('error', 'emulator', `Device emulator process error: ${error.message}`)
+  })
+
   child.on('exit', (code) => {
     console.log(`[emulator] exited with code ${code}`)
+    recordAppEvent(code === 0 ? 'info' : 'error', 'emulator', `Device emulator exited with code ${code ?? 'unknown'}`)
     if (emulatorProcess === child) {
       emulatorProcess = null
       emulatorDeviceId = null
@@ -348,6 +419,7 @@ function resumePersistedEmulator(): void {
   const emulatorCredentialsPath = path.join(EMULATOR_DIR, `${deviceName}.json`)
   if (!fs.existsSync(configPath) || !fs.existsSync(emulatorCredentialsPath)) {
     console.warn(`[emulator] Cannot resume ${deviceName}: saved config or credentials are missing`)
+    recordAppEvent('warning', 'emulator', 'Saved device emulator could not resume because local files are missing')
     return
   }
 
@@ -358,8 +430,10 @@ function resumePersistedEmulator(): void {
     startEmulatorProcess(emulatorType, configPath)
     emulatorDeviceId = credentials.device_id
     console.log(`[emulator] Resumed ${deviceName} (${emulatorDeviceId})`)
+    recordAppEvent('info', 'emulator', 'Saved device emulator resumed successfully')
   } catch (error) {
     console.error(`[emulator] Failed to resume ${deviceName}:`, error)
+    recordAppEvent('error', 'emulator', `Saved device emulator failed to resume: ${error instanceof Error ? error.message : 'unknown error'}`)
   }
 }
 
@@ -423,6 +497,11 @@ function pollForCredentials(credsPath: string, timeoutMs: number): Promise<Recor
 
 app.whenReady().then(() => {
   if (!hasSingleInstanceLock) return
+  const isFirstLaunch = !fs.existsSync(getAppLogFile())
+  if (isFirstLaunch) {
+    recordAppEvent('info', 'installation', 'Installation completed; HOMEPOT Agent launched for the first time')
+  }
+  recordAppEvent('info', 'application', `HOMEPOT Agent ${app.getVersion()} started`)
   registerIpcHandlers()
   resumePersistedEmulator()
   createWindow()
@@ -436,6 +515,7 @@ app.whenReady().then(() => {
 })
 
 app.on('before-quit', () => {
+  recordAppEvent('info', 'application', 'HOMEPOT Agent is stopping')
   killEmulator()
 })
 

--- a/user_app/electron/preload.ts
+++ b/user_app/electron/preload.ts
@@ -14,6 +14,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   app: {
     getVersion: () => ipcRenderer.invoke('app:getVersion'),
+    getRecentLogs: (limit = 15) => ipcRenderer.invoke('app:getRecentLogs', limit),
   },
   emulator: {
     start: (config: {

--- a/user_app/src/services/credentialStorage.ts
+++ b/user_app/src/services/credentialStorage.ts
@@ -32,6 +32,13 @@ declare global {
       }
       app: {
         getVersion(): Promise<string>
+        getRecentLogs(limit?: number): Promise<Array<{
+          id: string
+          timestamp: string
+          level: 'info' | 'warning' | 'error'
+          category: string
+          message: string
+        }>>
       }
       emulator: {
         start(config: {

--- a/user_app/src/test/integration.test.tsx
+++ b/user_app/src/test/integration.test.tsx
@@ -9,6 +9,7 @@ beforeEach(() => {
   mockFetch.mockReset()
   localStorage.clear()
   sessionStorage.clear()
+  delete window.electronAPI
   window.history.pushState({}, '', '/')
 })
 
@@ -145,22 +146,24 @@ describe('App routing', () => {
     expect(screen.getByText('Active')).toBeInTheDocument()
   })
 
-  it('shows device logs at /logs', async () => {
+  it('shows local application logs at /logs', async () => {
     localStorage.setItem('homepot_device_id', 'pos-001')
     sessionStorage.setItem('homepot_api_key', 'test-key')
     mockFetch.mockImplementation((url: string) => {
       if (url.includes('/pending')) {
         return ok([])
       }
-      if (url.includes('/logs')) {
-        return ok({ data: [{ id: 1, timestamp: null, category: 'network', severity: 'info', error_code: null, error_message: 'Network link up (eth0)', resolved: false }] })
-      }
       return ok({ data: [] })
     })
+    window.electronAPI = {
+      app: {
+        getRecentLogs: vi.fn().mockResolvedValue([{ id: 'event-1', timestamp: new Date().toISOString(), category: 'application', level: 'info', message: 'User interface ready' }]),
+      },
+    } as unknown as NonNullable<Window['electronAPI']>
     window.history.pushState({}, '', '/logs')
     render(<App />)
-    expect(await screen.findByText('Device Logs')).toBeInTheDocument()
-    expect(await screen.findByText('Network link up (eth0)')).toBeInTheDocument()
+    expect(await screen.findByText('Application Logs')).toBeInTheDocument()
+    expect(await screen.findByText('User interface ready')).toBeInTheDocument()
   })
 
   it('unknown path redirects to /', async () => {

--- a/user_app/src/test/logs.test.tsx
+++ b/user_app/src/test/logs.test.tsx
@@ -4,8 +4,7 @@ import { MemoryRouter } from 'react-router-dom'
 import { AppProvider } from '../context/AppContext'
 import Logs from '../views/Logs'
 
-const mockFetch = vi.fn()
-globalThis.fetch = mockFetch
+const getRecentLogs = vi.fn()
 
 vi.mock('../services/credentialStorage', () => ({
   credentialStorage: {
@@ -17,29 +16,16 @@ vi.mock('../services/credentialStorage', () => ({
   },
 }))
 
-function ok(body: unknown) {
-  return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }))
-}
-
 function mockLogsData() {
-  mockFetch.mockImplementation((url: string) => {
-    if (url.includes('/logs')) {
-      return ok({
-        data: [
-          {
-            id: 1,
-            timestamp: '2026-08-03T10:00:00.000Z',
-            category: 'network',
-            severity: 'warning',
-            error_code: null,
-            error_message: 'WAN link flapping detected',
-            resolved: false,
-          },
-        ],
-      })
-    }
-    return ok({ data: [] })
-  })
+  getRecentLogs.mockResolvedValue([
+    {
+      id: 'event-1',
+      timestamp: '2026-08-03T10:00:00.000Z',
+      category: 'application',
+      level: 'info',
+      message: 'HOMEPOT Agent started',
+    },
+  ])
 }
 
 function renderWithProviders(ui: React.ReactElement) {
@@ -52,19 +38,23 @@ function renderWithProviders(ui: React.ReactElement) {
 
 describe('Logs', () => {
   beforeEach(() => {
-    mockFetch.mockReset()
+    getRecentLogs.mockReset()
+    window.electronAPI = {
+      app: { getRecentLogs },
+    } as unknown as NonNullable<Window['electronAPI']>
   })
 
-  it('renders device logs', async () => {
+  it('renders the latest local application logs', async () => {
     mockLogsData()
     renderWithProviders(<Logs />)
-    expect(await screen.findByText('Device Logs')).toBeInTheDocument()
-    expect(await screen.findByText('WAN link flapping detected')).toBeInTheDocument()
+    expect(await screen.findByText('Application Logs')).toBeInTheDocument()
+    expect(await screen.findByText('HOMEPOT Agent started')).toBeInTheDocument()
+    expect(getRecentLogs).toHaveBeenCalledWith(15)
   })
 
   it('shows empty state when there is no data', async () => {
-    mockFetch.mockImplementation(() => ok({ data: [] }))
+    getRecentLogs.mockResolvedValue([])
     renderWithProviders(<Logs />)
-    expect(await screen.findByText('No logs yet.')).toBeInTheDocument()
+    expect(await screen.findByText('No application events yet.')).toBeInTheDocument()
   })
 })

--- a/user_app/src/test/views.test.tsx
+++ b/user_app/src/test/views.test.tsx
@@ -203,7 +203,7 @@ describe('DeviceInfo', () => {
     })
     renderWithProviders(<DeviceInfo />)
     expect(await screen.findByText('HOMEPOT Agent')).toBeInTheDocument()
-    expect(await screen.findByText(/Disconnect.*Unpair/)).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: /Disconnect & Unpair Device$/ })).toBeInTheDocument()
   })
 })
 

--- a/user_app/src/test/views.test.tsx
+++ b/user_app/src/test/views.test.tsx
@@ -82,6 +82,8 @@ describe('HomeDashboard', () => {
     renderWithProviders(<HomeDashboard />)
     expect(await screen.findByText('HOMEPOT Agent')).toBeInTheDocument()
     expect(await screen.findByText('SECURE — ONLINE')).toBeInTheDocument()
+    expect(screen.queryByText(/Lifecycle:/)).not.toBeInTheDocument()
+    expect(screen.queryByText('good')).not.toBeInTheDocument()
     expect(screen.getByText('CPU')).toBeInTheDocument()
     expect(screen.getByText('Memory')).toBeInTheDocument()
     expect(screen.getByText('Disk')).toBeInTheDocument()

--- a/user_app/src/test/views.test.tsx
+++ b/user_app/src/test/views.test.tsx
@@ -84,6 +84,8 @@ describe('HomeDashboard', () => {
     expect(await screen.findByText('SECURE — ONLINE')).toBeInTheDocument()
     expect(screen.queryByText(/Lifecycle:/)).not.toBeInTheDocument()
     expect(screen.queryByText('good')).not.toBeInTheDocument()
+    expect(screen.getByText('Device Resource Usage')).toBeInTheDocument()
+    expect(screen.queryByText('Agent Resource Usage')).not.toBeInTheDocument()
     expect(screen.getByText('CPU')).toBeInTheDocument()
     expect(screen.getByText('Memory')).toBeInTheDocument()
     expect(screen.getByText('Disk')).toBeInTheDocument()

--- a/user_app/src/views/DeviceInfo.tsx
+++ b/user_app/src/views/DeviceInfo.tsx
@@ -246,7 +246,7 @@ export default function DeviceInfo() {
                   Unpairing...
                 </>
               ) : (
-                '🔌  Disconnect &amp; Unpair Device'
+                '🔌  Disconnect & Unpair Device'
               )}
             </button>
           ) : (

--- a/user_app/src/views/HomeDashboard.tsx
+++ b/user_app/src/views/HomeDashboard.tsx
@@ -131,12 +131,6 @@ export default function HomeDashboard() {
               <p className={`font-bold text-sm ${isOnline ? 'text-emerald-400' : 'text-red-400'}`}>
                 {isOnline ? 'SECURE — ONLINE' : 'OFFLINE'}
               </p>
-              <div className="flex items-center gap-2 mt-0.5">
-                <span className="text-slate-400 text-xs">Lifecycle: {lifecycle}</span>
-                {status?.health_state && status.health_state !== 'unknown' && (
-                  <span className="text-slate-500 text-xs">· {status.health_state}</span>
-                )}
-              </div>
             </div>
             <div className={`ml-auto w-2 h-2 rounded-full flex-shrink-0 ${
               isOnline ? 'bg-emerald-400 animate-pulse' : 'bg-red-500'

--- a/user_app/src/views/HomeDashboard.tsx
+++ b/user_app/src/views/HomeDashboard.tsx
@@ -150,7 +150,7 @@ export default function HomeDashboard() {
 
         {/* Gauge Rings */}
         <div className="px-5 pt-5">
-          <p className="text-slate-500 text-xs font-medium mb-3 uppercase tracking-widest">Agent Resource Usage</p>
+          <p className="text-slate-500 text-xs font-medium mb-3 uppercase tracking-widest">Device Resource Usage</p>
           <div className="flex justify-around">
             <GaugeRing label="CPU" value={cpu} color="#10b981" />
             <GaugeRing label="Memory" value={mem} color="#f59e0b" />

--- a/user_app/src/views/Logs.tsx
+++ b/user_app/src/views/Logs.tsx
@@ -1,8 +1,7 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import TabBar from '../components/TabBar'
-import { credentialStorage } from '../services/credentialStorage'
-import { fetchDeviceLogs } from '../services/api'
-import type { DeviceLog } from '../services/api'
+
+type AppLogEntry = Awaited<ReturnType<NonNullable<Window['electronAPI']>['app']['getRecentLogs']>>[number]
 
 function formatTime(iso: string | null): string {
   if (!iso) return '—'
@@ -57,26 +56,17 @@ function Row({
 }
 
 export default function Logs() {
-  const [logs, setLogs] = useState<DeviceLog[]>([])
+  const [logs, setLogs] = useState<AppLogEntry[]>([])
   const [error, setError] = useState('')
-  const deviceIdRef = useRef<string | null>(null)
-  const apiKeyRef = useRef<string | null>(null)
-
-  useEffect(() => {
-    Promise.all([credentialStorage.getDeviceId(), credentialStorage.getApiKey()]).then(
-      ([did, key]) => {
-        if (did) deviceIdRef.current = did
-        if (key) apiKeyRef.current = key
-      },
-    )
-  }, [])
 
   const refresh = useCallback(async () => {
-    const dId = deviceIdRef.current
-    const aKey = apiKeyRef.current
-    if (!dId || !aKey) return
+    const getRecentLogs = window.electronAPI?.app.getRecentLogs
+    if (!getRecentLogs) {
+      setError('Application logs are available in the desktop app.')
+      return
+    }
     try {
-      setLogs(await fetchDeviceLogs(dId, aKey))
+      setLogs(await getRecentLogs(15))
       setError('')
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load logs')
@@ -84,15 +74,10 @@ export default function Logs() {
   }, [])
 
   useEffect(() => {
-    const credsReady = setInterval(() => {
-      if (deviceIdRef.current && apiKeyRef.current) {
-        clearInterval(credsReady)
-        refresh()
-      }
-    }, 100)
+    const initialRefresh = setTimeout(refresh, 0)
     const poll = setInterval(refresh, 15000)
     return () => {
-      clearInterval(credsReady)
+      clearTimeout(initialRefresh)
       clearInterval(poll)
     }
   }, [refresh])
@@ -104,7 +89,7 @@ export default function Logs() {
         <div className="flex items-center justify-between px-5 pt-5 pb-3 border-b border-slate-700">
           <div>
             <h1 className="text-slate-100 font-bold text-base tracking-wide">HOMEPOT Agent</h1>
-            <p className="text-slate-500 text-xs">Device Logs</p>
+            <p className="text-slate-500 text-xs">Application Logs</p>
           </div>
           <div className="w-8 h-8 rounded-full bg-slate-700 border border-slate-600 flex items-center justify-center">
             <span className="text-base">📊</span>
@@ -123,15 +108,15 @@ export default function Logs() {
         {/* Content */}
         <div className="px-5 py-2 min-h-40">
           {logs.length === 0 ? (
-            <p className="text-center text-slate-600 text-sm py-8">No logs yet.</p>
+            <p className="text-center text-slate-600 text-sm py-8">No application events yet.</p>
           ) : (
             logs.map(log => (
               <Row
                 key={log.id}
-                title={log.error_message}
+                title={log.message}
                 subtitle={log.category}
                 meta={formatTime(log.timestamp)}
-                dot={severityDot(log.severity)}
+                dot={severityDot(log.level)}
               />
             ))
           )}


### PR DESCRIPTION
## Summary

- resume persisted native device emulators when the Electron User App starts
- enforce a single Electron instance and manage the development stack as one process group
- improve start/stop readiness checks and cleanup behavior
- label CPU, memory, and disk metrics as device resource usage
- replace backend device events on the User App Logs page with the latest 15 private local installation/runtime events
- correct the Disconnect & Unpair Device label
- remove deprecated frontend `baseUrl` usage while preserving the `@/*` alias

## Validation

- User App tests: 90 passed
- User App production build passed
- focused Electron/renderer lint passed
- frontend tests: 19 passed
- frontend production build passed
- shell syntax and `git diff --check` passed
- live Electron lifecycle smoke test passed
- local event file verified at mode `0600`, bounded to 15 entries

## Follow-ups identified

- Check for Updates is currently a UI simulation and needs a release provider/updater implementation.
- User-initiated unpair currently sends device credentials to an operator-authenticated backend endpoint; a device-authenticated self-unpair contract is needed.