### PR TITLE
fix: align credential status badge with active/inactive source

### DIFF
--- a/backend/tests/test_homepot_integration.py
+++ b/backend/tests/test_homepot_integration.py
@@ -605,6 +605,7 @@ class TestDeviceSiteFields:
             assert "credential_status" in data
             assert "os_family" in data
             assert "os_details" in data
+            assert data.get("credential_status") in {"active", "inactive"}
 
     def test_device_list_includes_new_fields(self, client: TestClient) -> None:
         """GET /devices/device includes last_heartbeat_at and credential_status."""
@@ -616,6 +617,7 @@ class TestDeviceSiteFields:
             d = devices[0]
             assert "last_heartbeat_at" in d
             assert "credential_status" in d
+            assert d.get("credential_status") in {"active", "inactive"}
 
     def test_devices_by_site_includes_new_fields(self, client: TestClient) -> None:
         """GET /devices/sites/{site_id}/devices includes new fields."""

--- a/frontend/src/pages/Device/DeviceWidgets.jsx
+++ b/frontend/src/pages/Device/DeviceWidgets.jsx
@@ -480,13 +480,9 @@ export const DeviceInfoWidget = ({ device }) => (
         <span className="text-slate-400">Credential</span>
         <span
           className={`px-2 py-0.5 rounded text-xs font-medium uppercase ${
-            device?.credential_status === 'valid'
-              ? 'bg-emerald-500/10 text-emerald-400'
-              : device?.credential_status === 'expiring'
-                ? 'bg-yellow-500/10 text-yellow-400'
-                : device?.credential_status === 'expired' || device?.credential_status === 'invalid'
-                  ? 'bg-red-500/10 text-red-400'
-                  : 'bg-slate-700 text-slate-300'
+            device?.credential_status === 'active'
+              ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20'
+              : 'bg-red-500/10 text-red-400 border border-red-500/20'
           }`}
         >
           {device?.credential_status || 'N/A'}


### PR DESCRIPTION
## Summary
Fixes the **Credential** badge in the DEVICE INFO panel on the device detail page.

## Problem
The backend emits `credential_status` as `"active" | "inactive"` in all device endpoints (single, list, site-devices), derived from whether any device credential is `is_active`. The badge was styling the values `valid/expiring/expired/invalid`, which never occur — so every credential fell through to the grey fallback. A valid/active credential rendered as neutral grey instead of green, and the 4-color branches were dead code.

## Change
- **`DeviceWidgets.jsx`**: map `active` → emerald, everything else → red, matching the real `active`/`inactive` contract.
- **`test_homepot_integration.py`**: lock the contract by asserting `credential_status` is one of `active`/`inactive` for the single-device and list endpoints.

## Verification
- `npm run build` and `eslint` pass.
- black / isort / flake8 pass on the changed test file; targeted pytest passes.