### PR TITLE
feat: label Device ID / Site ID consistently

### DIFF
--- a/frontend/src/pages/Device/DeviceList.jsx
+++ b/frontend/src/pages/Device/DeviceList.jsx
@@ -168,7 +168,7 @@ export default function DeviceList() {
                 <h2 className="text-lg font-semibold text-white truncate">
                   {device.name || device.device_id}
                 </h2>
-                <p className="text-sm text-gray-400 truncate">ID: {device.device_id}</p>
+                <p className="text-sm text-gray-400 truncate">Device ID: {device.device_id}</p>
               </div>
 
               <div className="mt-auto space-y-2">

--- a/frontend/src/pages/Sites/SiteDetail.jsx
+++ b/frontend/src/pages/Sites/SiteDetail.jsx
@@ -164,7 +164,7 @@ export default function SiteDetail() {
             <div>
               <h1 className="text-3xl font-bold tracking-tight mb-1 text-white">{site.name}</h1>
               <div className="flex items-center text-teal-400/80 font-mono text-sm mb-2">
-                ID: {site.site_id || site.id}
+                Site ID: {site.site_id || site.id}
               </div>
               <div className="flex items-center text-gray-400">
                 <MapPin className="h-4 w-4 mr-1.5" />

--- a/frontend/src/pages/Sites/SitesList.jsx
+++ b/frontend/src/pages/Sites/SitesList.jsx
@@ -213,7 +213,7 @@ export default function SitesList() {
                 </h2>
                 <div className="flex flex-col gap-1 mt-1 mb-2">
                   <p className="text-xs font-mono text-teal-400/70 text-start truncate">
-                    ID: {site.site_id || site.id}
+                    Site ID: {site.site_id || site.id}
                   </p>
                   <p className="text-sm text-gray-400 text-start truncate">
                     {site.location || 'No location'}


### PR DESCRIPTION
## Summary
Match the ID labels across pages with the `Device ID:` prefix used on the device detail header.

## Changes
- `DeviceList.jsx`: `ID:` → `Device ID:`
- `SitesList.jsx`: `ID:` → `Site ID:`
- `SiteDetail.jsx`: `ID:` → `Site ID:`

## Verification
- `npm run build` and `eslint` pass.