### PR TITLE
feat: auto-generate canonical site IDs (SITE-XXXX-XXXX)

### DIFF
--- a/backend/src/homepot/app/api/API_v1/Endpoints/SitesEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/SitesEndpoint.py
@@ -1,6 +1,8 @@
 """API endpoints for managing sites in the HomePot system."""
 
 import logging
+import re
+import secrets
 from typing import Any, Dict, List, Optional, cast
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -31,6 +33,25 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+# Unambiguous alphabet for site IDs: excludes easily-confused characters
+# (0/O, 1/I/L).
+_SITE_ID_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789"
+# Canonical format: SITE-XXXX-XXXX (three groups)
+_SITE_ID_PATTERN = re.compile(r"^SITE-[A-HJ-KM-NP-Z2-9]{4}-[A-HJ-KM-NP-Z2-9]{4}$")
+
+
+def generate_site_id() -> str:
+    """Generate a canonical site ID: ``SITE-XXXX-XXXX``.
+
+    Uses only unambiguous uppercase alphanumerics so the ID can be read aloud
+    and typed without confusion during device enrollment.
+    """
+    parts: List[str] = []
+    for _ in range(2):
+        parts.append("".join(secrets.choice(_SITE_ID_ALPHABET) for _ in range(4)))
+    return f"SITE-{parts[0]}-{parts[1]}"
+
+
 class SiteHealthResponse(BaseModel):
     """Response model for site health status."""
 
@@ -46,9 +67,14 @@ class SiteHealthResponse(BaseModel):
 
 
 class CreateSiteRequest(BaseModel):
-    """Request model for creating a new site."""
+    """Request model for creating a new site.
 
-    site_id: str
+    ``site_id`` is auto-generated server-side (``SITE-XXXX-XXXX``), so a
+    caller-name ``site_id`` is not required. It is still accepted for
+    backwards compatibility but ignored in favour of the generated value.
+    """
+
+    site_id: Optional[str] = None
     name: str
     description: Optional[str] = None
     location: Optional[str] = None
@@ -58,7 +84,6 @@ class CreateSiteRequest(BaseModel):
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
-                "site_id": "site-123",
                 "name": "Main Retail Store",
                 "description": "Primary retail location with 5 POS terminals",
                 "location": "London, UK",
@@ -85,16 +110,15 @@ async def create_site(
     try:
         db_service = await get_database_service()
 
-        # Check if site already exists
-        existing_site = await db_service.get_site_by_site_id(site_request.site_id)
-        if existing_site:
-            raise HTTPException(
-                status_code=409, detail=f"Site {site_request.site_id} already exists"
-            )
+        site_id = generate_site_id()
+        # Keep trying until we land on an unused id (collision is astronomically
+        # unlikely with 4+4 unambiguous chars, but stay safe).
+        while await db_service.get_site_by_site_id(site_id):
+            site_id = generate_site_id()
 
         # Create new site
         site = await db_service.create_site(
-            site_id=site_request.site_id,
+            site_id=site_id,
             name=site_request.name,
             description=site_request.description,
             location=site_request.location,

--- a/backend/src/homepot/main.py
+++ b/backend/src/homepot/main.py
@@ -27,6 +27,7 @@ from pydantic import BaseModel, ConfigDict
 
 from homepot.agents import get_agent_manager, stop_agent_manager
 from homepot.app.api.API_v1.Api import api_v1_router
+from homepot.app.api.API_v1.Endpoints.SitesEndpoint import generate_site_id
 from homepot.audit import AuditEventType, get_audit_logger
 from homepot.client import HomepotClient
 from homepot.config import get_settings
@@ -273,9 +274,14 @@ class SiteHealthResponse(BaseModel):
 
 
 class CreateSiteRequest(BaseModel):
-    """Request model for creating a new site."""
+    """Request model for creating a new site.
 
-    site_id: str
+    ``site_id`` is auto-generated server-side (``SITE-XXXX-XXXX``), so a
+    caller-supplied ``site_id`` is not required. It is still accepted for
+    backwards compatibility but ignored in favour of the generated value.
+    """
+
+    site_id: Optional[str] = None
     name: str
     description: Optional[str] = None
     location: Optional[str] = None
@@ -285,7 +291,6 @@ class CreateSiteRequest(BaseModel):
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
-                "site_id": "site-123",
                 "name": "Main Retail Store",
                 "description": "Primary retail location with 5 POS terminals",
                 "location": "London, UK",
@@ -543,16 +548,13 @@ async def create_site(site_request: CreateSiteRequest) -> Dict[str, str]:
     try:
         db_service = await get_database_service()
 
-        # Check if site already exists
-        existing_site = await db_service.get_site_by_site_id(site_request.site_id)
-        if existing_site:
-            raise HTTPException(
-                status_code=409, detail=f"Site {site_request.site_id} already exists"
-            )
+        site_id = generate_site_id()
+        while await db_service.get_site_by_site_id(site_id):
+            site_id = generate_site_id()
 
         # Create new site
         site = await db_service.create_site(
-            site_id=site_request.site_id,
+            site_id=site_id,
             name=site_request.name,
             description=site_request.description,
             location=site_request.location,

--- a/backend/tests/test_dev_server_smoke.py
+++ b/backend/tests/test_dev_server_smoke.py
@@ -188,13 +188,13 @@ class TestDevServerSmoke:
         )
         assert resp.status_code == 200, resp.text
         data = resp.json()
-        assert data["site_id"] == "new-site-001"
+        new_site_id = data["site_id"]
 
         # Create enrolment intent on that site
         resp = client.post(
-            "/api/v1/sites/new-site-001/enrolment-intents",
+            f"/api/v1/sites/{new_site_id}/enrolment-intents",
             json={
-                "site_id": "new-site-001",
+                "site_id": new_site_id,
                 "device_type": "pos_terminal",
                 "expires_in_hours": 48,
             },
@@ -469,13 +469,14 @@ class TestBootstrapProvisionDuplicateNames:
             headers=headers,
         )
         assert resp.status_code == 200, resp.text
+        site2_id = resp.json()["site_id"]
 
         key1 = _generate_bootstrap_key(client, "smoke-site-001")
-        key2 = _generate_bootstrap_key(client, "smoke-site-002")
+        key2 = _generate_bootstrap_key(client, site2_id)
 
         for site_id, key in (
             ("smoke-site-001", key1),
-            ("smoke-site-002", key2),
+            (site2_id, key2),
         ):
             resp = client.post(
                 "/api/v1/devices/bootstrap-provision",

--- a/backend/tests/test_device_commands.py
+++ b/backend/tests/test_device_commands.py
@@ -118,6 +118,7 @@ def test_device_command_flow(client: TestClient):
     response = client.post("/api/v1/sites/", json=site_data, headers=auth_headers)
     if response.status_code != 409:
         assert response.status_code == 200
+    site_id = response.json()["site_id"]
 
     # 2. Create Device directly in DB
     device_id = "test-device-cmd-flow"
@@ -218,6 +219,7 @@ def _setup_site_and_device(client: TestClient) -> Dict[str, Any]:
     )
     if resp.status_code not in (200, 409):
         assert False, f"Failed to create site: {resp.text}"
+    site_id = resp.json()["site_id"]
 
     device_id = "test-device-history"
     api_key = secrets.token_urlsafe(32)

--- a/backend/tests/test_homepot_integration.py
+++ b/backend/tests/test_homepot_integration.py
@@ -24,11 +24,11 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from homepot.app.auth_utils import create_access_token, hash_password
 from homepot.app.api.API_v1.Endpoints.SitesEndpoint import (
-    generate_site_id,
     _SITE_ID_PATTERN,
+    generate_site_id,
 )
+from homepot.app.auth_utils import create_access_token, hash_password
 from homepot.config import reload_settings
 import homepot.database
 from homepot.models import Base, User

--- a/backend/tests/test_homepot_integration.py
+++ b/backend/tests/test_homepot_integration.py
@@ -12,6 +12,7 @@ The tests use httpx for async HTTP testing and cover the full API surface.
 import asyncio
 from datetime import datetime, timezone
 import os
+import re
 import tempfile
 import time
 from typing import Any, AsyncGenerator, Generator
@@ -24,11 +25,23 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from homepot.app.auth_utils import create_access_token, hash_password
+from homepot.app.api.API_v1.Endpoints.SitesEndpoint import (
+    generate_site_id,
+    _SITE_ID_PATTERN,
+)
 from homepot.config import reload_settings
 import homepot.database
 from homepot.models import Base, User
 
 TEST_USER_EMAIL = "integration@test.local"
+
+
+def test_generate_site_id_is_canonical() -> None:
+    """generate_site_id produces the canonical SITE-XXXX-XXXX format."""
+    generated = {generate_site_id() for _ in range(200)}
+    assert len(generated) == 200  # effectively unique
+    for site_id in generated:
+        assert _SITE_ID_PATTERN.fullmatch(site_id) is not None
 
 
 def generate_random_id(prefix: str) -> str:
@@ -207,11 +220,10 @@ class TestPhase2APIEndpoints:
             assert "created_at" in site
 
     def test_create_site(self, client: TestClient) -> None:
-        """Test creating a new POS site."""
+        """Test creating a new POS site (server generates a canonical SITE ID)."""
         h = TestPhase2APIEndpoints._headers
-        site_id = generate_random_id("TEST_SITE")
         test_site = {
-            "site_id": site_id,
+            "site_id": "custom-id-ignored",
             "name": "Test Site",
             "location": "Test Location",
             "type": "test",
@@ -224,10 +236,12 @@ class TestPhase2APIEndpoints:
             data = response.json()
             assert "message" in data
             assert "site_id" in data
-            assert data["site_id"] == site_id
+            assert re.fullmatch(
+                r"SITE-[A-HJ-KM-NP-Z2-9]{4}-[A-HJ-KM-NP-Z2-9]{4}", data["site_id"]
+            )
         finally:
             if response.status_code == 200:
-                client.delete(f"/api/v1/sites/{site_id}", headers=h)
+                client.delete(f"/api/v1/sites/{data['site_id']}", headers=h)
 
     def test_site_health(self, client: TestClient) -> None:
         """Test site health monitoring."""
@@ -462,6 +476,7 @@ class TestEndToEndWorkflows:
 
         site_response = client.post("/api/v1/sites", json=test_site, headers=h)
         assert site_response.status_code == 200
+        site_id = site_response.json()["site_id"]
 
         test_device = {
             "site_id": site_id,
@@ -501,7 +516,7 @@ class TestEndToEndWorkflows:
         """Test agent management workflow: list, monitor, notify, restart."""
         h = TestEndToEndWorkflows._headers
         site_id = generate_random_id("AGENT_WF_SITE")
-        client.post(
+        site_resp = client.post(
             "/api/v1/sites",
             json={
                 "site_id": site_id,
@@ -511,6 +526,8 @@ class TestEndToEndWorkflows:
             },
             headers=h,
         )
+        assert site_resp.status_code == 200
+        site_id = site_resp.json()["site_id"]
         setup_device_id = generate_random_id("AGENT_WF_DEVICE")
         client.post(
             "/api/v1/devices/device",
@@ -695,11 +712,9 @@ class TestDashboardAggregates:
 
     @staticmethod
     def _create_site(client: TestClient, headers: dict) -> str:
-        site_id = generate_random_id("DASH_SITE")
         resp = client.post(
             "/api/v1/sites",
             json={
-                "site_id": site_id,
                 "name": "Dashboard Site",
                 "location": "Test",
                 "type": "test",
@@ -707,7 +722,7 @@ class TestDashboardAggregates:
             headers=headers,
         )
         assert resp.status_code == 200, f"Failed to create site: {resp.text}"
-        return site_id
+        return resp.json()["site_id"]
 
     @staticmethod
     def _create_device(client: TestClient, headers: dict, site_id: str) -> str:

--- a/frontend/src/pages/Sites/SiteForm.jsx
+++ b/frontend/src/pages/Sites/SiteForm.jsx
@@ -130,22 +130,22 @@ export default function SiteForm() {
               />
             </div>
 
-            <div className="space-y-2">
-              <label htmlFor="site_id" className="text-sm font-medium leading-none text-gray-300">
-                Site ID <span className="text-red-400">*</span>
-              </label>
-              <input
-                id="site_id"
-                name="site_id"
-                type="text"
-                required
-                className="flex h-10 w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary disabled:cursor-not-allowed disabled:opacity-50"
-                placeholder="e.g. site-123"
-                value={formData.site_id}
-                onChange={handleChange}
-                disabled={isEditMode} // Assuming ID shouldn't change after creation
-              />
-            </div>
+            {isEditMode && (
+              <div className="space-y-2">
+                <label htmlFor="site_id" className="text-sm font-medium leading-none text-gray-300">
+                  Site ID
+                </label>
+                <input
+                  id="site_id"
+                  name="site_id"
+                  type="text"
+                  disabled
+                  className="flex h-10 w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary disabled:cursor-not-allowed disabled:opacity-50"
+                  value={formData.site_id}
+                  onChange={handleChange}
+                />
+              </div>
+            )}
 
             <div className="space-y-2">
               <label htmlFor="location" className="text-sm font-medium leading-none text-gray-300">


### PR DESCRIPTION
## Summary
Site IDs are now **server-generated** using an unambiguous uppercase alphabet (`SITE-XXXX-XXXX`), so every created site follows one consistent, easy-to-communicate format for device enrollment.

## Changes
- **`SitesEndpoint.py`**: new `generate_site_id()` + canonical `_SITE_ID_PATTERN`. `create_site` no longer requires or trusts a client-supplied `site_id` — it generates one and retries on the (astronomically unlikely) collision. Alphabet excludes easily-confused chars (0/O, 1/I/L).
- **`main.py`**: mirrors auto-generation for the legacy `/sites` handler.
- **`SiteForm.jsx`**: removed the required Site ID input in create mode (auto-generated); shown read-only when editing.
- **Tests**: updated tests that asserted a caller-provided `site_id` is echoed back; added a unit test asserting the generated ID matches the canonical pattern and is effectively unique.

## Verification
- Full backend suite: 933 passed, 10 skipped (live-server/WebSocket/psutil tests excluded).
- black / isort / flake8 / mypy pass.
- Frontend `npm run build` + `eslint` pass.