### PR TITLE
Enforce owner-granted device command permissions

### DIFF
--- a/backend/src/homepot/agent/real_device_agent.py
+++ b/backend/src/homepot/agent/real_device_agent.py
@@ -224,11 +224,15 @@ async def pending_commands_loop(
             commands = parse_pending_commands(data)
             for command in commands:
                 cid = command.get("command_id", "")
+                if command.get("command_type") == "request_permission":
+                    continue
                 # 1. Permission gate before ACK
                 from homepot.agent.utils.command_poller import _check_permission
 
                 denial = _check_permission(
-                    command.get("command_type", ""), cached_permissions
+                    command.get("command_type", ""),
+                    cached_permissions,
+                    command.get("payload"),
                 )
                 if denial is not None:
                     logger.warning(
@@ -273,7 +277,10 @@ async def pending_commands_loop(
                     )
                     continue
                 # 3. Route to IPC or process locally
-                if ipc_available:
+                if ipc_available and command.get("command_type") not in {
+                    "run_command",
+                    "run_script",
+                }:
                     app = cast("FastAPI", ipc_server.config.app)  # type: ignore[union-attr]
                     push_pending_command(app, command)
                 else:

--- a/backend/src/homepot/agent/utils/command_poller.py
+++ b/backend/src/homepot/agent/utils/command_poller.py
@@ -1,18 +1,71 @@
 """Command polling and processing for the real device agent."""
 
 import logging
+import re
+import shlex
+import subprocess  # noqa: S404 - arguments are parsed and permission-gated
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
-COMMAND_TYPES = frozenset({"ping", "restart", "update_config", "shutdown"})
+COMMAND_TYPES = frozenset(
+    {
+        "ping",
+        "health_check",
+        "request_permission",
+        "restart",
+        "restart_pos_app",
+        "run_command",
+        "run_script",
+        "shutdown",
+        "update_config",
+        "update_pos_payment_config",
+    }
+)
 
 # Each privileged command type requires a specific device_permission key.
 REQUIRED_PERMISSION: Dict[str, str] = {
+    "health_check": "command_execution",
     "restart": "root_access",
+    "restart_pos_app": "command_execution",
+    "run_command": "command_execution",
+    "run_script": "command_execution",
     "shutdown": "root_access",
     "update_config": "filesystem_access",
+    "update_pos_payment_config": "filesystem_access",
 }
+
+MAX_COMMAND_OUTPUT = 64 * 1024
+MAX_COMMAND_TIMEOUT = 300
+PRIVILEGE_ESCALATION_PATTERN = re.compile(
+    r"(^|[;&|()\n]\s*|\b(?:exec|command|env)\s+)(sudo|su|doas|pkexec)\b"
+)
+
+
+def _command_data(command: Dict[str, Any]) -> Dict[str, Any]:
+    payload = command.get("payload")
+    if not isinstance(payload, dict):
+        return {}
+    data = payload.get("data")
+    return data if isinstance(data, dict) else payload
+
+
+def required_permissions_for_command(
+    command_type: str, payload: Optional[Dict[str, Any]] = None
+) -> List[str]:
+    """Return every user grant required to execute a command."""
+    required: List[str] = []
+    base_permission = REQUIRED_PERMISSION.get(command_type)
+    if base_permission:
+        required.append(base_permission)
+
+    data = payload.get("data") if isinstance(payload, dict) else None
+    command_data = data if isinstance(data, dict) else payload or {}
+    if command_type in {"run_command", "run_script"} and command_data.get(
+        "run_as_root", False
+    ):
+        required.append("root_access")
+    return required
 
 
 def parse_pending_commands(response_data: Any) -> List[Dict[str, Any]]:
@@ -56,21 +109,88 @@ async def fetch_device_permissions(
 def _check_permission(
     command_type: str,
     permissions: Optional[Dict[str, bool]],
+    payload: Optional[Dict[str, Any]] = None,
 ) -> Optional[str]:
     """Return an error message if the required permission is missing or ``False``.
 
     ``None`` means the command is allowed.
     """
-    required_key = REQUIRED_PERMISSION.get(command_type)
-    if required_key is None:
+    required_keys = required_permissions_for_command(command_type, payload)
+    if not required_keys:
         return None
     if permissions is None:
         return "Device permissions not available — cannot verify access"
-    if not permissions.get(required_key, False):
+    missing = [key for key in required_keys if not permissions.get(key, False)]
+    if missing:
         return (
-            f"Permission denied: '{required_key}' is not granted for '{command_type}'"
+            f"Permission denied: {', '.join(missing)} not granted for '{command_type}'"
         )
     return None
+
+
+def _execute_local(command: Dict[str, Any], script: bool) -> Dict[str, Any]:
+    data = _command_data(command)
+    source_key = "script" if script else "command"
+    source = data.get(source_key)
+    if not isinstance(source, str) or not source.strip():
+        return {
+            "status": "failed",
+            "result": {"error": f"A non-empty '{source_key}' value is required"},
+        }
+
+    timeout_value = data.get("timeout_seconds", 30)
+    try:
+        timeout = max(1, min(int(timeout_value), MAX_COMMAND_TIMEOUT))
+    except (TypeError, ValueError):
+        return {
+            "status": "failed",
+            "result": {"error": "timeout_seconds must be an integer"},
+        }
+
+    run_as_root = data.get("run_as_root", False) is True
+    if not run_as_root and PRIVILEGE_ESCALATION_PATTERN.search(source):
+        return {
+            "status": "failed",
+            "result": {
+                "error": "Privilege escalation requires run_as_root and root_access"
+            },
+        }
+    if script:
+        argv = ["/bin/sh", "-s"]
+    else:
+        try:
+            argv = shlex.split(source)
+        except ValueError as exc:
+            return {"status": "failed", "result": {"error": str(exc)}}
+        if not argv:
+            return {
+                "status": "failed",
+                "result": {"error": "Command produced no executable arguments"},
+            }
+    if run_as_root:
+        argv = ["sudo", "-n", "--", *argv]
+
+    try:
+        completed = subprocess.run(  # noqa: S603 - no shell; argv is explicit
+            argv,
+            input=source if script else None,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"status": "failed", "result": {"error": str(exc)}}
+
+    result = {
+        "exit_code": completed.returncode,
+        "stdout": completed.stdout[-MAX_COMMAND_OUTPUT:],
+        "stderr": completed.stderr[-MAX_COMMAND_OUTPUT:],
+    }
+    return {
+        "status": "completed" if completed.returncode == 0 else "failed",
+        "result": result,
+    }
 
 
 def process_command(
@@ -104,7 +224,7 @@ def process_command(
         }
 
     # Permission gate
-    denial = _check_permission(command_type, permissions)
+    denial = _check_permission(command_type, permissions, command.get("payload"))
     if denial is not None:
         logger.warning(
             "Command denied id=%s type=%s reason=%s", command_id, command_type, denial
@@ -158,6 +278,9 @@ def process_command(
                 "applied_keys": applied_keys,
             },
         }
+
+    if command_type in {"run_command", "run_script"}:
+        return _execute_local(command, script=command_type == "run_script")
 
     return {
         "command_id": command_id,

--- a/backend/src/homepot/app/api/API_v1/Endpoints/AgentsEndpoints.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/AgentsEndpoints.py
@@ -3,11 +3,14 @@
 import logging
 from typing import Any, Dict, List, Optional, cast
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
 
 from homepot.app.api.API_v1.Endpoints.DevicesEndpoints import _compute_connectivity
+from homepot.app.auth_utils import UserDict, require_user, verify_device_belongs_to_user
 from homepot.client import HomepotClient
-from homepot.models import ConnectivityState, HealthState
+from homepot.database import get_db
+from homepot.models import ConnectivityState, HealthState, User
 
 client_instance: Optional[HomepotClient] = None
 
@@ -172,31 +175,29 @@ async def get_agent_status(device_id: str) -> Dict[str, Any]:
 
 @router.post("/agents/{device_id}/push", tags=["Agents"])
 async def send_push_notification(
-    device_id: str, notification_data: Dict[str, Any]
+    device_id: str,
+    notification_data: Dict[str, Any],
+    sync_db: Session = Depends(get_db),
+    current_user: UserDict = Depends(require_user()),
 ) -> Dict[str, Any]:
-    """Send a direct push notification to a POS agent for testing.
+    """Send a non-executable notification to a POS agent.
 
-    The composed payload is relayed to the device command queue so real or
-    emulated device agents can consume it via the pending-commands channel,
-    in addition to any in-process simulated agent.
+    Executable actions must use the authenticated, permission-gated device
+    command endpoint instead.
     """
     from datetime import datetime, timezone
 
-    action = str(notification_data.get("action") or "unknown")
+    from homepot.database import get_database_service
 
-    try:
-        from homepot.database import get_database_service
-
-        db_service = await get_database_service()
-        device = await db_service.get_device_by_device_id(device_id)
-        if device is not None:
-            await db_service.create_device_command(
-                device_id=cast(int, device.id),
-                command_type=action,
-                payload=notification_data,
-            )
-    except Exception as e:
-        logger.warning(f"Failed to queue push command for {device_id}: {e}")
+    db_service = await get_database_service()
+    device = await db_service.get_device_by_device_id(device_id)
+    if device is None:
+        raise HTTPException(status_code=404, detail="Device not found")
+    db_user = cast(
+        User, sync_db.query(User).filter(User.email == current_user["email"]).first()
+    )
+    verify_device_belongs_to_user(db_user, device, sync_db, minimum_role="operator")
+    notification_data = {**notification_data, "action": "notification"}
 
     try:
         from homepot.agents import get_agent_manager
@@ -212,7 +213,7 @@ async def send_push_notification(
     if response is None:
         response = {
             "status": "success",
-            "message": f"Command '{action}' queued for device agent",
+            "message": "Notification accepted for device agent",
             "device_id": device_id,
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }

--- a/backend/src/homepot/app/api/API_v1/Endpoints/DeviceCommandsEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DeviceCommandsEndpoint.py
@@ -6,6 +6,10 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session as SASession
 
+from homepot.agent.utils.command_poller import (
+    COMMAND_TYPES,
+    required_permissions_for_command,
+)
 from homepot.app.auth_utils import (
     UserDict,
     get_current_device,
@@ -88,9 +92,35 @@ async def queue_command(
 
     verify_device_belongs_to_user(db_user, device, sync_db, minimum_role="operator")
 
+    command_type = command_request.command_type.strip().lower()
+    if command_type not in COMMAND_TYPES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unsupported command type: {command_request.command_type}",
+        )
+
+    permissions: Dict[str, bool] = (
+        device.device_permissions if isinstance(device.device_permissions, dict) else {}
+    )
+    required_permissions = required_permissions_for_command(
+        command_type, command_request.payload
+    )
+    missing_permissions = [
+        key for key in required_permissions if not permissions.get(key, False)
+    ]
+    if missing_permissions:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "message": "Device owner has not granted the required permissions",
+                "required_permissions": required_permissions,
+                "missing_permissions": missing_permissions,
+            },
+        )
+
     command = await db.create_device_command(
         device_id=device.id,  # type: ignore
-        command_type=command_request.command_type,
+        command_type=command_type,
         payload=command_request.payload,
     )
 
@@ -98,14 +128,14 @@ async def queue_command(
     audit_logger = get_audit_logger()
     await audit_logger.log_event(
         AuditEventType.COMMAND_QUEUED,
-        f"User '{current_user['email']}' queued {command_request.command_type} "
+        f"User '{current_user['email']}' queued {command_type} "
         f"command for device '{device_id}'",
         user_id=db_user.id,  # type: ignore
         device_id=device.id,  # type: ignore
         site_id=device.site_id,  # type: ignore
         new_values={
             "command_id": str(command.command_id),
-            "command_type": command_request.command_type,
+            "command_type": command_type,
             "payload": command_request.payload,
         },
     )
@@ -165,15 +195,10 @@ async def ack_command(
     updated = await db.update_command_status(
         command_id=command_id,
         status=CommandStatus.SENT,
+        device_id=cast(int, current_device.id),
     )
     if updated is None:
         raise HTTPException(status_code=404, detail="Command not found")
-
-    if updated.device_id != current_device.id:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Command does not belong to this device",
-        )
 
     return CommandResponse(
         command_id=updated.command_id,  # type: ignore
@@ -194,33 +219,15 @@ async def update_command_status(
     """Update the status of a command (e.g., COMPLETED, FAILED)."""
     db = await get_database_service()
 
-    # First check if command exists and belongs to device
-    # We do this inside update_command_status implicitly by checking ownership after fetch
-    # But to be safe and give 403, we might want to fetch first.
-    # For efficiency, let's just update and check the returned object's device_id if we were strict.
-    # But update_command_status in DB service doesn't check ownership.
-
-    # Let's fetch it first to verify ownership
-    # We don't have a direct get_command_by_id exposed yet, but update handles it.
-    # Let's trust the DB service update method for now, but we should verify ownership.
-    # I'll rely on the fact that the agent only knows command IDs it fetched.
-
     updated_command = await db.update_command_status(
-        command_id=command_id, status=request.status, result=request.result
+        command_id=command_id,
+        status=request.status,
+        result=request.result,
+        device_id=cast(int, current_device.id),
     )
 
     if not updated_command:
         raise HTTPException(status_code=404, detail="Command not found")
-
-    if updated_command.device_id != current_device.id:  # type: ignore
-        # Rollback or just warn?
-        # Ideally we shouldn't have updated it if it wasn't ours.
-        # But since we already committed in the DB service...
-        # this is a slight flaw in my DB service design for this specific check.
-        # However, for this phase, it's acceptable.
-        raise HTTPException(
-            status_code=403, detail="Command does not belong to this device"
-        )
 
     return CommandResponse(
         command_id=updated_command.command_id,  # type: ignore

--- a/backend/src/homepot/app/api/API_v1/Endpoints/DevicePermissionsEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DevicePermissionsEndpoint.py
@@ -32,9 +32,10 @@ from homepot.app.schemas.permissions import (
     DevicePermissions,
     DevicePermissionsResponse,
     DevicePermissionsUpdate,
+    derive_capabilities,
 )
 from homepot.database import get_db
-from homepot.models import Device, LifecycleState, User
+from homepot.models import AuditLog, Device, LifecycleState, User
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -55,9 +56,30 @@ def _normalise_permissions(raw: Any) -> Dict[str, bool]:
 def _get_capabilities_dict(device: Device) -> Dict[str, bool]:
     """Return device capabilities or all-``False`` when unset."""
     caps = device.capabilities
+    derived = derive_capabilities(cast(Optional[str], device.os_details))
     if not caps or not isinstance(caps, dict):
-        return {k: False for k in ALL_PERMISSION_KEYS}
-    return {k: bool(caps.get(k, False)) for k in ALL_PERMISSION_KEYS}
+        return derived
+    return {k: bool(caps.get(k, derived.get(k, False))) for k in ALL_PERMISSION_KEYS}
+
+
+def _audit_permission_change(
+    db: Session,
+    device: Device,
+    old_permissions: Dict[str, bool],
+    new_permissions: Dict[str, bool],
+    user_id: int | None = None,
+) -> None:
+    db.add(
+        AuditLog(
+            event_type="permission_change",
+            description=f"Permissions changed for device '{device.device_id}'",
+            user_id=user_id,
+            device_id=device.id,
+            site_id=device.site_id,
+            old_values=old_permissions,
+            new_values=new_permissions,
+        )
+    )
 
 
 def _validate_against_capabilities(
@@ -123,9 +145,11 @@ def update_device_permissions(
         _validate_against_capabilities(incoming, capabilities)
 
         current_perms = _normalise_permissions(current_device.device_permissions)
+        old_perms = dict(current_perms)
         current_perms.update(incoming)
 
         current_device.device_permissions = copy.deepcopy(current_perms)  # type: ignore[arg-type]
+        _audit_permission_change(db, current_device, old_perms, current_perms)
         db.commit()
 
         logger.info(
@@ -169,11 +193,11 @@ def admin_override_device_permissions(
     db: Session = Depends(get_db),
     current_user: UserDict = Depends(require_user()),
 ) -> Dict[str, Any]:
-    """Override a device's permissions (operator JWT auth).
+    """Revoke a device's permissions (operator JWT auth).
 
     Requires operator-level access on the device's site.
-    The operator can set any permission the device's OS supports
-    (validated against ``capabilities``).
+    Operators may revoke access in an emergency, but only the device owner can
+    grant access through the User App consent flow.
     """
     try:
         device = db.query(Device).filter(Device.device_id == device_id).first()
@@ -189,12 +213,25 @@ def admin_override_device_permissions(
 
         capabilities = _get_capabilities_dict(device)
         incoming = payload.permissions.model_dump(exclude_unset=True)
+        attempted_grants = [key for key, value in incoming.items() if value]
+        if attempted_grants:
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "message": "Only the device owner can grant permissions",
+                    "permissions": attempted_grants,
+                },
+            )
         _validate_against_capabilities(incoming, capabilities)
 
         current_perms = _normalise_permissions(device.device_permissions)
+        old_perms = dict(current_perms)
         current_perms.update(incoming)
 
         device.device_permissions = copy.deepcopy(current_perms)  # type: ignore[arg-type]
+        _audit_permission_change(
+            db, device, old_perms, current_perms, user_id=cast(int, db_user.id)
+        )
         db.commit()
 
         logger.info(

--- a/backend/src/homepot/app/schemas/permissions.py
+++ b/backend/src/homepot/app/schemas/permissions.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 ALL_PERMISSION_KEYS = [
     "root_access",
+    "command_execution",
     "process_monitoring",
     "filesystem_access",
     "network_monitoring",
@@ -34,6 +35,7 @@ def derive_capabilities(os_details: Optional[str]) -> Dict[str, bool]:
     if "android" in os_lower:
         return {
             "root_access": False,
+            "command_execution": True,
             "process_monitoring": True,
             "filesystem_access": True,
             "network_monitoring": True,
@@ -42,6 +44,7 @@ def derive_capabilities(os_details: Optional[str]) -> Dict[str, bool]:
     if any(kw in os_lower for kw in ["windows", "win32", "win64"]):
         return {
             "root_access": False,
+            "command_execution": True,
             "process_monitoring": True,
             "filesystem_access": True,
             "network_monitoring": True,
@@ -53,6 +56,7 @@ def derive_capabilities(os_details: Optional[str]) -> Dict[str, bool]:
     if any(kw in os_lower for kw in ["ios", "ipados", "iphone os", "ipad"]):
         return {
             "root_access": False,
+            "command_execution": False,
             "process_monitoring": False,
             "filesystem_access": False,
             "network_monitoring": True,
@@ -65,6 +69,7 @@ class DeviceCapabilities(BaseModel):
     """Which permission flags a device's OS can support."""
 
     root_access: bool = Field(default=False)
+    command_execution: bool = Field(default=False)
     process_monitoring: bool = Field(default=False)
     filesystem_access: bool = Field(default=False)
     network_monitoring: bool = Field(default=False)
@@ -74,6 +79,9 @@ class DevicePermissions(BaseModel):
     """Device permission grants schema."""
 
     root_access: bool = Field(default=False, description="Can execute commands as root")
+    command_execution: bool = Field(
+        default=False, description="Can execute technician commands and scripts"
+    )
     process_monitoring: bool = Field(
         default=False, description="Can monitor running processes"
     )
@@ -88,6 +96,7 @@ class DevicePermissions(BaseModel):
         json_schema_extra={
             "example": {
                 "root_access": False,
+                "command_execution": False,
                 "process_monitoring": True,
                 "filesystem_access": False,
                 "network_monitoring": True,
@@ -106,6 +115,7 @@ class DevicePermissionsUpdate(BaseModel):
             "example": {
                 "permissions": {
                     "root_access": False,
+                    "command_execution": False,
                     "process_monitoring": True,
                     "filesystem_access": False,
                     "network_monitoring": True,

--- a/backend/src/homepot/database.py
+++ b/backend/src/homepot/database.py
@@ -727,6 +727,7 @@ class DatabaseService:
         command_id: str,
         status: CommandStatus,
         result: Optional[Dict[str, Any]] = None,
+        device_id: Optional[int] = None,
     ) -> Optional[DeviceCommand]:
         """Update command status."""
         from datetime import datetime, timezone
@@ -736,6 +737,8 @@ class DatabaseService:
         async with self.get_session() as session:
             # Fetch first to ensure existence and get object
             stmt = select(DeviceCommand).where(DeviceCommand.command_id == command_id)
+            if device_id is not None:
+                stmt = stmt.where(DeviceCommand.device_id == device_id)
             exec_result = await session.execute(stmt)
             command = exec_result.scalar_one_or_none()
 

--- a/backend/tests/test_agent_command_polling.py
+++ b/backend/tests/test_agent_command_polling.py
@@ -1,5 +1,7 @@
 """Tests for command polling and push wake-up utilities."""
 
+from unittest.mock import patch
+
 from homepot.agent.utils.command_poller import (
     build_status_update_payload,
     parse_pending_commands,
@@ -53,6 +55,7 @@ class TestParsePendingCommands:
 
 ALLOW_ALL: dict[str, bool] = {
     "root_access": True,
+    "command_execution": True,
     "process_monitoring": True,
     "filesystem_access": True,
     "network_monitoring": True,
@@ -60,6 +63,7 @@ ALLOW_ALL: dict[str, bool] = {
 
 DENY_ALL: dict[str, bool] = {
     "root_access": False,
+    "command_execution": False,
     "process_monitoring": False,
     "filesystem_access": False,
     "network_monitoring": False,
@@ -155,6 +159,70 @@ class TestProcessCommand:
         result = process_command({"command_id": "c1", "command_type": "restart"})
         assert result["status"] == "failed"
         assert "not available" in result["result"]["error"]
+
+    def test_run_command_requires_command_execution(self):
+        """Command execution is denied without the owner grant."""
+        result = process_command(
+            {
+                "command_id": "c1",
+                "command_type": "run_command",
+                "payload": {"data": {"command": "whoami"}},
+            },
+            DENY_ALL,
+        )
+        assert result["status"] == "failed"
+        assert "command_execution" in result["result"]["error"]
+
+    def test_root_command_requires_both_grants(self):
+        """Root execution requires command and root grants."""
+        permissions = {**ALLOW_ALL, "root_access": False}
+        result = process_command(
+            {
+                "command_id": "c1",
+                "command_type": "run_command",
+                "payload": {"data": {"command": "id", "run_as_root": True}},
+            },
+            permissions,
+        )
+        assert result["status"] == "failed"
+        assert "root_access" in result["result"]["error"]
+
+    def test_script_cannot_embed_sudo_without_root_request(self):
+        """Scripts cannot bypass explicit root approval with embedded sudo."""
+        result = process_command(
+            {
+                "command_id": "c1",
+                "command_type": "run_script",
+                "payload": {"data": {"script": "echo ready\nsudo id"}},
+            },
+            ALLOW_ALL,
+        )
+        assert result["status"] == "failed"
+        assert "run_as_root" in result["result"]["error"]
+
+    @patch("homepot.agent.utils.command_poller.subprocess.run")
+    def test_root_script_uses_non_interactive_sudo(self, run):
+        """Approved root scripts use non-interactive sudo."""
+        run.return_value.returncode = 0
+        run.return_value.stdout = "root\n"
+        run.return_value.stderr = ""
+        result = process_command(
+            {
+                "command_id": "c1",
+                "command_type": "run_script",
+                "payload": {
+                    "data": {
+                        "script": "id -u",
+                        "run_as_root": True,
+                        "timeout_seconds": 10,
+                    }
+                },
+            },
+            ALLOW_ALL,
+        )
+        assert result["status"] == "completed"
+        assert run.call_args.args[0] == ["sudo", "-n", "--", "/bin/sh", "-s"]
+        assert run.call_args.kwargs["input"] == "id -u"
 
 
 class TestBuildStatusUpdatePayload:

--- a/backend/tests/test_device_commands.py
+++ b/backend/tests/test_device_commands.py
@@ -144,7 +144,7 @@ def test_device_command_flow(client: TestClient):
 
     # 3. Queue Command (as authenticated admin)
     command_payload = {
-        "command_type": "REBOOT",
+        "command_type": "ping",
         "payload": {"reason": "integration_test"},
     }
     response = client.post(
@@ -168,7 +168,7 @@ def test_device_command_flow(client: TestClient):
     for cmd in pending_cmds:
         if cmd["command_id"] == command_id:
             found = True
-            assert cmd["command_type"] == "REBOOT"
+            assert cmd["command_type"] == "ping"
             break
     assert found, "Queued command not found in pending list"
 
@@ -255,7 +255,7 @@ def _queue_command(
     client: TestClient,
     device_id: str,
     headers: Dict[str, str],
-    command_type: str = "REBOOT",
+    command_type: str = "ping",
 ) -> str:
     """Queue a command and return its command_id."""
     resp = client.post(
@@ -267,14 +267,81 @@ def _queue_command(
     return resp.json()["command_id"]
 
 
+def _set_permissions(device_id: str, permissions: Dict[str, bool]) -> None:
+    db = homepot.database.SessionLocal()
+    try:
+        device = db.query(Device).filter(Device.device_id == device_id).first()
+        assert device is not None
+        device.device_permissions = permissions
+        db.commit()
+    finally:
+        db.close()
+
+
+def test_run_command_requires_owner_grant(client: TestClient) -> None:
+    """The API rejects commands before the owner grants execution."""
+    ctx = _setup_site_and_device(client)
+    _set_permissions(ctx["device_id"], {"command_execution": False})
+
+    resp = client.post(
+        f"/api/v1/devices/{ctx['device_id']}/commands",
+        json={
+            "command_type": "run_command",
+            "payload": {"data": {"command": "whoami"}},
+        },
+        headers=ctx["auth_headers"],
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["missing_permissions"] == ["command_execution"]
+
+
+def test_run_command_queues_after_owner_grant(client: TestClient) -> None:
+    """The API queues commands after owner approval."""
+    ctx = _setup_site_and_device(client)
+    _set_permissions(ctx["device_id"], {"command_execution": True})
+
+    resp = client.post(
+        f"/api/v1/devices/{ctx['device_id']}/commands",
+        json={
+            "command_type": "run_command",
+            "payload": {"data": {"command": "whoami"}},
+        },
+        headers=ctx["auth_headers"],
+    )
+
+    assert resp.status_code == 201
+    assert resp.json()["command_type"] == "run_command"
+
+
+def test_root_command_requires_separate_root_grant(client: TestClient) -> None:
+    """The API requires a separate root grant for sudo execution."""
+    ctx = _setup_site_and_device(client)
+    _set_permissions(
+        ctx["device_id"], {"command_execution": True, "root_access": False}
+    )
+
+    resp = client.post(
+        f"/api/v1/devices/{ctx['device_id']}/commands",
+        json={
+            "command_type": "run_command",
+            "payload": {"data": {"command": "id", "run_as_root": True}},
+        },
+        headers=ctx["auth_headers"],
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["missing_permissions"] == ["root_access"]
+
+
 def test_command_history_endpoint(client: TestClient) -> None:
     """GET /devices/device/{device_id}/commands returns command history."""
     ctx = _setup_site_and_device(client)
     h = ctx["auth_headers"]
     device_id = ctx["device_id"]
 
-    cmd1 = _queue_command(client, device_id, h, "REBOOT")
-    cmd2 = _queue_command(client, device_id, h, "UPDATE_CONFIG")
+    cmd1 = _queue_command(client, device_id, h, "ping")
+    cmd2 = _queue_command(client, device_id, h, "ping")
 
     resp = client.get(f"/api/v1/devices/device/{device_id}/commands", headers=h)
     assert resp.status_code == 200
@@ -283,8 +350,8 @@ def test_command_history_endpoint(client: TestClient) -> None:
     assert len(data) >= 2
 
     # Most recent command first (desc by created_at)
-    assert data[0]["command_type"] == "UPDATE_CONFIG"
-    assert data[1]["command_type"] == "REBOOT"
+    assert data[0]["command_type"] == "ping"
+    assert data[1]["command_type"] == "ping"
     assert data[0]["command_id"] == cmd2
     assert data[1]["command_id"] == cmd1
 
@@ -311,7 +378,7 @@ def test_expire_stale_commands(client: TestClient) -> None:
     h = ctx["auth_headers"]
     device_id = ctx["device_id"]
 
-    cmd_id = _queue_command(client, device_id, h, "PING")
+    cmd_id = _queue_command(client, device_id, h, "ping")
 
     # Directly manipulate the command's created_at to be in the past
     db = homepot.database.SessionLocal()

--- a/docs/agent-permissions-trust-model.md
+++ b/docs/agent-permissions-trust-model.md
@@ -47,17 +47,22 @@ device.
    reaches the device
 6. **Agent executes** only commands that pass the permission gate (U5)
 
+Technician commands and scripts require `command_execution`. When a command or
+script sets `run_as_root: true`, it additionally requires `root_access`. Root
+execution uses non-interactive `sudo`; an unavailable or disallowed sudo policy
+fails the command rather than prompting on the device.
+
 ## Heterogeneous device handling
 
 Each OS platform exposes different capabilities. The architecture handles
 this through device-reported OS DNA (set at provision/registration time):
 
-| OS | `root_access` | `process_monitoring` | `filesystem_access` | `network_monitoring` |
-|---|---|---|---|---|
-| Linux | ✓ | ✓ | ✓ | ✓ |
-| Windows | ✗ | ✓ | ✓ | ✓ |
-| iOS (non-jailbroken) | ✗ | ✗ | ✗ | ✓ |
-| Android | ✓ (rooted) / ✗ | ✓ | ✓ | ✓ |
+| OS | `root_access` | `command_execution` | `process_monitoring` | `filesystem_access` | `network_monitoring` |
+|---|---|---|---|---|---|
+| Linux | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Windows | ✗ | ✓ | ✓ | ✓ | ✓ |
+| iOS (non-jailbroken) | ✗ | ✗ | ✗ | ✗ | ✓ |
+| Android | ✗ | ✓ | ✓ | ✓ | ✓ |
 
 A future capability-to-permission mapping layer will reject PATCH requests
 for permissions the device's OS cannot support.
@@ -74,6 +79,10 @@ for permissions the device's OS cannot support.
 4. Device agent receives push payload, executes within granted scope
 5. Result flows back via heartbeat / telemetry
 ```
+
+The backend checks grants before queueing and the agent checks them again before
+acknowledging or executing. Operators may revoke permissions, but grants must
+come from the device owner through the User App.
 
 ## Benefits of the split-plane design
 

--- a/docs/device-emulators.md
+++ b/docs/device-emulators.md
@@ -177,8 +177,8 @@ Composed push commands (`update_pos_payment_config`, `restart_pos_app`, `health_
 
 The emulator models the **device-side consent** half of the platform permission
 model (see `backend/src/homepot/app/schemas/permissions.py`). The four
-permission keys are `root_access`, `process_monitoring`, `filesystem_access`,
-`network_monitoring`; which keys a device can support are derived from its
+permission keys are `root_access`, `command_execution`, `process_monitoring`,
+`filesystem_access`, `network_monitoring`; which keys a device can support are derived from its
 `os_details` (mirrored from the backend's `derive_capabilities`), so changing
 the emulated OS changes the capabilities the Dashboard shows.
 

--- a/emulators/linux_pos_emulator.py
+++ b/emulators/linux_pos_emulator.py
@@ -68,12 +68,24 @@ API_BASE_PATH = "/api/v1"
 
 ALL_PERMISSION_KEYS = [
     "root_access",
+    "command_execution",
     "process_monitoring",
     "filesystem_access",
     "network_monitoring",
 ]
 
-PERMISSION_CONSENT_MODES = ("auto", "fixed", "deny")
+PERMISSION_CONSENT_MODES = ("auto", "fixed", "deny", "external")
+
+COMMAND_PERMISSIONS = {
+    "health_check": "command_execution",
+    "restart": "root_access",
+    "restart_pos_app": "command_execution",
+    "run_command": "command_execution",
+    "run_script": "command_execution",
+    "shutdown": "root_access",
+    "update_config": "filesystem_access",
+    "update_pos_payment_config": "filesystem_access",
+}
 
 
 def derive_os_capabilities(os_details: str) -> dict[str, bool]:
@@ -320,6 +332,44 @@ class LinuxPOSEmulator:
         # ``auto`` and ``fixed`` start by granting every supported permission.
         return {k: bool(self._capabilities.get(k, False)) for k in ALL_PERMISSION_KEYS}
 
+    async def _refresh_device_permissions(self) -> bool:
+        try:
+            resp = await self._http.get(
+                f"{self._backend}/devices/device/{self.device_id}/permissions",
+                headers=self._headers(),
+            )
+            if resp.status_code >= 400:
+                print(f"  [permissions] refresh error: {resp.status_code}")
+                return False
+            data = resp.json().get("data", {})
+            permissions = data.get("permissions", {})
+            if not isinstance(permissions, dict):
+                return False
+            self._granted = {
+                key: bool(permissions.get(key, False)) for key in ALL_PERMISSION_KEYS
+            }
+            return True
+        except httpx.RequestError as exc:
+            print(f"  [permissions] refresh connection error: {exc}")
+            return False
+
+    def _permission_denial(self, command_type: str, payload: object) -> str | None:
+        required: list[str] = []
+        base_permission = COMMAND_PERMISSIONS.get(command_type)
+        if base_permission:
+            required.append(base_permission)
+        payload_dict = payload if isinstance(payload, dict) else {}
+        data = payload_dict.get("data")
+        command_data = data if isinstance(data, dict) else payload_dict
+        if command_type in ("run_command", "run_script") and command_data.get(
+            "run_as_root", False
+        ):
+            required.append("root_access")
+        missing = [key for key in required if not self._granted.get(key, False)]
+        if missing:
+            return f"Permission denied: {', '.join(missing)} not granted"
+        return None
+
     def _consent_for_request(self) -> bool:
         """Whether the simulated owner consents to an operator permission request."""
         if self.config.permission_consent_mode == "deny":
@@ -393,6 +443,10 @@ class LinuxPOSEmulator:
         await self._report_permission_audit(permission, granted, requested_by, action)
 
     async def _apply_default_consent(self) -> None:
+        if self.config.permission_consent_mode == "external":
+            await self._refresh_device_permissions()
+            print("  [permissions] consent managed by User App")
+            return
         self._granted = self._default_permission_grants()
         await self._update_device_permissions(dict(self._granted))
         print(
@@ -822,6 +876,31 @@ class LinuxPOSEmulator:
         print(f"  [commands] processing {ctype} ({cid})")
 
         try:
+            if (
+                ctype == "request_permission"
+                and self.config.permission_consent_mode == "external"
+            ):
+                return
+
+            payload = cmd.get("payload")
+            denial: str | None
+            if not await self._refresh_device_permissions():
+                denial = "Permission state unavailable"
+            else:
+                denial = self._permission_denial(ctype, payload)
+            if denial:
+                status_resp = await self._http.put(
+                    f"{self._backend}/devices/{cid}/status",
+                    json={"status": "failed", "result": {"error": denial}},
+                    headers=self._headers(),
+                )
+                print(f"  [commands] rejected {ctype}: {denial}")
+                if status_resp.status_code >= 400:
+                    print(
+                        f"  [commands] rejection update failed: {status_resp.status_code}"
+                    )
+                return
+
             ack_resp = await self._http.post(
                 f"{self._backend}/devices/{self.device_id}/commands/{cid}/ack",
                 headers=self._headers(),
@@ -834,7 +913,6 @@ class LinuxPOSEmulator:
             if ctype == "status_request":
                 status_report = self._status_report()
 
-            payload = cmd.get("payload")
             simulated_result = self._simulate_command_result(
                 ctype, status_report, payload
             )

--- a/frontend/src/pages/Device/DeviceWidgets.jsx
+++ b/frontend/src/pages/Device/DeviceWidgets.jsx
@@ -548,6 +548,7 @@ export const DeviceInfoWidget = ({ device }) => (
 
 const PERMISSION_LABELS = {
   root_access: 'Root Access',
+  command_execution: 'Command & Script Execution',
   process_monitoring: 'Process Monitoring',
   filesystem_access: 'Filesystem Access',
   network_monitoring: 'Network Monitoring',

--- a/frontend/src/pages/Device/PushReview.jsx
+++ b/frontend/src/pages/Device/PushReview.jsx
@@ -2,14 +2,30 @@ import { Button } from '@/components/ui/button';
 import { Toast } from '@/components/ui/Toast';
 import api from '@/services/api';
 // Cleaned up unused imports that were causing blank page errors
-import { AlertTriangle, ArrowLeft, FileJson, MessageSquare, Rocket, Terminal } from 'lucide-react';
+import { AlertTriangle, ArrowLeft, FileJson, MessageSquare, Rocket, ShieldAlert, Terminal } from 'lucide-react';
 import React, { useEffect, useState, useRef } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 
 // Predefined templates for common commands
 const COMMAND_TEMPLATES = {
+  RUN_COMMAND: {
+    label: 'Run Command',
+    action: 'run_command',
+    permission: 'command_execution',
+    defaultData: { command: 'uname -a', run_as_root: false, timeout_seconds: 30 },
+    description: 'Run one executable with arguments. Shell operators are not interpreted.',
+  },
+  RUN_SCRIPT: {
+    label: 'Run Script',
+    action: 'run_script',
+    permission: 'command_execution',
+    defaultData: { script: '#!/bin/sh\nid', run_as_root: false, timeout_seconds: 30 },
+    description: 'Run a POSIX shell script supplied through standard input.',
+  },
   APPLY_CONFIG: {
     label: 'Apply Configuration',
+    action: 'update_pos_payment_config',
+    permission: 'filesystem_access',
     defaultData: {
       volume: 50,
       brightness: 75,
@@ -20,6 +36,8 @@ const COMMAND_TEMPLATES = {
   },
   REBOOT_DEVICE: {
     label: 'Reboot Device',
+    action: 'restart_pos_app',
+    permission: 'command_execution',
     defaultData: {
       delay_seconds: 10,
       reason: 'Scheduled maintenance',
@@ -28,6 +46,8 @@ const COMMAND_TEMPLATES = {
   },
   UPDATE_FIRMWARE: {
     label: 'Update Firmware',
+    action: 'update_pos_payment_config',
+    permission: 'filesystem_access',
     defaultData: {
       version: '2.4.0',
       url: 'https://firmware.homepot.io/v2.4.0.bin',
@@ -37,18 +57,30 @@ const COMMAND_TEMPLATES = {
   },
   RUN_DIAGNOSTICS: {
     label: 'Run Diagnostics',
+    action: 'health_check',
+    permission: 'command_execution',
     defaultData: {
       tests: ['network', 'storage', 'memory'],
       upload_logs: true,
     },
     description: 'Execute self-tests and report status.',
   },
-  CUSTOM: {
-    label: 'Custom Command',
-    defaultData: {},
-    description: 'Send a raw command payload.',
-  },
 };
+
+const PERMISSION_LABELS = {
+  command_execution: 'Command & Script Execution',
+  filesystem_access: 'File System Access',
+  root_access: 'Root / Full Access',
+};
+
+const ACTION_TO_TEMPLATE = Object.fromEntries(
+  Object.entries(COMMAND_TEMPLATES).map(([key, template]) => [template.action, key])
+);
+
+function initialTemplate(action) {
+  if (COMMAND_TEMPLATES[action]) return action;
+  return ACTION_TO_TEMPLATE[action] || 'APPLY_CONFIG';
+}
 
 export default function PushReview() {
   const { id } = useParams();
@@ -62,7 +94,7 @@ export default function PushReview() {
   // State for the Command Builder
   // Initialize from location state if available
   const [selectedCommand, setSelectedCommand] = useState(
-    location.state?.initialCommand || 'APPLY_CONFIG'
+    initialTemplate(location.state?.initialCommand)
   );
   const [commandData, setCommandData] = useState(
     location.state?.initialData
@@ -87,17 +119,23 @@ export default function PushReview() {
   });
 
   useEffect(() => {
+    let active = true;
     const fetchDevice = async () => {
       try {
         const deviceData = await api.devices.getDeviceById(id);
-        setDevice(deviceData);
+        if (active) setDevice(deviceData);
       } catch (err) {
         console.error('Failed to load device:', err);
       } finally {
-        setLoading(false);
+        if (active) setLoading(false);
       }
     };
     fetchDevice();
+    const interval = setInterval(fetchDevice, 5000);
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
   }, [id]);
 
   // Update body/title when command or device changes
@@ -150,6 +188,15 @@ export default function PushReview() {
     parsedData = { error: 'Invalid JSON' };
   }
 
+  const template = COMMAND_TEMPLATES[selectedCommand];
+  const requiredPermissions = [
+    template?.permission,
+    ...(parsedData.run_as_root ? ['root_access'] : []),
+  ].filter(Boolean);
+  const missingPermissions = requiredPermissions.filter(
+    (permission) => !device?.device_permissions?.[permission]
+  );
+
   const payloadPreview = {
     title: payloadConfig.title,
     body: payloadConfig.body,
@@ -168,28 +215,7 @@ export default function PushReview() {
     setSending(true);
 
     try {
-      // Send the push notification via API
-      // We map the selected command to the action expected by the agent
-      let action = 'unknown';
-
-      // Map UI constants to Backend Actions
-      if (selectedCommand === 'APPLY_CONFIG') action = 'update_pos_payment_config';
-      else if (selectedCommand === 'REBOOT_DEVICE') action = 'restart_pos_app';
-      else if (selectedCommand === 'RUN_DIAGNOSTICS') action = 'health_check';
-      else if (selectedCommand === 'UPDATE_FIRMWARE') action = 'update_pos_payment_config';
-      // Support Reuse: If selectedCommand IS the backend action (from history), use it directly
-      else if (
-        ['update_pos_payment_config', 'restart_pos_app', 'health_check'].includes(selectedCommand)
-      ) {
-        action = selectedCommand;
-      }
-      // Support Custom: functionality via JSON payload
-      else if (selectedCommand === 'CUSTOM' || action === 'unknown') {
-        // Try to find action in the user-provided JSON
-        if (parsedData.action) action = parsedData.action;
-        // If still unknown, but selectedCommand is not one of the template keys, maybe selectedCommand IS the action
-        else if (selectedCommand !== 'CUSTOM') action = selectedCommand;
-      }
+      const action = template.action;
 
       // Ensure data has required fields for the agent simulator
       const finalPayload = {
@@ -202,25 +228,8 @@ export default function PushReview() {
         },
       };
 
-      const response = await api.agents.sendPush(id, finalPayload);
-
-      // Check if the agent reported an error
-      if (response.response && response.response.status === 'error') {
-        throw new Error(response.response.message || 'Agent reported an internal error');
-      }
-
-      // Check for warnings (e.g. DB log failure)
-      if (response.response && response.response.warning) {
-        setToast({
-          message: `Success, but DB Log Failed: ${response.response.warning}`,
-          type: 'error',
-        });
-        return; // Stay on page to show error
-      }
-
-      const jobId = response.response?.device_id
-        ? `job-${response.response.device_id.substring(0, 8)}`
-        : `job-${Math.random().toString(36).substr(2, 8)}`;
+      const response = await api.devices.triggerAction(id, action, finalPayload);
+      const jobId = response.command_id?.substring(0, 8) || 'queued';
 
       setToast({
         message: `Command Sent Successfully! Job ID: ${jobId}`,
@@ -234,6 +243,23 @@ export default function PushReview() {
       console.error('Failed to send push:', err);
       setToast({
         message: `Failed to send command: ${err.message || 'Unknown error'}`,
+        type: 'error',
+      });
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const handleRequestAccess = async () => {
+    setSending(true);
+    try {
+      for (const permission of missingPermissions) {
+        await api.devices.requestPermission(id, permission);
+      }
+      setToast({ message: 'Access request sent to the device owner.', type: 'success' });
+    } catch (err) {
+      setToast({
+        message: err.response?.data?.detail?.message || err.message || 'Access request failed',
         type: 'error',
       });
     } finally {
@@ -267,7 +293,7 @@ export default function PushReview() {
             </div>
           </div>
           <Button
-            onClick={handleSend}
+            onClick={missingPermissions.length ? handleRequestAccess : handleSend}
             disabled={sending || !!jsonError}
             className={`px-4 h-9 ${jsonError ? 'bg-slate-700 cursor-not-allowed' : 'bg-teal-600 hover:bg-teal-500 text-white'}`}
           >
@@ -275,8 +301,11 @@ export default function PushReview() {
               'Sending...'
             ) : (
               <>
-                <Rocket className="h-4 w-4 mr-2" />
-                Push Command
+                {missingPermissions.length ? (
+                  <><ShieldAlert className="h-4 w-4 mr-2" />Request Access</>
+                ) : (
+                  <><Rocket className="h-4 w-4 mr-2" />Queue Command</>
+                )}
               </>
             )}
           </Button>
@@ -313,6 +342,15 @@ export default function PushReview() {
                       {COMMAND_TEMPLATES[selectedCommand]?.description || 'Custom command'}
                     </p>
                   </div>
+                </div>
+
+                <div className={`border rounded-lg px-3 py-2 text-xs ${
+                  missingPermissions.length
+                    ? 'border-amber-700/60 bg-amber-950/30 text-amber-300'
+                    : 'border-emerald-700/50 bg-emerald-950/20 text-emerald-300'
+                }`}>
+                  Required: {requiredPermissions.map((key) => PERMISSION_LABELS[key]).join(' + ')}
+                  {missingPermissions.length > 0 && ' — awaiting device-owner approval'}
                 </div>
 
                 {/* JSON Data Editor */}

--- a/frontend/src/pages/Device/PushReview.jsx
+++ b/frontend/src/pages/Device/PushReview.jsx
@@ -2,7 +2,15 @@ import { Button } from '@/components/ui/button';
 import { Toast } from '@/components/ui/Toast';
 import api from '@/services/api';
 // Cleaned up unused imports that were causing blank page errors
-import { AlertTriangle, ArrowLeft, FileJson, MessageSquare, Rocket, ShieldAlert, Terminal } from 'lucide-react';
+import {
+  AlertTriangle,
+  ArrowLeft,
+  FileJson,
+  MessageSquare,
+  Rocket,
+  ShieldAlert,
+  Terminal,
+} from 'lucide-react';
 import React, { useEffect, useState, useRef } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 
@@ -302,9 +310,15 @@ export default function PushReview() {
             ) : (
               <>
                 {missingPermissions.length ? (
-                  <><ShieldAlert className="h-4 w-4 mr-2" />Request Access</>
+                  <>
+                    <ShieldAlert className="h-4 w-4 mr-2" />
+                    Request Access
+                  </>
                 ) : (
-                  <><Rocket className="h-4 w-4 mr-2" />Queue Command</>
+                  <>
+                    <Rocket className="h-4 w-4 mr-2" />
+                    Queue Command
+                  </>
                 )}
               </>
             )}
@@ -344,11 +358,13 @@ export default function PushReview() {
                   </div>
                 </div>
 
-                <div className={`border rounded-lg px-3 py-2 text-xs ${
-                  missingPermissions.length
-                    ? 'border-amber-700/60 bg-amber-950/30 text-amber-300'
-                    : 'border-emerald-700/50 bg-emerald-950/20 text-emerald-300'
-                }`}>
+                <div
+                  className={`border rounded-lg px-3 py-2 text-xs ${
+                    missingPermissions.length
+                      ? 'border-amber-700/60 bg-amber-950/30 text-amber-300'
+                      : 'border-emerald-700/50 bg-emerald-950/20 text-emerald-300'
+                  }`}
+                >
                   Required: {requiredPermissions.map((key) => PERMISSION_LABELS[key]).join(' + ')}
                   {missingPermissions.length > 0 && ' — awaiting device-owner approval'}
                 </div>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -373,6 +373,20 @@ const api = {
       const response = await apiClient.post(`/devices/${deviceId}/commands`, payload);
       return response.data;
     },
+
+    requestPermission: async (deviceId, permission, action = 'grant') => {
+      const response = await apiClient.post(`/devices/${deviceId}/commands`, {
+        command_type: 'request_permission',
+        payload: {
+          data: {
+            permission,
+            action,
+            requested_by: 'Dashboard technician',
+          },
+        },
+      });
+      return response.data;
+    },
   },
 
   // ==================== Jobs ====================

--- a/user_app/electron/main.ts
+++ b/user_app/electron/main.ts
@@ -301,6 +301,7 @@ function registerIpcHandlers() {
       heartbeat_interval_seconds: 10,
       telemetry_interval_seconds: 15,
       command_poll_interval_seconds: 15,
+      permission_consent_mode: 'external',
     }
 
     ensureCredentialsDir()

--- a/user_app/src/components/PermissionConsentPrompt.tsx
+++ b/user_app/src/components/PermissionConsentPrompt.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { credentialStorage } from '../services/credentialStorage'
 import {
   fetchPendingCommands,
-  ackCommand,
   updatePermissions,
   updateCommandStatus,
   reportPermissionAudit,
@@ -11,6 +10,7 @@ import type { PendingCommand } from '../services/api'
 
 const PERMISSION_LABELS: Record<string, string> = {
   root_access: 'Root / Full Access',
+  command_execution: 'Command & Script Execution',
   process_monitoring: 'Process Monitoring',
   filesystem_access: 'File System Access',
   network_monitoring: 'Network Monitoring',
@@ -47,7 +47,6 @@ export default function PermissionConsentPrompt() {
         c => c.command_type === 'request_permission' && !handledRef.current.has(c.command_id),
       )
       if (!cmd) return
-      await ackCommand(dId, aKey, cmd.command_id)
       if (requestRef.current) return
       setRequest(cmd)
       requestRef.current = cmd

--- a/user_app/src/test/permissionConsent.test.tsx
+++ b/user_app/src/test/permissionConsent.test.tsx
@@ -34,7 +34,6 @@ describe('PermissionConsentPrompt', () => {
   it('shows a prompt when a request_permission command is pending', async () => {
     mockFetch
       .mockResolvedValueOnce(ok([pendingCommand])) // GET /pending
-      .mockResolvedValueOnce(ok({})) // ack
     render(<PermissionConsentPrompt />)
     expect(await screen.findByText('Permission request')).toBeInTheDocument()
     expect(screen.getByText(/admin@example\.com/)).toBeInTheDocument()
@@ -56,7 +55,6 @@ describe('PermissionConsentPrompt', () => {
   it('grants the permission on accept', async () => {
     mockFetch
       .mockResolvedValueOnce(ok([pendingCommand])) // GET /pending
-      .mockResolvedValueOnce(ok({})) // ack
       .mockResolvedValueOnce(ok({})) // PATCH permissions
       .mockResolvedValueOnce(ok({})) // audit
       .mockResolvedValueOnce(ok({})) // PUT status
@@ -88,7 +86,6 @@ describe('PermissionConsentPrompt', () => {
   it('denies the permission on deny', async () => {
     mockFetch
       .mockResolvedValueOnce(ok([pendingCommand])) // GET /pending
-      .mockResolvedValueOnce(ok({})) // ack
       .mockResolvedValueOnce(ok({})) // PATCH permissions
       .mockResolvedValueOnce(ok({})) // audit
       .mockResolvedValueOnce(ok({})) // PUT status
@@ -116,7 +113,6 @@ describe('PermissionConsentPrompt', () => {
     }
     mockFetch
       .mockResolvedValueOnce(ok([revokeCommand])) // GET /pending
-      .mockResolvedValueOnce(ok({})) // ack
     render(<PermissionConsentPrompt />)
     expect(await screen.findByText('Revoke access requested')).toBeInTheDocument()
     expect(screen.getByText('Approve revocation')).toBeInTheDocument()

--- a/user_app/src/views/Permissions.tsx
+++ b/user_app/src/views/Permissions.tsx
@@ -12,7 +12,8 @@ interface PermissionEntry {
 }
 
 const PERMISSION_DEFS: { key: string; label: string; description: string }[] = [
-  { key: 'root_access', label: 'Root / Full Access', description: 'Allows full system scan' },
+  { key: 'root_access', label: 'Root / Full Access', description: 'Allow approved commands and scripts to use sudo' },
+  { key: 'command_execution', label: 'Command & Script Execution', description: 'Allow Dashboard technicians to run commands and scripts' },
   { key: 'process_monitoring', label: 'Process Monitoring', description: 'View running processes' },
   { key: 'filesystem_access', label: 'File System Access', description: 'Scan files & folders' },
   { key: 'network_monitoring', label: 'Network Monitoring', description: 'Track network connections' },
@@ -164,9 +165,10 @@ export default function Permissions() {
   }
 
   useEffect(() => {
+    const pendingDebounces = debounceRef.current
     return () => {
-      debounceRef.current.forEach(t => clearTimeout(t))
-      debounceRef.current.clear()
+      pendingDebounces.forEach(t => clearTimeout(t))
+      pendingDebounces.clear()
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- add a dedicated `command_execution` permission and require a separate `root_access` grant for sudo execution
- route Dashboard commands through the authenticated, permission-gated device queue and allow technicians to request missing access from the device owner
- enforce the same command policy in the backend, real agent, and emulator, including bounded output, timeouts, non-interactive sudo, and privilege-escalation bypass protection
- make User App consent retryable, remove embedded-emulator consent races, audit permission changes, and restrict operator overrides to revocation
- secure the legacy push endpoint as authenticated notification-only behavior
- update permission/trust documentation and add command permission regression tests

## Validation
- `mypy --config-file=backend/mypy.ini backend/src/homepot/ ai/ uq/ emulators/` - 159 files passed
- Black - 182 files passed
- isort - passed
- Flake8 - all touched backend files passed; repository-wide check retains unrelated legacy findings in emulator docstrings, TimescaleDB, and Mobivisor files
- backend focused permission/integration tests - 120 passed
- Dashboard - 19 tests passed; production build passed
- User App - 90 tests passed; production build passed
- emulator Python compilation and `git diff --check` - passed

## Operational note
Root commands use `sudo -n` and require a suitable least-privilege `NOPASSWD` sudoers policy for the agent service account. Without that policy, root commands fail closed.