### PR TITLE
feat: show Operating System in device info panel

### DIFF
--- a/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
@@ -485,6 +485,12 @@ async def get_device(
                 or (device.config.get("wan_ip") if device.config else "N/A"),
                 "os_details": device.os_details
                 or (device.config.get("os_details") if device.config else "N/A"),
+                "os_family": os_family(
+                    device.config.get("os")
+                    if device.config and isinstance(device.config, dict)
+                    else None
+                )
+                or os_family(cast(Optional[str], device.os_details)),
                 "firmware_version": device.firmware_version
                 or (device.config.get("firmware_version") if device.config else "N/A"),
                 "last_seen": device.last_seen.isoformat() if device.last_seen else None,

--- a/backend/tests/test_homepot_integration.py
+++ b/backend/tests/test_homepot_integration.py
@@ -603,6 +603,8 @@ class TestDeviceSiteFields:
             data = resp.json()
             assert "last_heartbeat_at" in data
             assert "credential_status" in data
+            assert "os_family" in data
+            assert "os_details" in data
 
     def test_device_list_includes_new_fields(self, client: TestClient) -> None:
         """GET /devices/device includes last_heartbeat_at and credential_status."""

--- a/backend/tests/test_os_family.py
+++ b/backend/tests/test_os_family.py
@@ -302,3 +302,27 @@ def test_devices_by_site_includes_os_family(file_db: Any) -> None:
     assert by_id["android-dev-1"]["os_family"] == "android"
     # No OS info anywhere -> no canonical family
     assert by_id["no-info-dev-1"]["os_family"] is None
+
+
+def test_single_device_includes_os_family(file_db: Any) -> None:
+    """GET /devices/device/{device_id} exposes os_family for the info panel."""
+    _seed_site_with_devices(
+        "site-device-family",
+        [
+            {
+                "device_id": "linux-dev-1",
+                "name": "linux-pos-1",
+                "os_details": "Ubuntu 22.04",
+                "config": {"os": "Ubuntu 22.04", "device_source": "emulator"},
+            },
+        ],
+    )
+    token = _admin_token()
+    headers = {"Authorization": f"Bearer {token}"}
+
+    client = TestClient(app)
+    response = client.get("/api/v1/devices/device/linux-dev-1", headers=headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["os_family"] == "linux"
+    assert data["os_details"] == "Ubuntu 22.04"

--- a/frontend/src/pages/Device/DeviceWidgets.jsx
+++ b/frontend/src/pages/Device/DeviceWidgets.jsx
@@ -15,6 +15,7 @@ import {
   Settings,
 } from 'lucide-react';
 import React from 'react';
+import OsIcon from '@/components/common/OsIcon';
 
 /* === Reusable UI Components === */
 export function Card({ children, className = '' }) {
@@ -524,6 +525,13 @@ export const DeviceInfoWidget = ({ device }) => (
         <span className="text-slate-400">Type</span>
         <span className="text-slate-200 uppercase">
           {device?.device_type?.replace(/_/g, ' ') || 'N/A'}
+        </span>
+      </div>
+      <div className="flex justify-between">
+        <span className="text-slate-400">Operating System</span>
+        <span className="flex items-center gap-1.5 text-slate-200">
+          {device?.os_family && <OsIcon type={device.os_family} size="w-3.5 h-3.5" />}
+          <span>{device?.os_details || device?.os_family || 'N/A'}</span>
         </span>
       </div>
       <div className="flex justify-between">


### PR DESCRIPTION
## Summary
Adds the **Operating System** to the **DEVICE INFO** panel on the device detail page (currently only `Type` was shown).

## Changes
- **Backend — `DevicesEndpoints.py`**: the single-device GET endpoint (`/devices/device/{device_id}`) now returns a canonical `os_family` key per device, computed via the shared `os_family` helper with the same config-first/`os_details`-fallback used by the site-devices endpoint. `os_details` was already returned.
- **Frontend — `DeviceWidgets.jsx`** (`DeviceInfoWidget`): added an **Operating System** row after `Type`, rendering the shared `OsIcon` + OS name (falls back to the family key, then `N/A`).

## Verification
- CI-identical quality gates pass: black, isort, flake8, mypy.
- `pytest`: new `test_single_device_includes_os_family` + extended `test_device_get_includes_last_heartbeat_at` pass, plus related suites (63 tests).
- Frontend `npm run build` and `eslint` pass.