### PR TITLE
fix: traceable device-auth failures and remove misleading DB session error logs

### DIFF
--- a/backend/src/homepot/app/auth_utils.py
+++ b/backend/src/homepot/app/auth_utils.py
@@ -209,6 +209,21 @@ def require_role(required_role: str) -> Any:
     return role_checker
 
 
+def _reject_unknown_device(device_id: str, api_key: Optional[str]) -> None:
+    """Reject an unrecognised device ID, logging the context so auth failures are traceable."""
+    logger.error(
+        "Device auth rejected: device_id=%r not found in DB "
+        "(key_provided=%s, key_length=%s)",
+        device_id,
+        "yes" if api_key else "no",
+        len(api_key) if api_key else 0,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid Device ID",
+    )
+
+
 def authenticate_device_credentials(
     db: Session, device_id: str, api_key: str
 ) -> Device:
@@ -227,10 +242,7 @@ def authenticate_device_credentials(
     device = result.scalars().first()
 
     if not device:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid Device ID",
-        )
+        _reject_unknown_device(device_id, api_key)
 
     # Reject inactive lifecycle states (allow ACTIVE + PENDING)
     allowed_states = {LifecycleState.ACTIVE.value, LifecycleState.PENDING.value}
@@ -273,10 +285,7 @@ async def get_current_device(
     device = result.scalars().first()
 
     if not device:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid Device ID",
-        )
+        _reject_unknown_device(device_id, api_key)
 
     # Reject inactive lifecycle states (allow ACTIVE + PENDING)
     allowed_states = {LifecycleState.ACTIVE.value, LifecycleState.PENDING.value}

--- a/backend/src/homepot/app/auth_utils.py
+++ b/backend/src/homepot/app/auth_utils.py
@@ -5,7 +5,7 @@ import logging
 import os
 from pathlib import Path
 import secrets
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, NoReturn, Optional, cast
 
 from dotenv import load_dotenv
 from fastapi import Depends, HTTPException, Request, status
@@ -209,7 +209,7 @@ def require_role(required_role: str) -> Any:
     return role_checker
 
 
-def _reject_unknown_device(device_id: str, api_key: Optional[str]) -> None:
+def _reject_unknown_device(device_id: str, api_key: Optional[str]) -> NoReturn:
     """Reject an unrecognised device ID, logging the context so auth failures are traceable."""
     logger.error(
         "Device auth rejected: device_id=%r not found in DB "

--- a/backend/src/homepot/database.py
+++ b/backend/src/homepot/database.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, AsyncGenerator, Dict, Generator, List, Optional
 import uuid
 
+from fastapi import HTTPException
 from sqlalchemy import Result, create_engine, func, inspect, select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import Session, sessionmaker
@@ -1393,6 +1394,11 @@ def get_db() -> Generator[Session, None, None]:
     try:
         db = SessionLocal()
         yield db
+    except HTTPException:
+        # Expected request-level failures (e.g. auth 401/403/404 raised in
+        # endpoint code) are not DB session errors; propagate unchanged without
+        # misleading "Database session error" log noise.
+        raise
     except Exception as e:
         logger.error("Database session error: %s", e)
         raise


### PR DESCRIPTION
## Summary

The backend log showed **700+ identical `Database session error: 401: Invalid Device ID`** lines with no device context, making the source untraceable. Investigation found two layered problems:

### Diagnostics from `logs/backend.log`
- A stale persisted emulator (`demo-pos-linux-2` / `pos_terminal-c3538fd3`, provisioned against `site-it-demo1`) was being resumed by the User App after the DB was re-seeded with canonical `SITE-XXXX-XXXX` IDs — the device and site no longer existed, so every heartbeat/telemetry/status/audit request failed auth.
- The healthy, registered emulator (`test-startup-01`) produced **zero** errors, confirming it was a staleness/observability problem, not a functional bug.

### Fixes
1. **`auth_utils.py`** — new `_reject_unknown_device()` logs the offender before rejecting:
   `Device auth rejected: device_id='pos_terminal-c3538fd3' not found in DB (key_provided=yes, key_length=43)`
   So an unrecognised device is now immediately identifiable in `logs/backend.log`.
2. **`database.get_db()`** — re-raise `HTTPException` (expected request-level auth failures) without logging them as `Database session error`, reserving that log line for genuine storage failures. This removes the misleading noise that obscured the real error.

### Operational note
The stale User App state was cleared (`~/.homepot/credentials` + `~/.homepot/emulators/`). No code change needed for that — `scripts/start-userapp.sh --reset` automates it.

## Verification
- Manual bogus-device request now emits the traceable `Device auth rejected: device_id=...` line with **no** `Database session error` noise.
- `test_homepot_integration.py -k "auth or device"` → 11 passed.
- `test_agent_local_ipc.py` + `test_pos_dummy.py` → 24 passed.
- `black`, `isort`, `flake8` pass. `mypy`: no new errors (diff against main is identical; 11 pre-existing).