### PR TITLE
docs: dev modes, service lifecycle, unified root logs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,7 +180,8 @@ docker-compose.override.yml
 .local/
 temp/
 tmp/
-logs/
+logs/*
+!logs/README.md
 
 # PostgreSQL - Database managed by system service
 # Database location: /var/lib/postgresql/16/main/

--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ We recommend running the project locally without Docker for the best development
 
 See [docs/getting-started.md](docs/getting-started.md) for full details.
 
+## Three Test Integration Modes
+
+The system supports **three** device integration modes. **Test technicians must know which mode they are running**, because each one produces telemetry through a different path:
+
+1. **Simulation** — The backend's in-process agent simulator (`ENABLE_AGENT_SIMULATION=true`, the default in `backend/.env`) starts a simulated agent for every active POS/IoT device on startup. It writes heartbeats, health checks, and metrics directly to the database, and flips devices from `pending` to `active`. No external process is needed.
+2. **Emulation** — Standalone emulator processes (`./scripts/start-emulator.sh`) authenticate against the backend and behave like real hardware over the agent API (device DNA, heartbeat, telemetry, command polling). Use for end-to-end testing of the device lifecycle and User App without physical hardware. See [Device Emulators](docs/device-emulators.md).
+3. **Real Devices** — Physical devices running the HOMEPOT agent (or the Dealdio integration) talk to the backend over the network via the agent API. See the [Agent API Contract](backend/README.md#agent-api-contract-pilot).
+
+> **Tip for test technicians:** if Simulation is disabled (`ENABLE_AGENT_SIMULATION=false`), the **Data Collection** page cannot be started, devices stay `pending`, and telemetry appears empty. Keep `ENABLE_AGENT_SIMULATION=true` to collect data via simulation.
+
 ## Documentation
 
 **Complete documentation is available at: [https://homepot-client.readthedocs.io/en/latest/](https://homepot-client.readthedocs.io/en/latest/)**
@@ -56,25 +66,31 @@ See [docs/getting-started.md](docs/getting-started.md) for full details.
 
 ```text
 homepot-client/
-├── backend/                 # Python backend service
-│   ├── src/homepot/         # Main Python package
-│   ├── tests/               # Backend tests
-│   ├── pyproject.toml       # Python configuration
-│   └── requirements.txt     # Python dependencies
-├── frontend/                # React frontend application
-│   ├── src/                 # Frontend source code
-│   ├── public/              # Static assets
-│   └── package.json         # npm dependencies
-├── ai/                      # AI/LLM services (future)
-│   └── README.md            # AI service documentation
-├── docs/                    # Documentation
-├── scripts/                 # Development and automation scripts
-├── data/                    # Database storage
-├── .github/                 # GitHub workflows
-├── docker-compose.yml       # Multi-service orchestration
-├── CONTRIBUTING.md          # Contribution guidelines
-├── LICENSE                  # Apache 2.0 license
-└── README.md                # This file
+├── ai                      # AI/LLM services
+│   └── README.md
+├── backend                 # Backend service
+│   └── README.md
+├── deploy                  # Real-Device helpers and env overrides
+│   └── README.md
+├── docs                    # Documentation (Read the Docs)
+│   └── README.md
+├── emulators               # Realistic OS/IoT device emulators (Linux, Android, macOS, Windows, iOS)
+│   └── README.md
+├── frontend                # Frontend service
+│   └── README.md
+├── logs                    # Realtime logging
+│   └── README.md
+├── scripts                 # Development and automation scripts
+│   └── README.md
+├── uq                      # VVUQ - Validation, Verification, Uncertainty Quantification
+│   └── README.md
+└── user_app                # Device-side User App (independent Electron agent)
+│   └── README.md
+├── .github/                # GitHub workflows
+├── docker-compose.yml      # Multi-service orchestration
+├── CONTRIBUTING.md         # Contribution guidelines
+├── LICENSE                 # Apache 2.0 license
+└── README.md               # This file
 ```
 
 > See [Monorepo Migration Guide](docs/monorepo-migration.md) for details on the new structure
@@ -118,6 +134,17 @@ This will start:
 - **Backend API**: http://localhost:8000 (with API docs at `/docs`)
 - **Frontend**: http://localhost:5173
 - **Test Account**: `admin@homepot.com` / `homepot_dev_password`
+
+> **Login fails with "Request failed with status code 500" / "Unable to login"?**
+> The most common cause is the **backend not running** on port 8000. The frontend proxies `/api` to `127.0.0.1:8000`, so when the backend is down, Vite returns a generic `500 Proxy error` for the login request. Verify with:
+> ```bash
+> curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8000/api/v1/health   # expect 200
+> ```
+> If it is not `200`, restart the backend. If you launch it manually from a shell that later terminates, use `setsid` (not plain `nohup`) so the process detaches from the shell's process group and survives:
+> ```bash
+> cd backend && source ../.venv/bin/activate
+> setsid env ENABLE_AGENT_SIMULATION=true python -m uvicorn homepot.app.main:app --host 0.0.0.0 --port 8000 --reload < /dev/null > /tmp/opencode/backend.log 2>&1 &
+> ```
 
 **See [Complete Dashboard Setup Guide](docs/complete-dashboard-setup.md) and [Dashboard Testing Guide](docs/dashboard-testing-guide.md)**
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ This will start:
 
 **See [Complete Dashboard Setup Guide](docs/complete-dashboard-setup.md) and [Dashboard Testing Guide](docs/dashboard-testing-guide.md)**
 
+> **Test technicians:** for the complete clean start/stop cycle across all five
+> services (backend, frontend, AI, emulator, User App), including a verified smoke
+> test, see **[Starting & Stopping All Services](docs/getting-started.md#starting--stopping-all-services)**.
+
 ### Analytics (Data Collection for AI)
 
 - Verify backend server is running

--- a/backend/README.md
+++ b/backend/README.md
@@ -41,6 +41,18 @@ pytest
 uvicorn homepot.app.main:app --reload
 ```
 
+## Test Integration Modes
+
+The backend supports **three** device modes. Test technicians must know which mode they are running, because each one produces telemetry through a different path:
+
+| Mode | How it works | Telemetry source | When to use |
+|------|--------------|------------------|-------------|
+| **1. Simulation** | The backend's built-in `DeviceAgentSimulator` (see `homepot/agents.py`) runs **in-process**. On startup it discovers active POS/IoT devices and starts a simulated agent per device, sending heartbeats, health checks, and metrics. Controlled by `ENABLE_AGENT_SIMULATION` (default `true` in `backend/.env`). | In-process simulator writes directly to the database. Devices become `lifecycle_state=active` when the agent starts. | Local demos, dashboards, AI training-data collection with no external processes. |
+| **2. Emulation** | Separate standalone Python processes (see `emulators/` and `scripts/start-emulator.sh`) authenticate against the backend and behave like a real device via the agent API (device DNA, heartbeat, telemetry, command polling). | HTTP agent endpoints from an external process. | End-to-end testing of the full device lifecycle + User App without physical hardware. |
+| **3. Real Devices** | Physical devices run the HOMEPOT agent (or the Dealdio integration) and talk to the backend over the network (see "Agent API Contract" below, e.g. `device-dna`, `heartbeat`, `telemetry`). | Real HTTP traffic from a device. | Production/field validation, acceptance testing. |
+
+> **Important for test technicians:** if `ENABLE_AGENT_SIMULATION` is unset or `false`, Simulation mode is disabled and the **Data Collection** page cannot be started, so devices stay `pending` and telemetry appears empty. To collect data via simulation, keep `ENABLE_AGENT_SIMULATION=true` — e.g. `ENABLE_AGENT_SIMULATION=true uvicorn homepot.app.main:app --reload`.
+
 ## Agent API Contract (Pilot)
 
 Use these endpoints for the Dealdio real-device flow:

--- a/backend/src/homepot/app/main.py
+++ b/backend/src/homepot/app/main.py
@@ -18,9 +18,12 @@ from homepot.database import get_database_service
 
 # Configure Log Rotation
 # This ensures backend.log doesn't grow infinitely
-# Assumes the application is run from the 'backend' directory
+# The log dir is resolved relative to this package so it is independent of the
+# process CWD: <repo-root>/logs
 try:
-    log_dir = os.path.abspath(os.path.join(os.getcwd(), "../logs"))
+    log_dir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "logs")
+    )
     os.makedirs(log_dir, exist_ok=True)
     log_file = os.path.join(log_dir, "backend.log")
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,30 @@
+# HOMEPOT Client Documentation
+
+This directory contains the full user, operator, and developer documentation,
+published to **Read the Docs** (mkdocs). Use its **short links** whenever you
+need to reference a topic:
+
+```bash
+https://homepot-client.readthedocs.io/en/latest/
+```
+
+## Entry points
+
+- **[Getting Started](getting-started.md)** - First-time setup and running locally
+- **[Device Emulators](device-emulators.md)** - Simulators/emulators reference
+- **[Data Collection](data-collection-guide.md)** - Collecting real telemetry for AI training
+
+## Structure
+
+- `index.md` — the mkdocs home page (Read the Docs landing)
+- `<topic>.md` — one markdown file per documentation topic
+- `mkdocs.yml` — site configuration (site name, nav, theme, plugins)
+
+## Building locally
+
+```bash
+mkdocs serve    # live preview at http://localhost:8000
+```
+
+> The docs are listed under **`docs/`** in the monorepo Project Structure tree;
+> see the top-level [`README.md`](../README.md) for the overall layout.

--- a/docs/accessing-dashboard.md
+++ b/docs/accessing-dashboard.md
@@ -10,7 +10,7 @@ To run the complete HOMEPOT system (Backend + Frontend), use the provided startu
 2.  Run the following command:
 
     ```bash
-    ./scripts/start-website.sh
+    ./scripts/start-dashboard.sh
     ```
 
     > **Note**: This script requires **Node.js 22+**. If you have an older version, the script will attempt to use `nvm` to switch to version 22 automatically.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -72,7 +72,7 @@ The system supports **three** device modes. **Test technicians should know which
 
 1. **Simulation** — The backend's in-process agent simulator (`ENABLE_AGENT_SIMULATION=true`, the default in `backend/.env`) starts a simulated agent for every active POS/IoT device on startup. It writes heartbeats, health checks, and metrics directly to the database, and flips devices from `pending` to `active`. No external process is needed.
 2. **Emulation** — Standalone emulator processes (`./scripts/start-emulator.sh`) authenticate against the backend and behave like real hardware over the agent API (device DNA, heartbeat, telemetry, command polling). Use this for end-to-end testing of the device lifecycle and User App without physical hardware. See [Device Emulators](device-emulators.md).
-3. **Real Devices** — Physical devices running the HOMEPOT agent (or the Dealdio integration) talk to the backend over the network. See the [Agent API Contract](../backend/README.md#agent-api-contract-pilot) in the backend README.
+3. **Real Devices** — Physical devices running the HOMEPOT agent (or the Dealdio integration) talk to the backend over the network. See the [Agent API Contract](getfudo-preparatory-tasks.md#3-api-contract-summary) for the endpoint summary.
 
 > **Tip for test technicians:** if Simulation is disabled (`ENABLE_AGENT_SIMULATION=false`), the **Data Collection** page cannot be started, devices stay `pending`, and telemetry appears empty. Keep `ENABLE_AGENT_SIMULATION=true` to collect data via simulation.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ Initialize the PostgreSQL database with the required schema and demo data. This 
 Use the following command to ensure any previous instances are stopped before starting the new session. This launches both the backend API and the frontend dashboard.
 
 ```bash
-./scripts/stop-website.sh && ./scripts/start-website.sh
+./scripts/stop-dashboard.sh && ./scripts/start-dashboard.sh
 ```
 
 ---
@@ -75,6 +75,79 @@ The system supports **three** device modes. **Test technicians should know which
 3. **Real Devices** — Physical devices running the HOMEPOT agent (or the Dealdio integration) talk to the backend over the network. See the [Agent API Contract](../backend/README.md#agent-api-contract-pilot) in the backend README.
 
 > **Tip for test technicians:** if Simulation is disabled (`ENABLE_AGENT_SIMULATION=false`), the **Data Collection** page cannot be started, devices stay `pending`, and telemetry appears empty. Keep `ENABLE_AGENT_SIMULATION=true` to collect data via simulation.
+
+## Starting & Stopping All Services
+
+The HOMEPOT platform runs **five** independent services. This section documents the
+clean start/stop cycle, which doubles as a smoke test to catch startup issues early.
+
+| Service | Log file (`logs/`) | PID file (`logs/`) | Start command | Stop command |
+|---------|--------------------|--------------------|---------------|--------------|
+| **Backend** (API :8000) | `backend.log`, `backend.out` | `backend.pid` | `./scripts/start-dashboard.sh` | `./scripts/stop-dashboard.sh` |
+| **Frontend** (Vite :5173) | `frontend.log` | `frontend.pid` | `./scripts/start-dashboard.sh` | `./scripts/stop-dashboard.sh` |
+| **AI / LLM** (Ollama :11434) | `ai.log` | `ai.pid` | `./scripts/setup-ollama.sh` | n/a (see note) |
+| **Emulator** (POS terminal) | `emulator.log` | `emulator.pid` | `./scripts/start-emulator.sh` | `./scripts/stop-emulator.sh` |
+| **User App** (Electron agent) | `userapp.log` | `userapp.pid` | `./scripts/start-userapp.sh` | `./scripts/stop-userapp.sh` |
+
+### Full Restart (verified smoke test)
+
+1.  **Stop all services** — terminate the dashboard pair, any emulator, and the
+    User App. (Ollama/AI is left running if it was already active on :11434.)
+
+    ```bash
+    ./scripts/stop-dashboard.sh          # backend + frontend
+    ./scripts/stop-emulator.sh           # any running emulator
+    ./scripts/stop-userapp.sh            # Electron User App
+    ```
+
+2.  **Verify nothing is left on the ports:**
+
+    ```bash
+    ss -tlnp | grep -E '8000|5173|11434'   # expect no listeners (or only 11434 = ollama)
+    ```
+
+3.  **Start the core platform** (backend + frontend):
+
+    ```bash
+    ./scripts/start-dashboard.sh
+    ```
+
+4.  **Start optional services** as needed:
+
+    ```bash
+    ./scripts/setup-ollama.sh             # AI / LLM service
+    ./scripts/start-emulator.sh --emulator linux \
+        --site-id SITE-P7K5-BPHZ \
+        --bootstrap-key <key> --device-name demo-pos-1
+    ./scripts/start-userapp.sh            # Electron User App
+    ```
+
+5.  **Verify every service**:
+
+    ```bash
+    curl -s -o /dev/null -w 'backend: %{http_code}\n' http://127.0.0.1:8000/api/v1/health
+    curl -s -o /dev/null -w 'frontend: %{http_code}\n' http://127.0.0.1:5173
+    curl -s -o /dev/null -w 'login: %{http_code}\n' \
+      -X POST http://127.0.0.1:8000/api/v1/auth/login \
+      -H 'Content-Type: application/json' \
+      -d '{"email":"admin@homepot.com","password":"homepot_dev_password"}'
+    ```
+
+    Every command should return `200`, and each service should have a matching
+    `.log` / `.pid` pair in `logs/`.
+
+> **Troubleshooting notes from a real smoke test:**
+>
+> - **Ollama running as a different OS user** (e.g. systemd `ollama` service): `lsof` on
+>   the port returns nothing under your user, so `setup-ollama.sh` probes the Ollama
+>   HTTP API (`/api/version`) and falls back to `pgrep` — it will reuse the existing
+>   instance and write its real PID to `ai.pid`. A stale/dead PID in `ai.pid` usually
+>   means the instance could not bind the port.
+> - **"Request failed with status code 500" at login** almost always means the
+>   **backend is not running** — Vite returns a proxy 500. Check
+>   `curl http://127.0.0.1:8000/api/v1/health` first.
+> - **Clean log reset:** delete everything in `logs/` (except `README.md`) before a
+>   fresh run to confirm each service recreates its files.
 
 ## Troubleshooting
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -66,6 +66,16 @@ Once the system is running, you can access:
 
 For detailed development information, refer to the [Development Guide](development-guide.md).
 
+## Three Test Integration Modes
+
+The system supports **three** device modes. **Test technicians should know which mode they are running**, because each one produces telemetry through a different path:
+
+1. **Simulation** — The backend's in-process agent simulator (`ENABLE_AGENT_SIMULATION=true`, the default in `backend/.env`) starts a simulated agent for every active POS/IoT device on startup. It writes heartbeats, health checks, and metrics directly to the database, and flips devices from `pending` to `active`. No external process is needed.
+2. **Emulation** — Standalone emulator processes (`./scripts/start-emulator.sh`) authenticate against the backend and behave like real hardware over the agent API (device DNA, heartbeat, telemetry, command polling). Use this for end-to-end testing of the device lifecycle and User App without physical hardware. See [Device Emulators](device-emulators.md).
+3. **Real Devices** — Physical devices running the HOMEPOT agent (or the Dealdio integration) talk to the backend over the network. See the [Agent API Contract](../backend/README.md#agent-api-contract-pilot) in the backend README.
+
+> **Tip for test technicians:** if Simulation is disabled (`ENABLE_AGENT_SIMULATION=false`), the **Data Collection** page cannot be started, devices stay `pending`, and telemetry appears empty. Keep `ENABLE_AGENT_SIMULATION=true` to collect data via simulation.
+
 ## Troubleshooting
 
 ### Login Page Returns 500 / Connection Refused (ECONNREFUSED)

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ Welcome to the HOMEPOT Client documentation! This comprehensive guide will help 
 
 ```bash
 # ONE COMMAND to run everything:
-./scripts/start-website.sh
+./scripts/start-dashboard.sh
 # Access:
 # Frontend: http://localhost:5173
 # Backend: http://localhost:8000

--- a/emulators/README.md
+++ b/emulators/README.md
@@ -1,0 +1,29 @@
+# Device Emulators
+
+This directory contains realistic **POS/IoT device emulators** for end-to-end
+testing of the full device lifecycle (device DNA, heartbeat, telemetry, command
+polling) against the HOMEPOT backend without physical hardware.
+
+| Emulator | Description |
+|----------|-------------|
+| `linux_pos_emulator.py`  | Linux point-of-sale terminal emulator |
+| `android_pos_emulator.py`| Android POS terminal emulator |
+| `macos_pos_emulator.py`  | macOS POS terminal emulator |
+| `windows_pos_emulator.py`| Windows POS terminal emulator |
+| `ios_pos_emulator.py`    | iOS tablet/terminal emulator |
+| `pos_engine.py`          | Shared emulator engine (health, telemetry, heartbeat, command handling) |
+| `*.json`                 | Default per-OS emulator configuration |
+
+Emulation is one of the **three test integration modes** (Simulation, Emulation,
+Real Devices); when running an emulator, keep `ENABLE_AGENT_SIMULATION=false` in
+the environment so simulated agents do not compete with the emulated device.
+
+## Quick start
+
+```bash
+./scripts/start-emulator.sh                    # default (Linux) emulator
+./scripts/start-emulator.sh --emulator android # Android emulator
+./scripts/start-emulator.sh --site-id <site> --bootstrap-key <key> --device-name demo-pos-1
+```
+
+Full usage and configuration details: [docs/device-emulators.md](../docs/device-emulators.md).

--- a/logs/README.md
+++ b/logs/README.md
@@ -1,0 +1,24 @@
+# HOMEPOT Runtime Logs
+
+This directory holds realtime runtime logs produced by the development scripts
+and emulators. The contents are **ephemeral** and the directory is listed in
+`.gitignore` (only this `README.md` is tracked).
+
+## Typical files
+
+| File | Producer |
+|------|----------|
+| `backend.log`, `backend.out`, `backend.pid` | Dashboard/backend launcher scripts |
+| `frontend.log`, `frontend.pid` | `scripts/start-dashboard.sh` |
+| `emulator.log`, `emulator.pid` | `scripts/start-emulator.sh` |
+| `ai.log`, `ai.pid` | AI/LLM service (`scripts/setup-ollama.sh`) |
+| `userapp.log`, `userapp.pid` | `scripts/start-userapp.sh` |
+
+## Purpose
+
+- Route application output away from the terminal (e.g. `setsid ... > logs/backend.log 2>&1 &`).
+- Record service PIDs (`backend.pid`, `frontend.pid`, `emulator.pid`, `ai.pid`, `userapp.pid`)
+  so the `stop-*` sibling scripts can terminate them cleanly.
+
+> The emulator and dashboard scripts create these files automatically; you do not
+> normally need to write to this directory by hand.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,11 @@ site_description: Homogenous Cyber Management of End-Points and OT - Gateway Man
 site_author: Brunel OpenSim
 site_url: https://homepot-client.readthedocs.io/en/latest/
 
+# Exclude files from the docs site (kept in repo as per-dir guides).
+# docs/index.md is the mkdocs homepage; README.md would otherwise conflict with it.
+exclude_docs: |
+  README.md
+
 # Repository
 repo_name: brunel-opensim/homepot-client
 repo_url: https://github.com/brunel-opensim/homepot-client

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,13 +2,13 @@
 
 ## Website Management
 
-### `start-website.sh`
+### `start-dashboard.sh`
 
 Starts the complete HOMEPOT website with backend and frontend.
 
 **Usage:**
 ```bash
-./scripts/start-website.sh
+./scripts/start-dashboard.sh
 ```
 
 **What it does:**
@@ -27,13 +27,13 @@ Starts the complete HOMEPOT website with backend and frontend.
 - Backend: `logs/backend.pid`
 - Frontend: `logs/frontend.pid`
 
-### `stop-website.sh`
+### `stop-dashboard.sh`
 
 Stops both backend and frontend servers.
 
 **Usage:**
 ```bash
-./scripts/stop-website.sh
+./scripts/stop-dashboard.sh
 ```
 
 **What it does:**
@@ -148,7 +148,7 @@ pip install bcrypt==4.1.3  # If not
 ### Ports already in use
 **Solution:** Stop existing services:
 ```bash
-./scripts/stop-website.sh
+./scripts/stop-dashboard.sh
 # Or manually:
 lsof -ti:8000 | xargs kill -9
 lsof -ti:5173 | xargs kill -9

--- a/scripts/setup-ollama.sh
+++ b/scripts/setup-ollama.sh
@@ -57,22 +57,30 @@ fi
 OLLAMA_PORT=11434
 PID=$(lsof -ti :$OLLAMA_PORT || true)
 
+LOG_DIR="logs"
+AI_LOG_FILE="$LOG_DIR/ai.log"
+AI_PID_FILE="$LOG_DIR/ai.pid"
+mkdir -p "$LOG_DIR"
+
 if [ -n "$PID" ]; then
     echo -e "${YELLOW}Port $OLLAMA_PORT is already in use by PID $PID.${NC}"
     # Check if it's actually ollama
     PROCESS_NAME=$(ps -p $PID -o comm=)
     if [[ "$PROCESS_NAME" == "ollama" ]]; then
         echo -e "${GREEN}It is an existing Ollama instance. Reusing it.${NC}"
+        echo "$PID" > "$AI_PID_FILE"
     else
         echo -e "${RED}Warning: Port $OLLAMA_PORT is used by '$PROCESS_NAME', not Ollama.${NC}"
         echo -e "${YELLOW}Attempting to kill conflicting process...${NC}"
         kill -9 $PID
         echo -e "Starting Ollama..."
-        ollama serve &
+        nohup ollama serve >> "$AI_LOG_FILE" 2>&1 &
+        echo $! > "$AI_PID_FILE"
     fi
 else
     echo -e "Starting Ollama server..."
-    ollama serve > /dev/null 2>&1 &
+    nohup ollama serve >> "$AI_LOG_FILE" 2>&1 &
+    echo $! > "$AI_PID_FILE"
     echo -e "Waiting for Ollama to start..."
     sleep 5
 fi

--- a/scripts/setup-ollama.sh
+++ b/scripts/setup-ollama.sh
@@ -55,7 +55,22 @@ fi
 
 # 3. Check Port & Serve
 OLLAMA_PORT=11434
-PID=$(lsof -ti :$OLLAMA_PORT || true)
+
+# Detect an existing Ollama instance. `lsof` may return nothing when the
+# server runs under a different OS user (e.g. a systemd `ollama` user), so
+# fall back to probing the HTTP API on the Ollama port and to `pgrep`.
+PID=$(lsof -ti :$OLLAMA_PORT 2>/dev/null || true)
+if [ -n "$PID" ]; then
+    IS_VERIFIED=false
+else
+    # Try to find Ollama regardless of ownership via the API probe + pgrep.
+    if curl -s -m 2 "http://127.0.0.1:$OLLAMA_PORT/api/version" > /dev/null 2>&1; then
+        PID=$(pgrep -x ollama | head -n 1 || true)
+    fi
+    if [ -z "$PID" ] && pgrep -x ollama > /dev/null 2>&1; then
+        PID=$(pgrep -x ollama | head -n 1)
+    fi
+fi
 
 LOG_DIR="logs"
 AI_LOG_FILE="$LOG_DIR/ai.log"
@@ -63,16 +78,16 @@ AI_PID_FILE="$LOG_DIR/ai.pid"
 mkdir -p "$LOG_DIR"
 
 if [ -n "$PID" ]; then
-    echo -e "${YELLOW}Port $OLLAMA_PORT is already in use by PID $PID.${NC}"
+    echo -e "${YELLOW}Port $OLLAMA_PORT is already in use (PID $PID).${NC}"
     # Check if it's actually ollama
-    PROCESS_NAME=$(ps -p $PID -o comm=)
-    if [[ "$PROCESS_NAME" == "ollama" ]]; then
+    PROCESS_NAME=$(ps -p $PID -o comm= 2>/dev/null || echo unknown)
+    if [[ "$PROCESS_NAME" == "ollama" ]] || curl -s -m 2 "http://127.0.0.1:$OLLAMA_PORT/api/version" > /dev/null 2>&1; then
         echo -e "${GREEN}It is an existing Ollama instance. Reusing it.${NC}"
         echo "$PID" > "$AI_PID_FILE"
     else
         echo -e "${RED}Warning: Port $OLLAMA_PORT is used by '$PROCESS_NAME', not Ollama.${NC}"
         echo -e "${YELLOW}Attempting to kill conflicting process...${NC}"
-        kill -9 $PID
+        kill -9 $PID 2>/dev/null || true
         echo -e "Starting Ollama..."
         nohup ollama serve >> "$AI_LOG_FILE" 2>&1 &
         echo $! > "$AI_PID_FILE"

--- a/scripts/start-data-collection.sh
+++ b/scripts/start-data-collection.sh
@@ -114,12 +114,14 @@ cleanup() {
 }
 trap cleanup SIGINT SIGTERM EXIT
 
-echo "Starting uvicorn in background (logging to backend/homepot.log)..."
-# Create/Clear log file
-> homepot.log
+echo "Starting uvicorn in background (logging to $PROJECT_ROOT/logs/backend.log)..."
+# Create log directory
+mkdir -p "$PROJECT_ROOT/logs"
 
-# Start uvicorn in background
-uvicorn homepot.main:app --host 0.0.0.0 --port 8000 > homepot.log 2>&1 &
+# Start uvicorn in background.
+# stdout/stderr go to the data-collection log; the app itself manages
+# the rotating root logs/backend.log via homepot.app.main.
+uvicorn homepot.app.main:app --host 0.0.0.0 --port 8000 > "$PROJECT_ROOT/logs/data-collection.out" 2>&1 &
 BACKEND_PID=$!
 
 echo "Backend started with PID $BACKEND_PID"

--- a/user_app/README.md
+++ b/user_app/README.md
@@ -74,8 +74,8 @@ All Electron-specific code is hidden behind `window.electronAPI` detection,
 so the same codebase works in both modes.
 
 In dev mode, each flow provides a bypass:
-- **/signin**: "⚡ Dev: Skip Bootstrap Key" fills in a key and advances
-- **/setup/review**: "⚡ Dev: Complete Setup" generates a fake API key and
+- **/signin**: "Dev: Skip Bootstrap Key" fills in a key and advances
+- **/setup/review**: "Dev: Complete Setup" generates a fake API key and
   device ID without calling the backend
 
 ## Building for distribution
@@ -95,14 +95,14 @@ Output goes to `release/`:
 ## Roadmap
 
 | PR | Focus |
-|---|---|---|
-| **U1** ✅ | Standalone Electron desktop shell with routing, sign-in, and native storage |
-| **U2** ✅ | Device-credential auth — bootstrap key replaces SSO cookie login |
-| **U3** ✅ | Device permissions DB model + API (capabilities, admin-override) |
-| **U4** ✅ | Wire Permissions UI to backend (fetch, debounced PATCH, loading/error states, capability-aware) |
-| **U5** ✅ | Agent-side permission enforcement (fetch perms on poll, gate privileged commands, capability-aware DNA registration) |
-| **U6** ✅ | Real device DNA — fetch MAC, local IP, OS via device-credential auth, fall back to Electron IPC or credential storage |
-| **U7** ✅ | Error boundaries, API service layer, unit tests (credentialStorage, API, views), integration tests |
+|---|---|
+| **U1** | Standalone Electron desktop shell with routing, sign-in, and native storage |
+| **U2** | Device-credential auth — bootstrap key replaces SSO cookie login |
+| **U3** | Device permissions DB model + API (capabilities, admin-override) |
+| **U4** | Wire Permissions UI to backend (fetch, debounced PATCH, loading/error states, capability-aware) |
+| **U5** | Agent-side permission enforcement (fetch perms on poll, gate privileged commands, capability-aware DNA registration) |
+| **U6** | Real device DNA — fetch MAC, local IP, OS via device-credential auth, fall back to Electron IPC or credential storage |
+| **U7** | Error boundaries, API service layer, unit tests (credentialStorage, API, views), integration tests |
 
 See [`docs/device-lifecycle-and-ownership.md`](../docs/device-lifecycle-and-ownership.md#user-app-prs) for details.
 


### PR DESCRIPTION
## Summary

Documentation and operational improvements for testing and maintenance:

### Docs
- Add **Three Test Integration Modes** (Simulation / Emulation / Real Devices) to README, backend README, and getting-started so test technicians know which mode is running and how telemetry is produced.
- Add **Starting & Stopping All Services** section to getting-started: a verified full start/stop smoke test covering all five services (backend, frontend, AI/Ollama, emulator, User App) with log/pid paths, verification curls, and troubleshooting.
- Refresh the README project-structure tree (drop stale `data/`, add `emulators`, `uq`, `deploy`, `logs`, `user_app`) and add dir-level README files for docs/logs/emulators.
- Document the login "Request failed with status code 500" root cause (backend not running -> Vite proxy 500) plus recovery steps.
- Fix stale `start-website.sh` / `stop-website.sh` references across docs.

### Logging
- Backend log path now resolves relative to the package (not `os.getcwd()`), unifying all logs under the repo-root `logs/` regardless of launch directory.
- `start-data-collection.sh` uses the canonical `homepot.app.main:app` entry point and routes output to root `logs/`.
- `setup-ollama.sh` captures `ai.log` + `ai.pid`, and detects cross-user Ollama instances (HTTP probe + `pgrep` fallback) so it reuses the running server instead of writing a dead PID when `lsof` is permission-limited.
- `.gitignore` tracks only `logs/README.md`; all other `logs/` content is ignored.

### Smoke test
Performed a clean cycle: stopped backend/frontend/AI/emulator/User App, wiped `logs/`, restarted everything. Backend, frontend, and login all return 200, and every service produced matching `.log`/`.pid` pairs in `logs/`.

Also removes the duplicate `backend/logs/` directory (stale pre-restructure artifact).