### PR TITLE
fix: rename test to avoid TruffleHog Lob false positive

### DIFF
--- a/backend/tests/test_pos_emulator_os_capabilities.py
+++ b/backend/tests/test_pos_emulator_os_capabilities.py
@@ -77,7 +77,7 @@ def test_derive_push_channel(os_details, expected_push_channel):
         ("Linux 6.8.0 (Debian 12)", None),
     ],
 )
-def test_push_hooks_derive_channel_and_token(os_details, expected_channel):
+def test_derive_push_channel_and_token_for_os(os_details, expected_channel):
     """The engine hooks expose a synthetic token only for push-capable OSes."""
     if expected_channel is None:
         cfg = emu.build_config(emu.parse_args([], defaults=None), defaults=None)


### PR DESCRIPTION
## Summary
Clears the post-merge `Secret Scanning` (TruffleHog) failure caused by a **false positive**.

On PR #269's merge, GitHub Secret Scanning (TruffleHog, `--only-verified`) flagged commit `ce8fa5d` with detector `Lob`, raw value `test_push_hooks_derive_channel_and_token`. This is a **Python test function name**, not a real credential. TruffleHog's `Lob` regex matches the `test_...<token>` pattern.

## Fix
Renamed the function in `backend/tests/test_pos_emulator_os_capabilities.py` to `test_derive_push_channel_and_token_for_os`.

## Verification
- TruffleHog `--only-verified` over the exact CI diff range (`ce8fa5d → this head`): `TOTAL FLAGGED: 0`.
- CI-identical quality gates pass: black, isort, flake8, mypy (164 files, no issues).
- No real credentials exist anywhere on the branch (checked full diff).