### PR TITLE
feat: preserve telemetry provenance and collection metadata

### DIFF
--- a/backend/src/homepot/agents.py
+++ b/backend/src/homepot/agents.py
@@ -37,6 +37,7 @@ from homepot.models import (
     Job,
     JobPriority,
     JobStatus,
+    derive_provenance,
 )
 
 logger = logging.getLogger(__name__)
@@ -684,6 +685,10 @@ class DeviceAgentSimulator:
 
                     if device:
                         previous_status = device.status
+                        derived_provenance = derive_provenance(device)
+                        provenance_value = (
+                            derived_provenance.value if derived_provenance else None
+                        )
 
                         # Update device status only if changed
                         if previous_status != new_status:
@@ -707,6 +712,7 @@ class DeviceAgentSimulator:
                                 new_state=new_status,
                                 changed_by="system",
                                 reason=reason,
+                                provenance=provenance_value,
                                 extra_data={
                                     "response_time_ms": self.response_time_ms,
                                     "health_status": (
@@ -756,6 +762,7 @@ class DeviceAgentSimulator:
                                 "active_connections"
                             ],
                             queue_depth=health_data["metrics"]["queue_depth"],
+                            provenance=provenance_value,
                             extra_metrics={
                                 "uptime_seconds": health_data["metrics"][
                                     "uptime_seconds"

--- a/backend/src/homepot/app/api/API_v1/Endpoints/AnalyticsEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/AnalyticsEndpoint.py
@@ -12,7 +12,7 @@ from homepot.app.auth_utils import TokenData, get_current_device, get_current_us
 from homepot.app.models import AnalyticsModel as models
 from homepot.app.utils.smart_filter import SmartDataFilter
 from homepot.database import get_db
-from homepot.models import Device
+from homepot.models import Device, derive_provenance
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -111,6 +111,18 @@ async def log_error(
         if device_id:
             context_data["device_id"] = device_id
 
+        # Resolve provenance from the device when one is supplied so the
+        # error row carries an immutable provenance snapshot.
+        provenance = None
+        if device_id:
+            from sqlalchemy import select
+
+            result = db.execute(select(Device).where(Device.device_id == device_id))
+            device = result.scalar_one_or_none()
+            if device:
+                derived = derive_provenance(device)
+                provenance = derived.value if derived else None
+
         error_log = models.ErrorLog(
             category=error.get("category", "unknown"),
             severity=error.get("severity", "error"),
@@ -121,6 +133,7 @@ async def log_error(
             user_id=error.get("user_id"),
             # device_id removed from model
             context=context_data,
+            provenance=provenance,
             timestamp=datetime.now(timezone.utc),
         )
         db.add(error_log)
@@ -156,6 +169,7 @@ async def log_device_metrics(
         "error_rate": 0.5,
         "active_connections": 10,
         "queue_depth": 2,
+        "collection_interval_seconds": 5,
         "extra_metrics": {...}
     }
     """
@@ -163,6 +177,7 @@ async def log_device_metrics(
         # Resolve device_id if it's a string
         device_id_input = metrics.get("device_id")
         device_pk = device_id_input
+        provenance_device = device
 
         if isinstance(device_id_input, str):
             # Look up the device to get the Integer PK
@@ -174,6 +189,7 @@ async def log_device_metrics(
             found_device = result.scalar_one_or_none()
             if found_device:
                 device_pk = found_device.id
+                provenance_device = found_device
             else:
                 # If device not found, we can't log metrics linked to it
                 logger.warning(
@@ -191,6 +207,7 @@ async def log_device_metrics(
                 "message": "Metrics filtered (no significant change)",
             }
 
+        provenance = derive_provenance(provenance_device)
         device_metrics = models.DeviceMetrics(
             device_id=device_pk,
             cpu_percent=metrics.get("cpu_percent"),
@@ -203,6 +220,8 @@ async def log_device_metrics(
             active_connections=metrics.get("active_connections"),
             queue_depth=metrics.get("queue_depth"),
             extra_metrics=metrics.get("extra_metrics"),
+            provenance=provenance.value if provenance else None,
+            collection_interval_seconds=metrics.get("collection_interval_seconds"),
             timestamp=datetime.now(timezone.utc),
         )
         db.add(device_metrics)
@@ -237,6 +256,7 @@ async def log_device_state_change(
         # Resolve device_id if it's a string
         device_id_input = state_change.get("device_id")
         device_pk = device_id_input
+        provenance_device = None
 
         if isinstance(device_id_input, str):
             # Look up the device to get the Integer PK
@@ -248,6 +268,7 @@ async def log_device_state_change(
             device = result.scalar_one_or_none()
             if device:
                 device_pk = device.id
+                provenance_device = device
             else:
                 logger.warning(
                     f"Device not found for state change logging: {device_id_input}"
@@ -257,6 +278,7 @@ async def log_device_state_change(
                     "message": f"Device {device_id_input} not found",
                 }
 
+        provenance = derive_provenance(provenance_device)
         state_log = models.DeviceStateHistory(
             device_id=device_pk,
             previous_state=state_change.get("previous_state"),
@@ -264,6 +286,7 @@ async def log_device_state_change(
             changed_by=current_user.email if current_user else "system",
             reason=state_change.get("reason"),
             metadata=state_change.get("metadata"),
+            provenance=provenance.value if provenance else None,
             timestamp=datetime.now(timezone.utc),
         )
         db.add(state_log)
@@ -300,6 +323,21 @@ async def log_job_outcome(
     }
     """
     try:
+        # Resolve provenance from the device when a device_id is supplied so
+        # the job outcome row carries an immutable provenance snapshot.
+        provenance = None
+        device_id_input = outcome.get("device_id")
+        if device_id_input:
+            from sqlalchemy import select
+
+            result = db.execute(
+                select(Device).where(Device.device_id == device_id_input)
+            )
+            device = result.scalar_one_or_none()
+            if device:
+                derived = derive_provenance(device)
+                provenance = derived.value if derived else None
+
         outcome_log = models.JobOutcome(
             job_id=outcome.get("job_id"),
             job_type=outcome.get("job_type"),
@@ -311,6 +349,7 @@ async def log_job_outcome(
             retry_count=outcome.get("retry_count", 0),
             initiated_by=outcome.get("initiated_by"),
             metadata=outcome.get("metadata"),
+            provenance=provenance,
             timestamp=datetime.now(timezone.utc),
         )
         db.add(outcome_log)

--- a/backend/src/homepot/app/models/AnalyticsModel.py
+++ b/backend/src/homepot/app/models/AnalyticsModel.py
@@ -68,6 +68,9 @@ class DeviceStateHistory(Base):
     reason = Column(String(500), nullable=True)
     extra_data = Column(JSON, nullable=True)
 
+    # Evidence provenance (snapshotted at write time)
+    provenance = Column(String(20), nullable=True, index=True)
+
     # Relationships
     device = relationship(
         "Device",
@@ -94,6 +97,9 @@ class JobOutcome(Base):
     retry_count = Column(Integer, default=0)
     initiated_by = Column(String(255), nullable=True)
     extra_data = Column(JSON, nullable=True)
+
+    # Evidence provenance (snapshotted at write time)
+    provenance = Column(String(20), nullable=True, index=True)
 
     __table_args__ = (
         Index("idx_job_status", "job_type", "status"),
@@ -124,6 +130,9 @@ class ErrorLog(Base):
     context = Column(JSON, nullable=True)  # Additional context data
     resolved = Column(Boolean, default=False, index=True)
     resolved_at = Column(DateTime, nullable=True)
+
+    # Evidence provenance (snapshotted at write time)
+    provenance = Column(String(20), nullable=True, index=True)
 
     __table_args__ = (
         Index("idx_category_severity", "category", "severity"),
@@ -181,6 +190,11 @@ class DeviceMetrics(Base):
     active_connections = Column(Integer, nullable=True)
     queue_depth = Column(Integer, nullable=True)
     extra_metrics = Column(JSON, nullable=True)
+
+    # Evidence provenance (snapshotted at write time so historical rows do
+    # not silently inherit a later change to the device's classification)
+    provenance = Column(String(20), nullable=True, index=True)
+    collection_interval_seconds = Column(Integer, nullable=True)
 
     # Relationships
     device = relationship(

--- a/backend/src/homepot/app/repositories/agent_repository.py
+++ b/backend/src/homepot/app/repositories/agent_repository.py
@@ -162,6 +162,8 @@ class AgentRepository:
         timestamp: datetime,
         uptime_seconds: int | None = None,
         network_latency_ms: float | None = None,
+        provenance: str | None = None,
+        collection_interval_seconds: int | None = None,
     ) -> DeviceMetrics:
         """Persist a single telemetry entry for a device."""
         metric = DeviceMetrics(
@@ -171,6 +173,8 @@ class AgentRepository:
             disk_percent=disk_usage,
             timestamp=timestamp,
             network_latency_ms=network_latency_ms,
+            provenance=provenance,
+            collection_interval_seconds=collection_interval_seconds,
             extra_metrics=(
                 {"uptime_seconds": uptime_seconds}
                 if uptime_seconds is not None
@@ -183,7 +187,12 @@ class AgentRepository:
         return metric
 
     def save_telemetry_bulk(
-        self, *, device_pk: int, entries: Iterable[dict]
+        self,
+        *,
+        device_pk: int,
+        entries: Iterable[dict],
+        provenance: str | None = None,
+        collection_interval_seconds: int | None = None,
     ) -> list[DeviceMetrics]:
         """Persist multiple telemetry entries for a device."""
         metrics: list[DeviceMetrics] = []
@@ -195,6 +204,8 @@ class AgentRepository:
                 disk_percent=entry["disk_usage"],
                 timestamp=entry["timestamp"],
                 network_latency_ms=entry.get("network_latency_ms"),
+                provenance=provenance,
+                collection_interval_seconds=collection_interval_seconds,
                 extra_metrics=(
                     {"uptime_seconds": entry["uptime_seconds"]}
                     if entry.get("uptime_seconds") is not None

--- a/backend/src/homepot/app/schemas/agent.py
+++ b/backend/src/homepot/app/schemas/agent.py
@@ -101,6 +101,11 @@ class AgentTelemetryRequest(BaseModel):
     uptime_seconds: Optional[int] = Field(
         default=None, ge=0, description="System uptime in seconds"
     )
+    collection_interval_seconds: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Configured collection interval between telemetry samples",
+    )
     timestamp: datetime = Field(
         default_factory=utc_now, description="Telemetry timestamp in UTC"
     )
@@ -114,6 +119,7 @@ class AgentTelemetryRequest(BaseModel):
                 "disk_usage": 48.3,
                 "network_latency_ms": 8.4,
                 "uptime_seconds": 3600,
+                "collection_interval_seconds": 5,
                 "timestamp": "2026-03-31T10:50:00Z",
             }
         }

--- a/backend/src/homepot/app/services/agent_service.py
+++ b/backend/src/homepot/app/services/agent_service.py
@@ -26,6 +26,7 @@ from homepot.models import (
     HealthState,
     LifecycleEpoch,
     LifecycleState,
+    derive_provenance,
 )
 
 
@@ -193,6 +194,7 @@ class AgentService:
                 if not device or not device.id:
                     raise LookupError(f"Device '{payload.device_id}' not found")
 
+                provenance = derive_provenance(device)
                 self.repository.save_telemetry_entry(
                     device_pk=int(device.id),
                     timestamp=payload.timestamp,
@@ -201,6 +203,8 @@ class AgentService:
                     disk_usage=payload.disk_usage,
                     uptime_seconds=payload.uptime_seconds,
                     network_latency_ms=payload.network_latency_ms,
+                    provenance=provenance.value if provenance else None,
+                    collection_interval_seconds=payload.collection_interval_seconds,
                 )
 
                 return {
@@ -232,9 +236,12 @@ class AgentService:
                 for item in entries
             ]
 
+            provenance = derive_provenance(device)
             self.repository.save_telemetry_bulk(
                 device_pk=int(device.id),
                 entries=serialized_entries,
+                provenance=provenance.value if provenance else None,
+                collection_interval_seconds=entries[0].collection_interval_seconds,
             )
 
             return {

--- a/backend/src/homepot/migrations/versions/20260815_add_provenance_and_collection_metadata.py
+++ b/backend/src/homepot/migrations/versions/20260815_add_provenance_and_collection_metadata.py
@@ -1,0 +1,53 @@
+"""Add provenance and collection metadata to analytics tables.
+
+Revision ID: 20260815_add_provenance_and_collection_metadata
+Revises: 20260807_add_push_token_channel
+Create Date: 2026-08-15
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20260815_add_provenance_and_collection_metadata"
+down_revision = "20260807_add_push_token_channel"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Snapshot evidence provenance onto telemetry and event rows.
+
+    The provenance column is nullable so existing rows are not silently
+    assigned a guessed classification; only rows written after this
+    migration carry a provenance value.
+    """
+    op.add_column(
+        "device_metrics",
+        sa.Column("provenance", sa.String(length=20), nullable=True),
+    )
+    op.add_column(
+        "device_metrics",
+        sa.Column("collection_interval_seconds", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "device_state_history",
+        sa.Column("provenance", sa.String(length=20), nullable=True),
+    )
+    op.add_column(
+        "job_outcomes",
+        sa.Column("provenance", sa.String(length=20), nullable=True),
+    )
+    op.add_column(
+        "error_logs",
+        sa.Column("provenance", sa.String(length=20), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Rollback the provenance and collection metadata columns."""
+    op.drop_column("error_logs", "provenance")
+    op.drop_column("job_outcomes", "provenance")
+    op.drop_column("device_state_history", "provenance")
+    op.drop_column("device_metrics", "collection_interval_seconds")
+    op.drop_column("device_metrics", "provenance")

--- a/backend/src/homepot/models.py
+++ b/backend/src/homepot/models.py
@@ -120,6 +120,53 @@ class EnrollmentMethod(str, Enum):
     EMULATED = "emulated"
 
 
+class Provenance(str, Enum):
+    """Evidence provenance class for telemetry and events.
+
+    Per the KPI evaluation roadmap, every exported row must carry one of
+    these classes so that real, controlled, and simulated evidence cannot
+    be mixed silently:
+
+    REAL       — produced by a physical pilot device or an authoritative
+                 POS/application integration.
+    CONTROLLED — produced by a deterministic emulator or injected fault
+                 under a recorded test protocol.
+    SIMULATED  — random or seeded demonstration data.
+
+    The classification is derived from the device at write time and
+    snapshotted onto the row, so historical rows never inherit a device's
+    current classification.
+    """
+
+    REAL = "real"
+    CONTROLLED = "controlled"
+    SIMULATED = "simulated"
+
+
+def derive_provenance(device: "Device | None") -> Provenance | None:
+    """Derive the evidence provenance class for a device.
+
+    Returns ``None`` when the device is not available so callers do not
+    silently store a guessed classification.
+    """
+    if device is None:
+        return None
+
+    source = None
+    if isinstance(device.config, dict):
+        source = device.config.get("device_source")
+
+    if source == "emulator":
+        return Provenance.CONTROLLED
+    if source == "simulation":
+        return Provenance.SIMULATED
+    if source == "physical":
+        return Provenance.REAL
+    if device.is_simulated:
+        return Provenance.SIMULATED
+    return Provenance.REAL
+
+
 class EnrolmentIntentStatus(str, Enum):
     """Status of an enrolment intent."""
 

--- a/backend/tests/test_provenance.py
+++ b/backend/tests/test_provenance.py
@@ -1,0 +1,405 @@
+"""Tests for evidence provenance and collection metadata preservation.
+
+The KPI evaluation roadmap requires every telemetry and event row to carry
+an immutable provenance class (real/controlled/simulated) so historical rows
+never silently inherit a device's current classification, plus collection
+metadata (the configured collection interval) for telemetry completeness
+KPIs.
+"""
+
+import asyncio
+import os
+import tempfile
+
+from fastapi.testclient import TestClient
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from homepot.app.auth_utils import create_access_token, hash_password
+from homepot.app.models.AnalyticsModel import (
+    DeviceMetrics,
+    DeviceStateHistory,
+    ErrorLog,
+    JobOutcome,
+)
+from homepot.config import reload_settings
+import homepot.database
+from homepot.models import Base, Device, LifecycleState, Provenance, Site
+
+
+@pytest.fixture(autouse=True)
+def mock_db_url(monkeypatch):
+    """Use a temporary SQLite DB so tests do not touch real data."""
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    db_url = f"sqlite:///{path}"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    monkeypatch.setenv("DATABASE__URL", db_url)
+    reload_settings()
+
+    if homepot.database._db_service is not None:
+        try:
+            asyncio.run(homepot.database._db_service.close())
+        except Exception:
+            pass
+        homepot.database._db_service = None
+
+    new_engine = create_engine(
+        db_url, connect_args={"check_same_thread": False}, pool_pre_ping=True
+    )
+    Base.metadata.create_all(bind=new_engine)
+    new_session_local = sessionmaker(bind=new_engine, autocommit=False, autoflush=False)
+
+    monkeypatch.setattr(homepot.database, "sync_engine", new_engine)
+    monkeypatch.setattr(homepot.database, "SessionLocal", new_session_local)
+
+    yield
+
+    new_engine.dispose()
+    if os.path.exists(path):
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def _create_site(site_code: str = "site-prov-1") -> Site:
+    """Create and return a site row for provenance tests."""
+    db = homepot.database.SessionLocal()
+    try:
+        site = Site(site_id=site_code, name="Provenance Test Site", location="Lab")
+        db.add(site)
+        db.commit()
+        db.refresh(site)
+        return site
+    finally:
+        db.close()
+
+
+def _create_device(
+    device_id: str,
+    site_pk: int,
+    api_key: str = "test-api-key",
+    is_simulated: bool = False,
+    device_source: str | None = None,
+) -> str:
+    """Create a device row and return the plain-text API key."""
+    db = homepot.database.SessionLocal()
+    try:
+        device = Device(
+            device_id=device_id,
+            name="Provenance Device",
+            device_type="pos_terminal",
+            site_id=site_pk,
+            api_key_hash=hash_password(api_key),
+            is_active=True,
+            is_simulated=is_simulated,
+            config={"device_source": device_source} if device_source else None,
+            lifecycle_state=LifecycleState.ACTIVE.value,
+        )
+        db.add(device)
+        db.commit()
+        db.refresh(device)
+        return api_key
+    finally:
+        db.close()
+
+
+def _device_headers(device_id: str, api_key: str) -> dict[str, str]:
+    """Headers used for device-authenticated endpoints."""
+    return {"X-Device-ID": device_id, "X-API-Key": api_key}
+
+
+def _auth_header(email: str = "provenance-test@example.com") -> dict[str, str]:
+    """Headers used for user-authenticated endpoints."""
+    token = create_access_token({"sub": email})
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _latest_metric(device_pk: int) -> DeviceMetrics | None:
+    """Return the most recent metrics row for a device primary key."""
+    db = homepot.database.SessionLocal()
+    try:
+        return (
+            db.query(DeviceMetrics)
+            .filter(DeviceMetrics.device_id == device_pk)
+            .order_by(DeviceMetrics.id.desc())
+            .first()
+        )
+    finally:
+        db.close()
+
+
+class TestMetricsProvenance:
+    """Device metrics rows snapshot the device provenance class."""
+
+    def test_real_device_metrics_carry_real_provenance(
+        self, client: TestClient
+    ) -> None:
+        """Metrics from a physical device are classified REAL."""
+        site = _create_site()
+        api_key = _create_device("real-pos-001", int(site.id), device_source="physical")
+        device_pk = _device_pk("real-pos-001")
+
+        resp = client.post(
+            "/api/v1/analytics/device-metrics",
+            json={
+                "device_id": "real-pos-001",
+                "cpu_percent": 12.0,
+                "memory_percent": 51.0,
+                "collection_interval_seconds": 5,
+            },
+            headers=_device_headers("real-pos-001", api_key),
+        )
+        assert resp.status_code == 201, resp.text
+
+        row = _latest_metric(device_pk)
+        assert row is not None
+        assert row.provenance == Provenance.REAL.value
+        assert row.collection_interval_seconds == 5
+
+    def test_seeded_device_metrics_carry_simulated_provenance(
+        self, client: TestClient
+    ) -> None:
+        """Metrics from a device marked is_simulated are classified SIMULATED."""
+        site = _create_site()
+        api_key = _create_device("sim-pos-001", int(site.id), is_simulated=True)
+        device_pk = _device_pk("sim-pos-001")
+
+        resp = client.post(
+            "/api/v1/analytics/device-metrics",
+            json={
+                "device_id": "sim-pos-001",
+                "cpu_percent": 20.0,
+                "memory_percent": 60.0,
+            },
+            headers=_device_headers("sim-pos-001", api_key),
+        )
+        assert resp.status_code == 201, resp.text
+
+        row = _latest_metric(device_pk)
+        assert row is not None
+        assert row.provenance == Provenance.SIMULATED.value
+
+    def test_emulator_device_metrics_carry_controlled_provenance(
+        self, client: TestClient
+    ) -> None:
+        """Metrics from a deterministic emulator are classified CONTROLLED."""
+        site = _create_site()
+        api_key = _create_device("emul-pos-001", int(site.id), device_source="emulator")
+        device_pk = _device_pk("emul-pos-001")
+
+        resp = client.post(
+            "/api/v1/analytics/device-metrics",
+            json={
+                "device_id": "emul-pos-001",
+                "cpu_percent": 30.0,
+                "memory_percent": 70.0,
+            },
+            headers=_device_headers("emul-pos-001", api_key),
+        )
+        assert resp.status_code == 201, resp.text
+
+        row = _latest_metric(device_pk)
+        assert row is not None
+        assert row.provenance == Provenance.CONTROLLED.value
+
+    def test_provenance_is_immutable_after_classification_change(
+        self, client: TestClient
+    ) -> None:
+        """Historical rows keep their provenance when the device changes."""
+        site = _create_site()
+        api_key = _create_device(
+            "mutable-pos-001", int(site.id), device_source="physical"
+        )
+        device_pk = _device_pk("mutable-pos-001")
+
+        resp = client.post(
+            "/api/v1/analytics/device-metrics",
+            json={"device_id": "mutable-pos-001", "cpu_percent": 15.0},
+            headers=_device_headers("mutable-pos-001", api_key),
+        )
+        assert resp.status_code == 201, resp.text
+
+        # Re-classify the device as simulated after the row was written.
+        db = homepot.database.SessionLocal()
+        try:
+            device = db.get(Device, device_pk)
+            assert device is not None
+            device.is_simulated = True
+            device.config = {"device_source": "simulation"}
+            db.commit()
+        finally:
+            db.close()
+
+        row = _latest_metric(device_pk)
+        assert row is not None
+        # The historical row must not silently inherit the new classification.
+        assert row.provenance == Provenance.REAL.value
+
+
+class TestEventProvenance:
+    """State, job, and error event rows snapshot the device provenance class."""
+
+    def test_state_change_carries_provenance(self, client: TestClient) -> None:
+        """State-change rows snapshot the device provenance."""
+        site = _create_site()
+        _create_device("state-pos-001", int(site.id), device_source="physical")
+
+        resp = client.post(
+            "/api/v1/analytics/device-state-change",
+            json={
+                "device_id": "state-pos-001",
+                "previous_state": "online",
+                "new_state": "offline",
+                "reason": "Network timeout",
+            },
+            headers=_auth_header(),
+        )
+        assert resp.status_code == 201, resp.text
+
+        db = homepot.database.SessionLocal()
+        try:
+            row = (
+                db.query(DeviceStateHistory)
+                .order_by(DeviceStateHistory.id.desc())
+                .first()
+            )
+            assert row is not None
+            assert row.provenance == Provenance.REAL.value
+        finally:
+            db.close()
+
+    def test_job_outcome_carries_provenance(self, client: TestClient) -> None:
+        """Job-outcome rows snapshot the device provenance."""
+        site = _create_site()
+        _create_device("job-pos-001", int(site.id), is_simulated=True)
+
+        resp = client.post(
+            "/api/v1/analytics/job-outcome",
+            json={
+                "job_id": "job-456",
+                "job_type": "restart",
+                "device_id": "job-pos-001",
+                "status": "success",
+                "duration_ms": 5000,
+            },
+            headers=_auth_header(),
+        )
+        assert resp.status_code == 201, resp.text
+
+        db = homepot.database.SessionLocal()
+        try:
+            row = db.query(JobOutcome).order_by(JobOutcome.id.desc()).first()
+            assert row is not None
+            assert row.provenance == Provenance.SIMULATED.value
+        finally:
+            db.close()
+
+    def test_error_log_carries_provenance(self, client: TestClient) -> None:
+        """Error rows snapshot the device provenance."""
+        site = _create_site()
+        _create_device("err-pos-001", int(site.id), device_source="emulator")
+
+        resp = client.post(
+            "/api/v1/analytics/error",
+            json={
+                "category": "device",
+                "severity": "error",
+                "error_message": "Device unreachable",
+                "device_id": "err-pos-001",
+            },
+            headers=_auth_header(),
+        )
+        assert resp.status_code == 201, resp.text
+
+        db = homepot.database.SessionLocal()
+        try:
+            row = db.query(ErrorLog).order_by(ErrorLog.id.desc()).first()
+            assert row is not None
+            assert row.provenance == Provenance.CONTROLLED.value
+        finally:
+            db.close()
+
+
+class TestAgentTelemetryProvenance:
+    """Agent telemetry rows snapshot provenance and collection metadata."""
+
+    def test_agent_telemetry_carries_provenance(self, client: TestClient) -> None:
+        """Agent telemetry persists provenance and the collection interval."""
+        site = _create_site()
+        api_key = _create_device(
+            "agent-pos-001", int(site.id), device_source="physical"
+        )
+        device_pk = _device_pk("agent-pos-001")
+
+        resp = client.post(
+            "/api/v1/agent/telemetry",
+            json={
+                "device_id": "agent-pos-001",
+                "cpu_usage": 21.0,
+                "memory_usage": 56.0,
+                "disk_usage": 45.0,
+                "collection_interval_seconds": 5,
+            },
+            headers=_device_headers("agent-pos-001", api_key),
+        )
+        assert resp.status_code == 200, resp.text
+
+        row = _latest_metric(device_pk)
+        assert row is not None
+        assert row.provenance == Provenance.REAL.value
+        assert row.collection_interval_seconds == 5
+
+    def test_agent_telemetry_bulk_carries_provenance(self, client: TestClient) -> None:
+        """Bulk agent telemetry persists provenance on every row."""
+        site = _create_site()
+        api_key = _create_device(
+            "agent-bulk-001", int(site.id), device_source="emulator"
+        )
+        device_pk = _device_pk("agent-bulk-001")
+
+        resp = client.post(
+            "/api/v1/agent/telemetry",
+            json=[
+                {
+                    "device_id": "agent-bulk-001",
+                    "cpu_usage": 21.0,
+                    "memory_usage": 56.0,
+                    "disk_usage": 45.0,
+                },
+                {
+                    "device_id": "agent-bulk-001",
+                    "cpu_usage": 22.0,
+                    "memory_usage": 57.0,
+                    "disk_usage": 46.0,
+                },
+            ],
+            headers=_device_headers("agent-bulk-001", api_key),
+        )
+        assert resp.status_code == 200, resp.text
+
+        db = homepot.database.SessionLocal()
+        try:
+            rows = (
+                db.query(DeviceMetrics)
+                .filter(DeviceMetrics.device_id == device_pk)
+                .all()
+            )
+            assert len(rows) == 2
+            assert all(row.provenance == Provenance.CONTROLLED.value for row in rows)
+        finally:
+            db.close()
+
+
+def _device_pk(device_id: str) -> int:
+    """Resolve the integer primary key for a device_id string."""
+    db = homepot.database.SessionLocal()
+    try:
+        result = db.execute(select(Device).where(Device.device_id == device_id))
+        device = result.scalar_one()
+        return int(device.id)
+    finally:
+        db.close()

--- a/backend/utils/real_device_agent.py
+++ b/backend/utils/real_device_agent.py
@@ -27,6 +27,7 @@ DEVICE_TYPE = "linux_server"
 HOSTNAME = socket.gethostname()
 DEVICE_ID = f"wsl-device-{HOSTNAME.lower().replace(' ', '-')}"
 API_KEY_FILE = ".device_api_key"
+COLLECTION_INTERVAL_SECONDS = 5
 
 
 async def register_device(client: httpx.AsyncClient) -> Optional[str]:
@@ -83,6 +84,7 @@ async def collect_and_send_metrics(client: httpx.AsyncClient, api_key: str):
                 "transaction_volume": 0.0,
                 "error_rate": 0.0,
                 "active_connections": len(psutil.net_connections()),
+                "collection_interval_seconds": COLLECTION_INTERVAL_SECONDS,
                 "extra_metrics": {
                     "boot_time": psutil.boot_time(),
                     "bytes_sent": net_io.bytes_sent,
@@ -109,7 +111,7 @@ async def collect_and_send_metrics(client: httpx.AsyncClient, api_key: str):
             logger.error(f"Error collecting/sending metrics: {e}")
 
         # Wait before next collection
-        await asyncio.sleep(5)
+        await asyncio.sleep(COLLECTION_INTERVAL_SECONDS)
 
 
 async def poll_commands(client: httpx.AsyncClient, api_key: str):

--- a/emulators/pos_engine.py
+++ b/emulators/pos_engine.py
@@ -653,6 +653,7 @@ class POSEmulator:
                     "device_id": self.device_id,
                     **metrics,
                     "uptime_seconds": uptime_seconds,
+                    "collection_interval_seconds": int(self.config.telemetry_interval),
                     "timestamp": datetime.now(timezone.utc).isoformat(),
                 }
                 resp = await self._http.post(


### PR DESCRIPTION
## Summary

Real, controlled, and simulated evidence can no longer be mixed silently. This PR snapshots an immutable evidence provenance class onto every telemetry and event row at write time, so exported rows retain their source classification independently of later changes to the device (per `docs/KPI-evaluation-roadmap.md` section 3.1 and Phase 1 P0).

## Changes

- **Provenance model**: new `Provenance` enum (`real`/`controlled`/`simulated`) and `derive_provenance(device)` helper in `homepot.models` — emulator `device_source` maps to `controlled`, `simulation`/seed to `simulated`, physical to `real`.
- **Schema (migration `20260815_add_provenance_and_collection_metadata`)**: adds `provenance` to `device_metrics`, `device_state_history`, `job_outcomes`, `error_logs` and `collection_interval_seconds` to `device_metrics`. Columns are nullable so existing rows are not silently given a guessed classification.
- **Write paths**: provenance snapshotted in `log_device_metrics`, `log_device_state_change`, `log_job_outcome`, `log_error`, the agent telemetry ingest (single + bulk), and the in-process simulator. `collection_interval_seconds` is populated by the real device agent and the deterministic POS emulator, and accepted on `AgentTelemetryRequest`.
- **Tests**: new `test_provenance.py` (9 tests) covering real/simulated/controlled classification, immutability after a device is re-classified, event-row provenance, and collection metadata on both analytics and agent telemetry paths.

## Verification

- `python -m pytest backend/tests/test_provenance.py` — 9 passed
- Targeted analytics/agent/device suites — 80 passed
- Full suite: 955 passed; the 16 failures (`test_live_api.py`, `test_performance.py`) are pre-existing environment-dependent failures confirmed on the base branch
- `flake8`, `black --check`, `isort --check-only` clean on all changed files
- `alembic heads` resolves to the new migration