### PR TITLE
feat: canonical DEVICE IDs for simulated & provisioned devices

### DIFF
--- a/backend/src/homepot/app/services/agent_service.py
+++ b/backend/src/homepot/app/services/agent_service.py
@@ -18,6 +18,7 @@ from homepot.app.schemas.bootstrap import BootstrapProvisionRequest
 from homepot.app.schemas.permissions import derive_capabilities, derive_push_channel
 from homepot.app.schemas.provision import DeviceProvisionRequest
 from homepot.app.services.lifecycle_service import LifecycleService
+from homepot.canonical_ids import generate_device_id
 from homepot.models import (
     ConnectivityState,
     DeviceCredential,
@@ -31,6 +32,14 @@ from homepot.models import (
 def _utc_now() -> datetime:
     """Return current UTC timestamp."""
     return datetime.now(timezone.utc)
+
+
+def _generate_unique_device_id(repository: AgentRepository) -> str:
+    """Generate a canonical, collision-free device ID."""
+    device_id = generate_device_id()
+    while repository.get_device_by_device_id(device_id):
+        device_id = generate_device_id()
+    return device_id
 
 
 class AgentService:
@@ -254,7 +263,7 @@ class AgentService:
             if not site or not site.id:
                 raise LookupError(f"Site '{payload.site_id}' not found")
 
-            device_id = f"{payload.device_type}-{secrets.token_hex(4)}"
+            device_id = _generate_unique_device_id(self.repository)
             api_key = secrets.token_urlsafe(32)
             device_token = secrets.token_urlsafe(24)
 
@@ -355,7 +364,7 @@ class AgentService:
             if not site or not site.id:
                 raise LookupError(f"Site '{payload.site_id}' not found")
 
-            device_id = f"{payload.device_type}-{secrets.token_hex(4)}"
+            device_id = _generate_unique_device_id(self.repository)
             api_key = secrets.token_urlsafe(32)
 
             requested_name = (payload.device_name or "").strip() or device_id

--- a/backend/tests/test_agent_endpoints.py
+++ b/backend/tests/test_agent_endpoints.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import sessionmaker
 
 from homepot.app.auth_utils import create_access_token, hash_password
 from homepot.app.models.AnalyticsModel import DeviceMetrics
+from homepot.canonical_ids import _DEVICE_ID_PATTERN
 from homepot.config import reload_settings
 import homepot.database
 from homepot.models import Base, Device, LifecycleState, Site, User
@@ -302,6 +303,7 @@ def test_provision_returns_credentials_and_hashes_key(client: TestClient):
     payload = response.json()
     assert payload["status"] == "success"
     assert payload["data"]["device_id"]
+    assert _DEVICE_ID_PATTERN.fullmatch(payload["data"]["device_id"])
     assert payload["data"]["api_key"]
 
     created_device_id = payload["data"]["device_id"]

--- a/backend/tests/test_dev_server_smoke.py
+++ b/backend/tests/test_dev_server_smoke.py
@@ -14,6 +14,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from homepot.app.auth_utils import create_access_token
+from homepot.canonical_ids import _DEVICE_ID_PATTERN
 from homepot.config import reload_settings
 import homepot.database
 from homepot.models import Base
@@ -303,6 +304,7 @@ class TestDevServerSmoke:
         claimed_device_id = claim["device_id"]
         assert "api_key" in claim
         assert "site_id" in claim
+        assert _DEVICE_ID_PATTERN.fullmatch(claimed_device_id)
 
         api_key = claim["api_key"]
 

--- a/backend/utils/run_fleet_simulation.py
+++ b/backend/utils/run_fleet_simulation.py
@@ -9,9 +9,14 @@ import asyncio
 import logging
 import random
 import sys
+from pathlib import Path
 from typing import List
 
 import httpx
+
+# Add backend/src to path so homepot imports resolve (mirrors seed_data.py).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
 
 # Configure logging
 logging.basicConfig(
@@ -58,6 +63,35 @@ SAMPLE_PRINTERS = [
         },
     ],
 ]
+
+
+async def discover_simulated_device_ids(limit: int = 1000) -> List[str]:
+    """Return device IDs of simulated devices from the local DB.
+
+    The seed script now assigns canonical ``DEVICE-XXXX-XXXX-XXXX`` IDs, so we
+    must discover the actual IDs rather than hardcoding names.  Returns an
+    empty list if the DB is unavailable (caller then falls back).
+    """
+    try:
+        from sqlalchemy import select
+
+        from homepot.database import DatabaseService
+        from homepot.models import Device
+
+        db_service = DatabaseService()
+        async with db_service.get_session() as session:
+            result = await session.execute(
+                select(Device.device_id)
+                .where(Device.is_simulated.is_(True))
+                .limit(limit)
+            )
+            ids = [row[0] for row in result.all()]
+            await db_service.close()
+            logger.info(f"Discovered {len(ids)} simulated device IDs from DB")
+            return ids
+    except Exception as exc:
+        logger.warning(f"Could not discover simulated devices from DB: {exc}")
+        return []
 
 
 async def setup_test_devices(device_ids: List[str], client: httpx.AsyncClient) -> None:
@@ -126,23 +160,15 @@ async def simulate_device(
 
 async def main() -> None:
     """Run the fleet simulation."""
-    # Extract the exact device IDs defined in seed_data.py
-    seed_device_ids = [
-        "site1-linux-01",
-        "site1-windows-02",
-        "site1-macos-03",
-        "site1-web-04",
-        "site1-iot-05",
-        "site2-linux-01",
-        "site2-windows-02",
-        "site2-macos-03",
-        "site2-web-04",
-        "site2-iot-05",
-    ]
-
-    # We will simulate exactly the 10 seed devices
-    device_ids = seed_device_ids
+    # The seed script assigns canonical DEVICE-XXXX-XXXX-XXXX IDs, so discover
+    # the actual simulated devices from the DB instead of hardcoding names.
+    device_ids = await discover_simulated_device_ids()
     num_active_devices = len(device_ids)
+    if num_active_devices == 0:
+        logger.warning(
+            "No simulated devices found in DB; run backend/utils/seed_data.py first."
+        )
+        return
 
     logger.info(
         f"Starting simulation of {num_active_devices} devices for {SIMULATION_DURATION_SECONDS}s"

--- a/backend/utils/seed_data.py
+++ b/backend/utils/seed_data.py
@@ -54,6 +54,7 @@ from homepot.app.models.AnalyticsModel import (
 )
 from homepot.app.api.API_v1.Endpoints.SitesEndpoint import generate_site_id
 from homepot.app.models.UserModel import Base as AppBase
+from homepot.canonical_ids import generate_device_id
 from homepot.database import DatabaseService
 from homepot.models import (
     Base,
@@ -479,7 +480,6 @@ async def init_database():
 
     async def get_or_create_device(
         session,
-        device_id,
         name,
         device_type,
         site_id,
@@ -492,9 +492,17 @@ async def init_database():
         capabilities=None,
         device_permissions=None,
     ):
-        existing = await db_service.get_device_by_device_id(device_id)
+        # Idempotency key is (site, name): on re-runs the existing device is
+        # reused while its device_id stays canonical.
+        existing = await session.execute(
+            select(Device).where(Device.site_id == site_id, Device.name == name)
+        )
+        existing = existing.scalar_one_or_none()
         if existing:
             return existing
+        device_id = generate_device_id()
+        while await db_service.get_device_by_device_id(device_id):
+            device_id = generate_device_id()
         device = await create_device(
             session,
             device_id=device_id,
@@ -512,7 +520,7 @@ async def init_database():
             device_permissions=device_permissions,
         )
         print(
-            f"Created device: {device.name} ({device_id}) [Monitored: {is_monitored}] [Simulated: {is_simulated}] [Method: {enrollment_method}]"
+            f"Created device: {device.name} ({device.device_id}) [Monitored: {is_monitored}] [Simulated: {is_simulated}] [Method: {enrollment_method}]"
         )
         return device
 
@@ -532,7 +540,6 @@ async def init_database():
     async with db_service.get_session() as session:
         await get_or_create_device(
             session,
-            "site1-linux-01",
             "Linux POS 1-1",
             DeviceType.POS_TERMINAL,
             site1.id,
@@ -549,7 +556,6 @@ async def init_database():
         )
         await get_or_create_device(
             session,
-            "site1-windows-02",
             "Windows POS 1-2",
             DeviceType.POS_TERMINAL,
             site1.id,
@@ -567,7 +573,6 @@ async def init_database():
         )
         await get_or_create_device(
             session,
-            "site1-macos-03",
             "Apple POS 1-3",
             DeviceType.POS_TERMINAL,
             site1.id,
@@ -583,7 +588,6 @@ async def init_database():
         )
         await get_or_create_device(
             session,
-            "site1-web-04",
             "Web Dashboard 1-4",
             DeviceType.POS_TERMINAL,
             site1.id,
@@ -599,7 +603,6 @@ async def init_database():
         )
         await get_or_create_device(
             session,
-            "site1-iot-05",
             "IoT Sensor 1-5",
             DeviceType.IOT_SENSOR,
             site1.id,
@@ -615,7 +618,6 @@ async def init_database():
         )
         await get_or_create_device(
             session,
-            "site1-android-pos-06",
             "Android POS 1-6",
             DeviceType.POS_TERMINAL,
             site1.id,
@@ -635,7 +637,6 @@ async def init_database():
         )
         await get_or_create_device(
             session,
-            "site2-linux-01",
             "Linux POS 2-1",
             DeviceType.POS_TERMINAL,
             site2.id,
@@ -653,7 +654,6 @@ async def init_database():
         )
         await get_or_create_device(
             session,
-            "site2-windows-02",
             "Windows POS 2-2",
             DeviceType.POS_TERMINAL,
             site2.id,
@@ -669,7 +669,6 @@ async def init_database():
         )
         await get_or_create_device(
             session,
-            "site2-macos-03",
             "Apple POS 2-3",
             DeviceType.POS_TERMINAL,
             site2.id,
@@ -685,7 +684,6 @@ async def init_database():
         )
         await get_or_create_device(
             session,
-            "site2-web-04",
             "Web Dashboard 2-4",
             DeviceType.POS_TERMINAL,
             site2.id,
@@ -701,7 +699,6 @@ async def init_database():
         )
         await get_or_create_device(
             session,
-            "site2-iot-05",
             "IoT Sensor 2-5",
             DeviceType.IOT_SENSOR,
             site2.id,

--- a/docs/fleet-simulation.md
+++ b/docs/fleet-simulation.md
@@ -14,7 +14,7 @@ The **Fleet Simulation framework** allows developers to safely load-test the API
 The standalone runner script `backend/utils/run_fleet_simulation.py` acts as a driver to orchestrate multiple simulated edge devices using Python's `asyncio` and `httpx`.
 
 ### Key Characteristics
-1. **Accurate Seed Mapping:** The simulation maps exactly to the realistic subset of expected mock devices defined in `backend/utils/seed_data.py` (e.g., `site1-linux-01`, `site2-macos-03`).
+1. **Accurate Seed Mapping:** The simulation discovers the simulated devices directly from the local database (all devices created by `backend/utils/seed_data.py` with `is_simulated=True`), so it tracks the seeded fleet exactly regardless of the canonical `DEVICE-XXXX-XXXX-XXXX` IDs assigned at creation. If no simulated devices exist yet, the runner aborts with a hint to run `seed_data.py` first.
 2. **Concurrency Control:** Utilizes `asyncio.Semaphore` and `httpx.Limits` to strictly throttle the maximum active TCP connections. This simulates scale without causing native OS socket port exhaustion locally (ephemeral port exhaustion).
 3. **Scatter & Gather Timing:** Employs randomized `asyncio.sleep()` delays between requests to create realistic traffic distributions ("jitter"), perfectly mimicking thousands of endpoints syncing asynchronously over WAN.
 4. **Behavioral Variance:** Automatically rotates through varied telemetry scenarios (`healthy`, `low_memory`, `high_errors`) natively supported by the `/api/v1/testing/simulate/device` fast API endpoint.

--- a/scripts/query-db.sh
+++ b/scripts/query-db.sh
@@ -38,7 +38,7 @@ if [ $# -eq 0 ]; then
     echo "  ./scripts/query-db.sh show enrolment_intents"
     echo "  ./scripts/query-db.sh show tenants"
     echo "  ./scripts/query-db.sh site_devices site-001"
-    echo "  ./scripts/query-db.sh device_details site1-linux-01"
+    echo "  ./scripts/query-db.sh device_details DEVICE-XXXX-XXXX-XXXX"
     echo "  ./scripts/query-db.sh jobs"
     exit 0
 fi
@@ -265,7 +265,7 @@ EOF
         ;;
     device_details)
         if [ -z "$2" ]; then
-            echo "Please provide a device_id: ./scripts/query-db.sh device_details site1-linux-01"
+            echo "Please provide a device_id: ./scripts/query-db.sh device_details DEVICE-XXXX-XXXX-XXXX"
             exit 1
         fi
         echo "=== Device Information: $2 ==="


### PR DESCRIPTION
## Summary

Extends canonical `DEVICE-XXXX-XXXX-XXXX` ID generation (introduced in #282 for server-created devices) to **all simulated/provisioned devices**, and regenerates the local dev seed so every device carries the canonical format.

## Changes

- **`backend/src/homepot/app/services/agent_service.py`**
  - Added `_generate_unique_device_id(repository)` (collision-loop generator).
  - `provision_device` (SSO path) and `bootstrap_provision_device` (emulator/bootstrap path) now assign canonical IDs instead of `<device_type>-<token_hex(4)>`.
- **`backend/utils/seed_data.py`**
  - Simulated devices now get canonical `DEVICE-XXXX-XXXX-XXXX` IDs.
  - Idempotency key changed from `device_id` to `(site_id, name)` since IDs are now auto-generated (site codes stay canonical `SITE-XXXX-XXXX`).
  - Removed 11 hardcoded `site1-*` / `site2-*` seed IDs.
- **`backend/utils/run_fleet_simulation.py`**
  - Discovers simulated device IDs directly from the local DB instead of hardcoding the old seed names; aborts with a hint if no simulated devices exist.
- **Tests** (`test_agent_endpoints.py`, `test_dev_server_smoke.py`)
  - Assert the canonical `DEVICE-...` pattern on the SSO provision response and the bootstrap claim response.
- **Docs/scripts** (`scripts/query-db.sh`, `docs/fleet-simulation.md`)
  - Replaced legacy `site1-linux-01` examples.

## Local dev database

The dev DB was dropped and recreated with fresh canonical seed data:

- 11 simulated devices, all `DEVICE-XXXX-XXXX-XXXX` (verified no legacy IDs remain).
- Verified end-to-end: SSO provision via the live API produces a canonical ID.
- `/api/v1/agent/register` still honors a client-supplied `device_id` (agent identity, machine-id derived) — unchanged by this PR.

## Verification

- black, isort, flake8, mypy clean (CI-scoped dirs)
- 67 smoke/integration/agent-endpoint tests pass
- 44 bootstrap/os-family/enrolment tests pass
- Fleet sim discovery resolves the 11 canonical simulated device IDs