### PR TITLE
fix: seed enrolment intents against the homepot_admin user

### DIFF
--- a/backend/utils/seed_data.py
+++ b/backend/utils/seed_data.py
@@ -919,7 +919,7 @@ async def init_database():
         site2 = await session.execute(select(Site).where(Site.site_id == "site-002"))
         site2 = site2.scalar_one()
 
-        admin_user = await session.execute(select(User).where(User.username == "analytics_admin"))
+        admin_user = await session.execute(select(User).where(User.username == "homepot_admin"))
         admin_user = admin_user.scalar_one()
 
         now = datetime.now(timezone.utc)


### PR DESCRIPTION
## Summary
Fixes the seed script's enrolment-intents stage failing with `NoResultFound`.

## Problem
`seed_data.py:922` queried a user named `analytics_admin` which the script never creates (it only creates `homepot_admin` and `homepot_client`). `db_utils/init-postgresql.sh` seeding aborted at that point, leaving the rest of the seed (operating schedules) uncreated.

## Change
- Look up the real seeded admin (`homepot_admin`) when creating enrolment intents.

## Verification
- `DATABASE__URL=... python backend/utils/seed_data.py` exits 0 with zero errors and creates enrolment intents + operating schedules.