### PR TITLE
feat: canonical DEVICE-XXXX-XXXX-XXXX IDs auto-generated server-side

### DIFF
--- a/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
@@ -30,6 +30,7 @@ from homepot.app.auth_utils import (
 from homepot.app.models import AnalyticsModel as analytics_models
 from homepot.app.schemas.permissions import os_family
 from homepot.audit import AuditEventType, get_audit_logger
+from homepot.canonical_ids import generate_device_id
 from homepot.client import HomepotClient
 from homepot.database import get_database_service, get_db
 from homepot.models import (
@@ -149,15 +150,11 @@ async def create_device(
 
         db_service = await get_database_service()
 
-        # Check if device already exists
-        existing_device = await db_service.get_device_by_device_id(
-            device_request.device_id
-        )
-        if existing_device:
-            raise HTTPException(
-                status_code=409,
-                detail=f"Device {device_request.device_id} already exists",
-            )
+        # Generate a canonical device ID server-side (client-supplied IDs are
+        # ignored, mirroring the canonical SITE-XXXX-XXXX site IDs).
+        device_id = generate_device_id()
+        while await db_service.get_device_by_device_id(device_id):
+            device_id = generate_device_id()
 
         # Verify site exists
         site = await db_service.get_site_by_site_id(device_request.site_id)
@@ -168,7 +165,7 @@ async def create_device(
 
         # Create device
         device = await db_service.create_device(
-            device_id=device_request.device_id,
+            device_id=device_id,
             name=device_request.name,
             device_type=device_request.device_type,
             site_id=int(site.id),

--- a/backend/src/homepot/app/api/API_v1/Endpoints/SitesEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/SitesEndpoint.py
@@ -1,8 +1,6 @@
 """API endpoints for managing sites in the HomePot system."""
 
 import logging
-import re
-import secrets
 from typing import Any, Dict, List, Optional, cast
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -18,6 +16,12 @@ from homepot.app.auth_utils import (
 )
 from homepot.app.schemas.permissions import os_family
 from homepot.audit import AuditEventType, get_audit_logger
+
+# Canonical site IDs live in the shared canonical_ids module (which also
+# hosts canonical device IDs); re-export the previous public names so
+# existing imports (e.g. seed_data, tests) keep working.
+from homepot.canonical_ids import _SITE_ID_PATTERN as _SITE_ID_PATTERN  # noqa: F401
+from homepot.canonical_ids import generate_site_id as generate_site_id
 from homepot.client import HomepotClient
 from homepot.database import get_database_service, get_db
 from homepot.error_logger import log_error
@@ -31,25 +35,6 @@ logger = logging.getLogger(__name__)
 
 
 router = APIRouter()
-
-
-# Unambiguous alphabet for site IDs: excludes easily-confused characters
-# (0/O, 1/I/L).
-_SITE_ID_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789"
-# Canonical format: SITE-XXXX-XXXX (three groups)
-_SITE_ID_PATTERN = re.compile(r"^SITE-[A-HJ-KM-NP-Z2-9]{4}-[A-HJ-KM-NP-Z2-9]{4}$")
-
-
-def generate_site_id() -> str:
-    """Generate a canonical site ID: ``SITE-XXXX-XXXX``.
-
-    Uses only unambiguous uppercase alphanumerics so the ID can be read aloud
-    and typed without confusion during device enrollment.
-    """
-    parts: List[str] = []
-    for _ in range(2):
-        parts.append("".join(secrets.choice(_SITE_ID_ALPHABET) for _ in range(4)))
-    return f"SITE-{parts[0]}-{parts[1]}"
 
 
 class SiteHealthResponse(BaseModel):

--- a/backend/src/homepot/canonical_ids.py
+++ b/backend/src/homepot/canonical_ids.py
@@ -1,0 +1,52 @@
+"""Canonical identifier generation for sites and devices.
+
+Both site and device IDs use the same unambiguous uppercase alphabet
+(``A-HJ-KM-NP-Z2-9``, excluding the easily-confused characters ``0/O``
+and ``1/I/L``) so they can be read aloud and typed without errors during
+device enrollment.
+
+Formats
+-------
+* Site:   ``SITE-XXXX-XXXX``
+* Device: ``DEVICE-XXXX-XXXX-XXXX``
+"""
+
+import re
+import secrets
+from typing import List
+
+# Unambiguous alphabet: excludes 0/O, 1/I/L.
+_ID_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789"
+# Character class form of the alphabet for regexes.
+_ID_CHARS = "A-HJ-KM-NP-Z2-9"
+
+_GROUP_LENGTH = 4
+
+_SITE_ID_PATTERN = re.compile(
+    rf"^SITE-[{_ID_CHARS}]{{{_GROUP_LENGTH}}}-[{_ID_CHARS}]{{{_GROUP_LENGTH}}}$"
+)
+_DEVICE_ID_PATTERN = re.compile(
+    rf"^DEVICE-[{_ID_CHARS}]{{{_GROUP_LENGTH}}}-[{_ID_CHARS}]{{{_GROUP_LENGTH}}}"
+    rf"-[{_ID_CHARS}]{{{_GROUP_LENGTH}}}$"
+)
+
+
+def _generate_group() -> str:
+    """Return a single group of unambiguous uppercase alphanumerics."""
+    return "".join(secrets.choice(_ID_ALPHABET) for _ in range(_GROUP_LENGTH))
+
+
+def _canonical_id(prefix: str, groups: int) -> str:
+    """Generate ``PREFIX-XXXX-...`` with ``groups`` groups of 4 chars."""
+    parts: List[str] = [_generate_group() for _ in range(groups)]
+    return f"{prefix}-{'-'.join(parts)}"
+
+
+def generate_site_id() -> str:
+    """Generate a canonical site ID: ``SITE-XXXX-XXXX``."""
+    return _canonical_id("SITE", 2)
+
+
+def generate_device_id() -> str:
+    """Generate a canonical device ID: ``DEVICE-XXXX-XXXX-XXXX``."""
+    return _canonical_id("DEVICE", 3)

--- a/backend/src/homepot/database.py
+++ b/backend/src/homepot/database.py
@@ -17,6 +17,7 @@ from sqlalchemy import Result, create_engine, func, inspect, select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import Session, sessionmaker
 
+from homepot.canonical_ids import generate_device_id
 from homepot.config import get_settings
 from homepot.models import (
     AuditLog,
@@ -1098,8 +1099,14 @@ class DatabaseService:
                     f"does not match provided '{expected_device_identity}'"
                 )
 
-            # Create the device
-            new_device_id = f"{device_type}-{_secrets.token_hex(4)}"
+            # Create the device with a canonical, server-generated device ID.
+            new_device_id = generate_device_id()
+            # Keep trying until we land on an unused id (collision is
+            # astronomically unlikely, but stay safe).
+            while await session.scalar(
+                select(Device.id).where(Device.device_id == new_device_id)
+            ):
+                new_device_id = generate_device_id()
             api_key = _secrets.token_urlsafe(32)
             api_key_hash = _pwd.hash(api_key)
 

--- a/backend/src/homepot/seed_factories.py
+++ b/backend/src/homepot/seed_factories.py
@@ -21,6 +21,7 @@ from passlib.context import CryptContext
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
+from homepot.canonical_ids import generate_device_id
 from homepot.models import (
     AuditLog,
     Device,
@@ -219,7 +220,7 @@ def build_device(
 ) -> Device:
     """Build an unsaved Device instance."""
     if device_id is None:
-        device_id = f"dev-{uuid4().hex[:8]}"
+        device_id = generate_device_id()
     kwargs.setdefault("lifecycle_state", LifecycleState.PENDING.value)
     kwargs.setdefault("health_state", HealthState.UNKNOWN.value)
     return Device(

--- a/backend/tests/test_dev_server_smoke.py
+++ b/backend/tests/test_dev_server_smoke.py
@@ -247,8 +247,12 @@ class TestDevServerSmoke:
             headers=headers,
         )
         assert resp.status_code == 200, resp.text
+        # The server auto-generates a canonical device ID; fetch by that.
+        created_device_id = resp.json()["device_id"]
 
-        resp = client.get("/api/v1/devices/device/real-pos-001", headers=headers)
+        resp = client.get(
+            f"/api/v1/devices/device/{created_device_id}", headers=headers
+        )
         assert resp.status_code == 200, resp.text
         device = resp.json()
         assert device.get("is_simulated") is not None

--- a/backend/tests/test_homepot_integration.py
+++ b/backend/tests/test_homepot_integration.py
@@ -29,6 +29,10 @@ from homepot.app.api.API_v1.Endpoints.SitesEndpoint import (
     generate_site_id,
 )
 from homepot.app.auth_utils import create_access_token, hash_password
+from homepot.canonical_ids import (
+    _DEVICE_ID_PATTERN,
+    generate_device_id,
+)
 from homepot.config import reload_settings
 import homepot.database
 from homepot.models import Base, User
@@ -42,6 +46,14 @@ def test_generate_site_id_is_canonical() -> None:
     assert len(generated) == 200  # effectively unique
     for site_id in generated:
         assert _SITE_ID_PATTERN.fullmatch(site_id) is not None
+
+
+def test_generate_device_id_is_canonical() -> None:
+    """generate_device_id produces the canonical DEVICE-XXXX-XXXX-XXXX format."""
+    generated = {generate_device_id() for _ in range(200)}
+    assert len(generated) == 200  # effectively unique
+    for device_id in generated:
+        assert _DEVICE_ID_PATTERN.fullmatch(device_id) is not None
 
 
 def generate_random_id(prefix: str) -> str:
@@ -260,17 +272,16 @@ class TestPhase2APIEndpoints:
             assert health["site_id"] == site_id
 
     def test_device_registration(self, client: TestClient) -> None:
-        """Test device registration at a site."""
+        """Test device registration at a site (server generates a canonical DEVICE ID)."""
         h = TestPhase2APIEndpoints._headers
         sites_response = client.get("/api/v1/sites", headers=h)
         sites = sites_response.json().get("sites", [])
 
         if sites:
             site_id = sites[0]["site_id"]
-            device_id = generate_random_id("TEST_DEVICE")
             test_device = {
                 "site_id": site_id,
-                "device_id": device_id,
+                "device_id": "custom-id-ignored",
                 "name": "Test Device 001",
                 "device_type": "pos_terminal",
                 "location": "Test Counter",
@@ -284,7 +295,12 @@ class TestPhase2APIEndpoints:
             data = response.json()
             assert "message" in data
             assert "device_id" in data
-            assert data["device_id"] == device_id
+            # The server must auto-generate a canonical DEVICE ID, ignoring the
+            # caller-supplied value.
+            assert re.fullmatch(
+                r"DEVICE-[A-HJ-KM-NP-Z2-9]{4}-[A-HJ-KM-NP-Z2-9]{4}-[A-HJ-KM-NP-Z2-9]{4}",
+                data["device_id"],
+            )
 
     def test_job_creation(self, client: TestClient) -> None:
         """Test creating a job for a site."""
@@ -726,19 +742,19 @@ class TestDashboardAggregates:
 
     @staticmethod
     def _create_device(client: TestClient, headers: dict, site_id: str) -> str:
-        device_id = generate_random_id("DASH_DEV")
         resp = client.post(
             "/api/v1/devices/device",
             json={
                 "site_id": site_id,
-                "device_id": device_id,
-                "name": f"Device {device_id}",
+                "device_id": generate_random_id("DASH_DEV"),
+                "name": f"Device {generate_random_id('DASH_DEV')}",
                 "device_type": "pos_terminal",
             },
             headers=headers,
         )
         assert resp.status_code == 200, f"Failed to create device: {resp.text}"
-        return device_id
+        # The server auto-generates a canonical device ID, so return that.
+        return resp.json()["device_id"]
 
     @staticmethod
     def _set_device_state(


### PR DESCRIPTION
## Summary

Extends the canonical-ID approach (previously applied only to sites as `SITE-XXXX-XXXX`) to devices. Every server-side device creation now stores a canonical `DEVICE-XXXX-XXXX-XXXX` ID.

- **New** `backend/src/homepot/canonical_ids.py`: shared module hosting both site and device ID generators + regex patterns, using the same unambiguous alphabet (`ABCDEFGHJKMNPQRSTUVWXYZ23456789`) so IDs can be read aloud/typed during enrollment.
- `generate_site_id` moved from `SitesEndpoint.py` into the shared module and re-exported, so existing callers (`seed_data.py`, tests) are unaffected.
- **Dashboard/user path** (`POST /api/v1/devices/device`): auto-generates the device ID server-side and ignores the caller-supplied `device_id` (mirrors site creation). Removal of the old 409 duplicate check; a collision-retry loop keeps uniqueness.
- **Enrolment claim path** (`claim_enrolment_intent_atomic`): now stores a canonical ID instead of `<device_type>-<hex>`, with a collision-retry loop.
- **Seed factories**: `build_device` default becomes a canonical ID.

## Formats
| Entity | Format |
|---|---|
| Site | `SITE-XXXX-XXXX` |
| Device | `DEVICE-XXXX-XXXX-XXXX` |

## Tests
- New `test_generate_device_id_is_canonical` (uniqueness × 200 + pattern match).
- `test_device_registration` now asserts the returned ID matches `DEVICE-XXXX-XXXX-XXXX` (caller-supplied ID ignored).
- Smoke test `test_is_simulated_false_on_provisioned_device` fetches the created device by its server-generated ID.
- Ran integration, smoke, authorization, device-commands, OS-family, agent-IPC suites (39 + 16 + 26 + 54 passing). Architecture: black, isort, flake8, mypy all clean (165 files).

**Note:** `tests/test_authorization.py` full-file run keeps hanging at test #33 — confirmed pre-existing on `main` (reproduced with stashed changes); the file passes in isolates.