### PR TITLE
feat: align analytics event contracts end to end

### DIFF
--- a/backend/tests/test_analytics.py
+++ b/backend/tests/test_analytics.py
@@ -102,6 +102,7 @@ class TestErrorLogContract:
         Base.metadata.create_all(bind=sync_engine)
 
     def test_error_message_and_context_persist(self, client) -> None:
+        """Error message and context survive the frontend payload round trip."""
         from homepot.app.models.AnalyticsModel import ErrorLog
         from homepot.database import SessionLocal
 
@@ -136,6 +137,7 @@ class TestErrorLogContract:
             db.close()
 
     def test_legacy_message_and_extra_data_are_not_persisted(self, client) -> None:
+        """Legacy message/extra_data payload is not treated as canonical fields."""
         from homepot.app.models.AnalyticsModel import ErrorLog
         from homepot.database import SessionLocal
 

--- a/backend/tests/test_analytics.py
+++ b/backend/tests/test_analytics.py
@@ -70,3 +70,108 @@ class TestAnalyticsEndpointStructure:
 
         assert AnalyticsMiddleware is not None
         assert hasattr(AnalyticsMiddleware, "dispatch")
+
+
+class TestErrorLogContract:
+    """Frontend-to-backend error analytics contract.
+
+    The frontend posts {category, severity, error_message, context} to
+    /api/v1/analytics/error. The backend must persist error_message and
+    context unchanged. The legacy frontend fields `message`/`extra_data`
+    must not be accepted as substitutes.
+    """
+
+    PAYLOAD = {
+        "category": "external_service",
+        "severity": "error",
+        "error_message": "Payment gateway timeout",
+        "context": {"page_url": "/checkout"},
+    }
+
+    def _auth_header(self, email: str = "analytics-test@example.com") -> dict:
+        from homepot.app.auth_utils import create_access_token
+
+        token = create_access_token({"sub": email})
+        return {"Authorization": f"Bearer {token}"}
+
+    def _ensure_tables(self) -> None:
+        from homepot.app.models.AnalyticsModel import ErrorLog  # noqa: F401
+        from homepot.database import sync_engine
+        from homepot.models import Base
+
+        Base.metadata.create_all(bind=sync_engine)
+
+    def test_error_message_and_context_persist(self, client) -> None:
+        from homepot.app.models.AnalyticsModel import ErrorLog
+        from homepot.database import SessionLocal
+
+        self._ensure_tables()
+
+        resp = client.post(
+            "/api/v1/analytics/error",
+            json=self.PAYLOAD,
+            headers=self._auth_header(),
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["success"] is True
+
+        db = SessionLocal()
+        log = None
+        try:
+            log = (
+                db.query(ErrorLog)
+                .filter(ErrorLog.error_message == self.PAYLOAD["error_message"])
+                .order_by(ErrorLog.id.desc())
+                .first()
+            )
+            assert log is not None
+            assert log.error_message == "Payment gateway timeout"
+            assert log.category == "external_service"
+            assert log.severity == "error"
+            assert log.context == {"page_url": "/checkout"}
+        finally:
+            if log is not None:
+                db.delete(log)
+                db.commit()
+            db.close()
+
+    def test_legacy_message_and_extra_data_are_not_persisted(self, client) -> None:
+        from homepot.app.models.AnalyticsModel import ErrorLog
+        from homepot.database import SessionLocal
+
+        self._ensure_tables()
+
+        # Old frontend payload using message/extra_data must not be treated
+        # as the error_message/context fields.
+        legacy_payload = {
+            "category": "client_error",
+            "severity": "error",
+            "message": "Should not be stored as error_message",
+            "extra_data": {"page_url": "/legacy"},
+        }
+
+        resp = client.post(
+            "/api/v1/analytics/error",
+            json=legacy_payload,
+            headers=self._auth_header(),
+        )
+        assert resp.status_code == 201, resp.text
+
+        db = SessionLocal()
+        log = None
+        try:
+            log = (
+                db.query(ErrorLog)
+                .filter(ErrorLog.category == "client_error")
+                .order_by(ErrorLog.id.desc())
+                .first()
+            )
+            assert log is not None
+            # The legacy fields must not leak into the canonical columns.
+            assert log.error_message != legacy_payload["message"]
+            assert log.context != legacy_payload["extra_data"]
+        finally:
+            if log is not None:
+                db.delete(log)
+                db.commit()
+            db.close()

--- a/docs/frontend-analytics-integration.md
+++ b/docs/frontend-analytics-integration.md
@@ -77,8 +77,8 @@ export const trackError = async (errorMessage, pageUrl, errorType = 'client_erro
       {
         category: errorType,
         severity: 'error',
-        message: errorMessage,
-        extra_data: { page_url: pageUrl }
+        error_message: errorMessage,
+        context: { page_url: pageUrl }
       },
       {
         withCredentials: true,

--- a/frontend/src/utils/analytics.js
+++ b/frontend/src/utils/analytics.js
@@ -115,8 +115,8 @@ export const trackError = async (errorMessage, pageUrl, errorType = 'client_erro
       {
         category: errorType,
         severity: 'error',
-        message: errorMessage,
-        extra_data: { page_url: pageUrl },
+        error_message: errorMessage,
+        context: { page_url: pageUrl },
       },
       {
         withCredentials: true,

--- a/frontend/src/utils/analytics.test.js
+++ b/frontend/src/utils/analytics.test.js
@@ -82,4 +82,31 @@ describe('analytics.js', () => {
 
     await expect(trackError('Error', '/page')).resolves.not.toThrow();
   });
+
+  it('trackError sends the backend error contract (error_message + context)', async () => {
+    axios.post.mockResolvedValue({});
+
+    await trackError('Payment gateway timeout', '/checkout', 'external_service');
+
+    expect(axios.post).toHaveBeenCalledWith(
+      expect.stringContaining('/analytics/error'),
+      expect.objectContaining({
+        category: 'external_service',
+        severity: 'error',
+        error_message: 'Payment gateway timeout',
+        context: { page_url: '/checkout' },
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('trackError does not send legacy message/extra_data fields', async () => {
+    axios.post.mockResolvedValue({});
+
+    await trackError('Some error', '/page');
+
+    const body = axios.post.mock.calls[0][1];
+    expect(body).not.toHaveProperty('message');
+    expect(body).not.toHaveProperty('extra_data');
+  });
 });


### PR DESCRIPTION
## Summary

First of the KPI-evaluation roadmap tasks (`docs/KPI-evaluation-roadmap.md`, PR sequence item 1): align the frontend error-analytics payload with the backend contract.

The frontend `trackError` posted `message` / `extra_data`, but the backend `/api/v1/analytics/error` endpoint reads `error_message` / `context`. As a result the error message and page context were silently dropped (stored as the `"Unknown error"` default with empty context).

## Changes

- **`frontend/src/utils/analytics.js`**: `trackError` now posts `error_message` and `context: { page_url }`; the legacy `message` / `extra_data` fields are removed.
- **`frontend/src/utils/analytics.test.js`**: new tests assert the contract payload is sent and that legacy fields are no longer present.
- **`backend/tests/test_analytics.py`**: new `TestErrorLogContract` proves `error_message` / `context` persist via the endpoint, and that a legacy `message` / `extra_data` payload is not accepted as the canonical fields.
- **`docs/frontend-analytics-integration.md`**: updated the `trackError` example to the aligned contract.

## Verification

- Frontend: `npm run lint` clean, `npm run build` succeeds, 21/21 tests pass
- Backend: `pytest tests/test_analytics.py` 10/10 pass