### PR TITLE
feat: add User App reset and window-reopen support to start script

### DIFF
--- a/docs/get_start_userapp.md
+++ b/docs/get_start_userapp.md
@@ -44,7 +44,8 @@ Avoids running `nvm use` every time you open a new terminal.
 
 | Command | What it does |
 |---|---|
-| `./scripts/start-userapp.sh` | Automatically check requirements and start the App via `nohup` |
+| `./scripts/start-userapp.sh` | Automatically check requirements and start the App via `nohup`; if the App is already running, reopens its window |
+| `./scripts/start-userapp.sh --reset` | Clear stored device credentials and start the App **directly into the Setup wizard** so a new device can be provisioned |
 | `./scripts/stop-userapp.sh` | Kill the `nohup` server processes running the user app |
 | `npm run dev` | Start local dev server at http://localhost:5174 |
 | `npm run build` | Production build → output to `dist/` |
@@ -64,6 +65,8 @@ This method automates Node version checking, port validation, and background log
 ```
 
 **Note:** Logs go to `logs/userapp.log`. To stop it, run `./scripts/stop-userapp.sh`.
+
+**Resuming / reopening:** Closing the App window does **not** quit the App — it hides it to the system tray so the running device (and any in-progress setup) is preserved. Re-running `./scripts/start-userapp.sh` detects the running App and reopens its window so you can pick up exactly where you left off. If the App is not running at all, it starts fresh and resumes your provisioned credentials and emulator automatically.
 
 ### Option 2: Manual Start
 
@@ -108,9 +111,21 @@ When you open the app for the first time you will see the **Setup Wizard (Page 1
 3. Click **Login with SSO** to authenticate
 4. Click **Complete Setup** — app moves to the Home Dashboard
 
-### Reset the wizard (for testing)
+### Reset the wizard (for testing / provisioning a new device)
 
-Open browser DevTools → **Application** → **Local Storage** → delete `homepot_token` → refresh.
+The app stores the provisioned device's credentials in `~/.homepot/credentials`.
+Once provisioned, the app opens on the **Home Dashboard**. To start a fresh
+setup and provision a new device, clear those credentials **before** launching:
+
+```bash
+# Stop the app if it is running, then relaunch in reset mode
+./scripts/stop-userapp.sh
+./scripts/start-userapp.sh --reset
+```
+
+`--reset` deletes the stored credentials and boots the app straight into the
+Setup wizard. You can also run `./scripts/start-userapp.sh --help` for a list
+of options.
 
 ---
 

--- a/docs/verify-user-app-with-emulator.md
+++ b/docs/verify-user-app-with-emulator.md
@@ -169,6 +169,17 @@ In **Terminal 2**, first start the HOMEPOT **User App** — the device-side UI (
 ./scripts/start-userapp.sh
 ```
 
+If the User App was used before on this machine, it opens on the **Home
+Dashboard** instead of the wizard. To provision a **new** device, relaunch it in
+reset mode:
+
+```bash
+./scripts/start-userapp.sh --reset
+```
+
+`--reset` clears the stored credentials (`~/.homepot/credentials`) so the Setup
+wizard opens again.
+
 The **HOMEPOT Agent** Electron window opens with the setup wizard. Walk through
 it with the handed-off site info: enter the **Site ID**, the **Bootstrap Key**, a
 **Device Name**, and pick a device type. As you type the device name, the
@@ -327,6 +338,8 @@ Back in **Terminal 1** / the Dashboard browser:
 | Symptom | Cause / fix |
 |---------|-------------|
 | "Device name ... already in use" (400) | A live device in the site already uses that name (case-insensitive). Pick a different name, or retire/unpair the old device first. |
+| User App opens on Home instead of the Setup wizard | The device is already provisioned (`~/.homepot/credentials` exists). Relaunch with `./scripts/start-userapp.sh --reset` to clear it and start a fresh setup. |
+| User App window is gone but the app is still running | Closing the window hides it to the system tray (the process, running emulator, and setup state are preserved). Re-run `./scripts/start-userapp.sh` to reopen the window, or click the tray icon. |
 | Device never appears on the Dashboard | Bootstrap key typo, or wrong `--site-id`. The key is single-use-ish — generate a new one in Step 2. |
 | Emulator re-provisions but Dashboard shows the old device | Stale credentials file — delete `~/.homepot/emulators/<device_name>.json` and re-run **with a different `--device-name`** (the old name is still registered and the duplicate check will reject it). |
 | `health_state` shows `error` on a healthy device | The legacy simulator was enabled (`ENABLE_AGENT_SIMULATION=true`). Restart the backend with it disabled (Step 0). |

--- a/scripts/start-userapp.sh
+++ b/scripts/start-userapp.sh
@@ -5,7 +5,12 @@
 #
 # This script starts the HOMEPOT User App (Agent) locally.
 #
-# Usage: ./scripts/start-userapp.sh
+# Usage: ./scripts/start-userapp.sh [--reset]
+#
+# Options:
+#   -r, --reset   Clear stored device credentials and boot directly into the
+#                 Setup wizard so a new device can be provisioned.
+#   -h, --help    Show usage information.
 ################################################################################
 
 set -e
@@ -72,6 +77,46 @@ userapp_ready() {
 }
 
 ################################################################################
+# Command-line Arguments
+################################################################################
+
+RESET_MODE=false
+
+show_help() {
+    cat <<EOF
+Usage: ./scripts/start-userapp.sh [--reset]
+
+Starts the HOMEPOT User App (Agent) desktop application.
+
+Options:
+  -r, --reset   Clear stored device credentials and boot directly into the
+                Setup wizard so a new device can be provisioned.
+  -h, --help    Show this help message.
+EOF
+    exit 0
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        -r|--reset) RESET_MODE=true ;;
+        -h|--help) show_help ;;
+        *) print_error "Unknown argument: $arg"; show_help ;;
+    esac
+done
+
+if [ "$RESET_MODE" = true ]; then
+    print_step "Reset mode: clearing stored device credentials..."
+    CREDENTIALS_FILE="$HOME/.homepot/credentials"
+    if [ -f "$CREDENTIALS_FILE" ]; then
+        rm -f "$CREDENTIALS_FILE"
+        print_success "Removed $CREDENTIALS_FILE"
+    else
+        print_info "No stored credentials found at $CREDENTIALS_FILE"
+    fi
+    "$SCRIPT_DIR/stop-userapp.sh" >/dev/null 2>&1 || true
+fi
+
+################################################################################
 # Prerequisites Check
 ################################################################################
 
@@ -108,6 +153,14 @@ if [ -f "$PID_FILE" ]; then
     EXISTING_PID="$(cat "$PID_FILE" 2>/dev/null || true)"
     if [[ "$EXISTING_PID" =~ ^[0-9]+$ ]] && userapp_ready "$EXISTING_PID"; then
         print_success "Electron User App is already running (PID: $EXISTING_PID)"
+        # The app holds a single-instance lock. Relaunching Electron briefly
+        # triggers its 'second-instance' handler, which shows and focuses the
+        # existing (possibly hidden, in-tray) window. Then it exits on its own.
+        print_info "Reopening the User App window..."
+        (
+            cd "$REPO_ROOT/user_app"
+            nohup "$ELECTRON_BIN" . --no-sandbox >/dev/null 2>&1 &
+        )
         exit 0
     fi
     print_warning "Cleaning an incomplete or stale User App process"
@@ -217,5 +270,8 @@ echo ""
 echo -e "${GREEN}Next Steps:${NC}"
 echo -e "  1. The Electron User App is ready."
 echo -e "  2. Complete setup in the ${BLUE}HOMEPOT Agent${NC} desktop window."
+echo -e ""
+echo -e "  ${YELLOW}Tip:${NC} To provision a new device later, stop the app and run"
+echo -e "       ${CYAN}$SCRIPT_DIR/start-userapp.sh --reset${NC}"
 echo ""
 exit 0


### PR DESCRIPTION
## Summary

Enhances `scripts/start-userapp.sh` so a test technician can control the User App lifecycle from the CLI:

- **`--reset` / `-r`** — clears stored device credentials (`~/.homepot/credentials`) and boots the App directly into the **Setup wizard** so a new device can be provisioned.
- **`--help` / `-h`** — prints usage.
- **Window reopen** — when the App is already running, relaunching Electron briefly triggers its single-instance `second-instance` handler, which shows + focuses the existing (possibly hidden, in-tray) window, picks up exactly where the user left off, then the transient process exits on its own.

## Background

Closing the Electron window does **not** quit the App — it hides it to the system tray so the running device (and any in-progress setup) is preserved. Previously, re-running the script only printed "already running" and exited `0` without restoring the window. Now it reopens the App, and if the App is not running at all it starts fresh and auto-resumes provisioned credentials and the emulator.

## Changes

- `scripts/start-userapp.sh`: add argument parsing, `--reset`/`--help`, and the already-running window-reopen branch (matches the app's real launch invocation `electron . --no-sandbox`); add a trailing newline.
- `docs/get_start_userapp.md`: run-commends table row, a "Resuming / reopening" note, and replaced the outdated DevTools/localStorage reset instructions with `--reset`.
- `docs/verify-user-app-with-emulator.md`: reset instructions plus a troubleshooting row for the hidden-window case.

## Verification

- `bash -n` passes; `--help` prints usage.
- Cold start: App auto-resumes provisioned credentials and the persisted POS emulator.
- Already-running path: prints "already running" + "Reopening the User App window...", `second-instance` handler fired (recorded in the app-events log), transient relaunch exits cleanly, main App stays stable.