### PR TITLE
fix(scripts): use macOS-compatible sed -i in setup-pgpass.sh

### DIFF
--- a/scripts/setup-pgpass.sh
+++ b/scripts/setup-pgpass.sh
@@ -43,8 +43,12 @@ if [ -f "$PGPASS_FILE" ]; then
             exit 0
         fi
         
-        # Remove old entry
-        sed -i "/^${DB_HOST}:${DB_PORT}:${DB_NAME}:${DB_USER}:/d" "$PGPASS_FILE"
+        # Remove old entry (BSD sed on macOS requires an explicit, possibly empty, backup suffix after -i)
+        if [[ "$(uname)" == "Darwin" ]]; then
+            sed -i '' "/^${DB_HOST}:${DB_PORT}:${DB_NAME}:${DB_USER}:/d" "$PGPASS_FILE"
+        else
+            sed -i "/^${DB_HOST}:${DB_PORT}:${DB_NAME}:${DB_USER}:/d" "$PGPASS_FILE"
+        fi
         echo -e "${GREEN}[OK]${NC} Removed old entry"
     fi
 else


### PR DESCRIPTION
## Summary
Fixes `./scripts/setup-pgpass.sh` failing on macOS when updating an existing `.pgpass` entry.

## Problem
On macOS, `sed -i` (BSD sed) requires an explicit backup-suffix argument. The script called `sed -i "/pattern/d" "$PGPASS_FILE"` without one, so BSD sed consumed the pattern as the suffix and tried to parse the file path as the sed script, producing:
```
sed: 1: "/Users/<user>/...": invalid command code m
```

## Fix
Branch on `uname` (Darwin vs. Linux) before the `sed -i` call, matching the existing pattern already used in `scripts/init-postgresql.sh` for the `backend/.env` update.

## Testing
- `bash -n scripts/setup-pgpass.sh` — syntax OK
- Manually verified the corrected `sed -i ''` deletion against a temp file on macOS: old `.pgpass` entry is removed without error.

Fixes #285