### PR TITLE
feat: capture real-agent latency, uptime, and operational signals

### DIFF
--- a/backend/src/homepot/agent/agent-config.json
+++ b/backend/src/homepot/agent/agent-config.json
@@ -23,5 +23,7 @@
   "log_backup_count": 5,
   "watchdog_enabled": true,
   "watchdog_interval_seconds": 10,
-  "shutdown_timeout_seconds": 30
+  "shutdown_timeout_seconds": 30,
+  "pos_signals_source": null,
+  "submission_log_path": null
 }

--- a/backend/src/homepot/agent/real_device_agent.py
+++ b/backend/src/homepot/agent/real_device_agent.py
@@ -43,7 +43,12 @@ from homepot.agent.utils.proxy_settings import build_httpx_proxy_kwargs
 from homepot.agent.utils.push_listener import create_push_listener
 from homepot.agent.utils.real_device_discovery import get_connected_peripherals
 from homepot.agent.utils.retry_queue import RetryQueue
-from homepot.agent.utils.telemetry import build_telemetry_payload
+from homepot.agent.utils.submission_log import SubmissionLog
+from homepot.agent.utils.telemetry import (
+    build_telemetry_payload,
+    collect_pos_signals,
+    measure_network_latency_ms,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +110,11 @@ def load_agent_config() -> Dict[str, Any]:
     data.setdefault("watchdog_enabled", True)
     data.setdefault("watchdog_interval_seconds", 10)
     data.setdefault("shutdown_timeout_seconds", 30)
+    data.setdefault(
+        "pos_signals_source",
+        None,  # Inert until a data-source agreement and source validation exist
+    )
+    data.setdefault("submission_log_path", None)
     return data
 
 
@@ -121,15 +131,41 @@ async def post_json(
     url: str,
     payload: Dict[str, Any],
     headers: Dict[str, str],
+    *,
+    submission_log: Optional[SubmissionLog] = None,
+    timeout: float = 10.0,
 ) -> bool:
-    """Send JSON payload to backend and return True on HTTP success."""
+    """Send JSON payload to backend and return True on HTTP success.
+
+    When ``submission_log`` is provided, the attempt (endpoint, payload
+    sample timestamp, HTTP status, and acceptance) is appended to the
+    agent submission log so PF-01 ingestion success can be computed.
+    """
+    accepted = False
+    status_code: Optional[int] = None
     try:
-        response = await client.post(url, json=payload, headers=headers, timeout=10.0)
+        response = await client.post(
+            url, json=payload, headers=headers, timeout=timeout
+        )
         response.raise_for_status()
-        return True
+        accepted = True
+        status_code = response.status_code
     except Exception as e:
         logger.warning("POST failed url=%s error=%s", url, e)
-        return False
+
+    if submission_log is not None:
+        sample_timestamp = None
+        if isinstance(payload, dict):
+            sample_timestamp = payload.get("timestamp")
+        submission_log.append(
+            endpoint=url,
+            status_code=status_code,
+            payload_timestamp=(
+                str(sample_timestamp) if sample_timestamp is not None else None
+            ),
+            accepted=accepted,
+        )
+    return accepted
 
 
 async def get_json(
@@ -471,6 +507,7 @@ async def heartbeat_loop(
     config: Dict[str, Any],
     retry_queue: RetryQueue,
     ipc_server: Server | None,
+    submission_log: Optional[SubmissionLog] = None,
 ) -> None:
     """Continuously send heartbeats and update local IPC state."""
     url = f"{config['backend_url'].rstrip('/')}/api/v1/agent/heartbeat"
@@ -489,7 +526,13 @@ async def heartbeat_loop(
                 site_id=config["site_id"],
                 status="ONLINE",
             )
-            ok = await post_json(client, url, payload, get_auth_headers(config))
+            ok = await post_json(
+                client,
+                url,
+                payload,
+                get_auth_headers(config),
+                submission_log=submission_log,
+            )
             if ok:
                 if ipc_server is not None:
                     update_local_agent_state(
@@ -514,10 +557,12 @@ async def telemetry_loop(
     config: Dict[str, Any],
     retry_queue: RetryQueue,
     ipc_server: Server | None,
+    submission_log: Optional[SubmissionLog] = None,
 ) -> None:
     """Continuously send telemetry metrics and update local IPC state."""
     url = f"{config['backend_url'].rstrip('/')}/api/v1/agent/telemetry"
     interval = int(config["telemetry_interval_seconds"])
+    backend_url = str(config["backend_url"])
     while True:
         try:
             # Payload sent to POST /api/v1/agent/telemetry
@@ -527,11 +572,28 @@ async def telemetry_loop(
             #   "cpu_usage": 20.1,
             #   "memory_usage": 55.4,
             #   "disk_usage": 44.8,
+            #   "uptime_seconds": 86400,
+            #   "network_latency_ms": 8.4,
+            #   "collection_interval_seconds": 30,
             #   "timestamp": "2026-04-13T12:00:30Z"
             # }
-            payload = build_telemetry_payload(config["device_id"])
+            network_latency_ms = await measure_network_latency_ms(client, backend_url)
+            payload = build_telemetry_payload(
+                config["device_id"],
+                network_latency_ms=network_latency_ms,
+                collection_interval_seconds=interval,
+            )
             payload["site_id"] = config["site_id"]
-            ok = await post_json(client, url, payload, get_auth_headers(config))
+            pos = collect_pos_signals(config.get("pos_signals_source"))
+            if pos is not None:
+                payload["pos"] = pos
+            ok = await post_json(
+                client,
+                url,
+                payload,
+                get_auth_headers(config),
+                submission_log=submission_log,
+            )
             if ok and ipc_server is not None:
                 update_local_agent_state(
                     ipc_server.config.app,  # type: ignore[arg-type]
@@ -548,6 +610,7 @@ async def retry_flush_loop(
     client: httpx.AsyncClient,
     config: Dict[str, Any],
     retry_queue: RetryQueue,
+    submission_log: Optional[SubmissionLog] = None,
 ) -> None:
     """Flush queued failed payloads to backend at a fixed interval.
 
@@ -565,6 +628,7 @@ async def retry_flush_loop(
                     item["url"],
                     item["payload"],
                     get_auth_headers(config),
+                    submission_log=submission_log,
                 )
                 if not ok:
                     retry_queue.requeue(item)
@@ -776,6 +840,11 @@ async def run_agent(
 
     cred = create_credential_storage()
     retry_queue = RetryQueue()
+    submission_log = SubmissionLog(
+        Path(config["submission_log_path"])
+        if config.get("submission_log_path")
+        else None
+    )
     ipc_server = start_local_ipc_server(config)
 
     push_listener = create_push_listener(config, cred=cred)
@@ -825,12 +894,14 @@ async def run_agent(
 
         tasks = [
             asyncio.ensure_future(
-                heartbeat_loop(client, config, retry_queue, ipc_server)
+                heartbeat_loop(client, config, retry_queue, ipc_server, submission_log)
             ),
             asyncio.ensure_future(
-                telemetry_loop(client, config, retry_queue, ipc_server)
+                telemetry_loop(client, config, retry_queue, ipc_server, submission_log)
             ),
-            asyncio.ensure_future(retry_flush_loop(client, config, retry_queue)),
+            asyncio.ensure_future(
+                retry_flush_loop(client, config, retry_queue, submission_log)
+            ),
             asyncio.ensure_future(
                 pending_commands_loop(
                     client,

--- a/backend/src/homepot/agent/utils/submission_log.py
+++ b/backend/src/homepot/agent/utils/submission_log.py
@@ -1,0 +1,85 @@
+"""Append-only submission-attempt log for the real device agent.
+
+Each backend submission attempt is recorded as one JSON line so the
+PF-01 telemetry-ingestion KPI can be computed by joining this log to the
+backend ingestion log (attempted vs accepted submissions).
+"""
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from homepot.agent.identity import identity_dir
+
+
+def _default_log_path() -> Path:
+    """Return the default submission log path inside the identity directory."""
+    return identity_dir() / ".agent_submissions.jsonl"
+
+
+class SubmissionLog:
+    """Append-only JSONL log of agent submission attempts.
+
+    Each record carries the submission timestamp, endpoint path, the
+    payload's device sample timestamp (when present), the HTTP status, and
+    whether the backend accepted the submission.
+    """
+
+    def __init__(self, log_path: Optional[Path] = None) -> None:
+        """Initialize the log.
+
+        Parameters
+        ----------
+        log_path:
+            Path to the JSONL file.  Defaults to
+            ``<identity_dir>/.agent_submissions.jsonl``.
+        """
+        self.path = log_path or _default_log_path()
+
+    def append(
+        self,
+        *,
+        endpoint: str,
+        status_code: Optional[int],
+        payload_timestamp: Optional[str] = None,
+        accepted: Optional[bool] = None,
+        retry_count: int = 0,
+    ) -> None:
+        """Record one submission attempt as a JSON line."""
+        if accepted is None:
+            accepted = bool(status_code is not None and 200 <= int(status_code) < 300)
+        record: Dict[str, Any] = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "endpoint": endpoint,
+            "payload_timestamp": payload_timestamp,
+            "status_code": status_code,
+            "accepted": accepted,
+            "retry_count": retry_count,
+        }
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+
+    def read_all(self) -> List[Dict[str, Any]]:
+        """Read every recorded submission attempt."""
+        if not self.path.exists():
+            return []
+        records: List[Dict[str, Any]] = []
+        try:
+            with self.path.open("r", encoding="utf-8") as f:
+                for line in f:
+                    if not line.strip():
+                        continue
+                    try:
+                        records.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
+        except OSError:
+            return []
+        return records
+
+    def clear(self) -> None:
+        """Remove the log file, dropping all recorded attempts."""
+        if self.path.exists():
+            self.path.unlink()

--- a/backend/src/homepot/agent/utils/telemetry.py
+++ b/backend/src/homepot/agent/utils/telemetry.py
@@ -1,6 +1,18 @@
-"""Telemetry payload utilities for the real device agent."""
+"""Telemetry payload utilities for the real device agent.
+
+Provides system metric collection (CPU, memory, disk, uptime), a genuine
+network-latency measurement against the backend, and a config-gated seam
+for permitted POS/application signals.
+
+Per the KPI evaluation roadmap, operational POS KPIs remain **excluded**
+until a data-source agreement and side-by-side source validation exist;
+``collect_pos_signals`` is inert unless a source path is configured.
+"""
 
 from datetime import datetime, timezone
+import json
+from pathlib import Path
+import time
 from typing import Any, Dict, Optional
 
 import psutil
@@ -11,21 +23,85 @@ def utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def collect_uptime_seconds() -> float:
+    """Return host OS uptime in seconds derived from the boot time."""
+    try:
+        return max(0.0, time.time() - psutil.boot_time())
+    except Exception:
+        return 0.0
+
+
 def collect_system_telemetry() -> Dict[str, float]:
-    """Collect basic CPU, memory, and disk usage metrics from the host."""
+    """Collect basic CPU, memory, disk, and uptime metrics from the host."""
     return {
         "cpu_usage": float(psutil.cpu_percent(interval=0.1)),
         "memory_usage": float(psutil.virtual_memory().percent),
         "disk_usage": float(psutil.disk_usage("/").percent),
+        "uptime_seconds": collect_uptime_seconds(),
     }
 
 
+async def measure_network_latency_ms(
+    client: Any, backend_url: str, *, timeout: float = 5.0
+) -> Optional[float]:
+    """Measure end-to-end round-trip latency to the backend in milliseconds.
+
+    Sends a lightweight ``GET`` to the backend root URL and returns the
+    elapsed time in milliseconds, or ``None`` when the backend is
+    unreachable or the request fails.
+    """
+    url = f"{backend_url.rstrip('/')}/"
+    start = time.perf_counter()
+    try:
+        await client.get(url, timeout=timeout)
+    except Exception:
+        # Transport errors (unreachable, timeout, DNS) yield no measurement.
+        return None
+    elapsed_ms = (time.perf_counter() - start) * 1000.0
+    return elapsed_ms
+
+
+def collect_pos_signals(source: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Collect permitted POS/application signals from a configured source.
+
+    Reads a JSON file whose top level is an object of POS metrics (for
+    example ``transaction_count``, ``transaction_volume``, ``error_rate``).
+    Returns ``None`` when no ``source`` is configured (the default) so the
+    agent never fabricates POS data.  This seam stays inert until a
+    data-source agreement and side-by-side source validation exist.
+    """
+    if not source:
+        return None
+    try:
+        data = json.loads(Path(source).read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
 def build_telemetry_payload(
-    device_id: str, *, extra: Optional[Dict[str, Any]] = None
+    device_id: str,
+    *,
+    extra: Optional[Dict[str, Any]] = None,
+    network_latency_ms: Optional[float] = None,
+    collection_interval_seconds: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """Build telemetry payload using host metrics and optional extra fields."""
-    payload: Dict[str, Any] = {"device_id": device_id, "timestamp": utc_now_iso()}
+    """Build telemetry payload using host metrics and optional extra fields.
+
+    The payload timestamp is the device sample time (UTC ISO-8601) used as
+    the PF-02 latency reference point.
+    """
+    payload: Dict[str, Any] = {
+        "device_id": device_id,
+        "timestamp": utc_now_iso(),
+    }
     payload.update(collect_system_telemetry())
+    if network_latency_ms is not None:
+        payload["network_latency_ms"] = network_latency_ms
+    if collection_interval_seconds is not None:
+        payload["collection_interval_seconds"] = collection_interval_seconds
     if extra:
         payload["extra"] = extra
     return payload

--- a/backend/tests/test_agent_heartbeat_telemetry.py
+++ b/backend/tests/test_agent_heartbeat_telemetry.py
@@ -1,11 +1,18 @@
 """Tests for heartbeat and telemetry payload utilities."""
 
+import asyncio
 from datetime import datetime, timezone
+import json
+
+import httpx
 
 from homepot.agent.utils.heartbeat import build_heartbeat_payload, utc_now_iso
 from homepot.agent.utils.telemetry import (
     build_telemetry_payload,
+    collect_pos_signals,
     collect_system_telemetry,
+    collect_uptime_seconds,
+    measure_network_latency_ms,
 )
 from homepot.agent.utils.telemetry import utc_now_iso as te_utc_now
 
@@ -125,6 +132,88 @@ class TestCollectSystemTelemetry:
         metrics = collect_system_telemetry()
         assert 0 <= metrics["disk_usage"] <= 100
 
+    def test_includes_uptime_seconds(self):
+        """System telemetry includes a host uptime value."""
+        metrics = collect_system_telemetry()
+        assert "uptime_seconds" in metrics
+        assert isinstance(metrics["uptime_seconds"], float)
+        assert metrics["uptime_seconds"] >= 0
+
+
+class TestCollectUptimeSeconds:
+    """Tests for ``collect_uptime_seconds``."""
+
+    def test_returns_non_negative_float(self):
+        """Uptime is a non-negative float."""
+        uptime = collect_uptime_seconds()
+        assert isinstance(uptime, float)
+        assert uptime >= 0
+
+
+class TestMeasureNetworkLatencyMs:
+    """Tests for ``measure_network_latency_ms``."""
+
+    def test_returns_elapsed_ms_on_http_response(self):
+        """A responding backend yields a non-negative latency in milliseconds."""
+
+        async def _handler(request):
+            return httpx.Response(404, json={})
+
+        async def _run():
+            transport = httpx.MockTransport(_handler)
+            async with httpx.AsyncClient(transport=transport) as client:
+                return await measure_network_latency_ms(
+                    client, "https://backend.example.com"
+                )
+
+        result = asyncio.run(_run())
+        assert isinstance(result, float)
+        assert result >= 0
+
+    def test_returns_none_on_transport_error(self):
+        """An unreachable backend yields no latency measurement."""
+
+        async def _handler(request):
+            raise httpx.ConnectError("connection refused")
+
+        async def _run():
+            transport = httpx.MockTransport(_handler)
+            async with httpx.AsyncClient(transport=transport) as client:
+                return await measure_network_latency_ms(
+                    client, "https://backend.example.com"
+                )
+
+        result = asyncio.run(_run())
+        assert result is None
+
+
+class TestCollectPosSignals:
+    """Tests for ``collect_pos_signals``."""
+
+    def test_returns_none_when_unconfigured(self):
+        """No source configured means no POS signals (never fabricated)."""
+        assert collect_pos_signals(None) is None
+
+    def test_reads_json_source(self, tmp_path):
+        """A configured JSON source yields its POS metrics object."""
+        source = tmp_path / "pos_signals.json"
+        source.write_text(
+            json.dumps({"transaction_count": 42, "transaction_volume": 120.5}),
+            encoding="utf-8",
+        )
+        result = collect_pos_signals(str(source))
+        assert result == {
+            "transaction_count": 42,
+            "transaction_volume": 120.5,
+        }
+
+    def test_returns_none_for_invalid_source(self, tmp_path):
+        """A missing or malformed source yields no POS signals."""
+        assert collect_pos_signals(str(tmp_path / "missing.json")) is None
+        bad = tmp_path / "bad.json"
+        bad.write_text("not json", encoding="utf-8")
+        assert collect_pos_signals(str(bad)) is None
+
 
 class TestBuildTelemetryPayload:
     """Tests for ``build_telemetry_payload``."""
@@ -142,11 +231,38 @@ class TestBuildTelemetryPayload:
         assert parsed.tzinfo is not None
 
     def test_includes_system_metrics(self):
-        """Payload includes cpu, memory, and disk metrics."""
+        """Payload includes cpu, memory, disk, and uptime metrics."""
         payload = build_telemetry_payload("dev-1")
         assert "cpu_usage" in payload
         assert "memory_usage" in payload
         assert "disk_usage" in payload
+        assert "uptime_seconds" in payload
+
+    def test_includes_network_latency_when_provided(self):
+        """Payload includes measured network latency when available."""
+        payload = build_telemetry_payload("dev-1", network_latency_ms=8.4)
+        assert payload["network_latency_ms"] == 8.4
+
+    def test_omits_network_latency_when_not_measured(self):
+        """Payload omits network latency when unavailable."""
+        payload = build_telemetry_payload("dev-1")
+        assert "network_latency_ms" not in payload
+
+    def test_includes_collection_interval_when_provided(self):
+        """Payload includes the configured collection interval."""
+        payload = build_telemetry_payload("dev-1", collection_interval_seconds=30)
+        assert payload["collection_interval_seconds"] == 30
+
+    def test_omits_collection_interval_when_not_provided(self):
+        """Payload omits the collection interval when unavailable."""
+        payload = build_telemetry_payload("dev-1")
+        assert "collection_interval_seconds" not in payload
+
+    def test_timestamp_is_sample_time(self):
+        """Payload timestamp is the device sample time (UTC ISO-8601)."""
+        payload = build_telemetry_payload("dev-1")
+        parsed = datetime.fromisoformat(payload["timestamp"])
+        assert parsed.tzinfo is not None
 
     def test_cpu_is_float(self):
         """CPU usage is a float."""

--- a/backend/tests/test_agent_submission_log.py
+++ b/backend/tests/test_agent_submission_log.py
@@ -1,0 +1,132 @@
+"""Tests for the agent submission-attempt log and submission recording."""
+
+import asyncio
+import json
+
+import httpx
+
+from homepot.agent.real_device_agent import post_json
+from homepot.agent.utils.submission_log import SubmissionLog
+
+
+class TestSubmissionLog:
+    """Tests for the append-only JSONL submission log."""
+
+    def test_append_and_read_round_trip(self, tmp_path):
+        """Appended records are readable with all fields intact."""
+        log = SubmissionLog(log_path=tmp_path / "subs.jsonl")
+        log.append(
+            endpoint="https://x/api/v1/agent/telemetry",
+            status_code=201,
+            payload_timestamp="2026-01-01T00:00:00+00:00",
+        )
+
+        records = log.read_all()
+        assert len(records) == 1
+        record = records[0]
+        assert record["endpoint"].endswith("/api/v1/agent/telemetry")
+        assert record["status_code"] == 201
+        assert record["accepted"] is True
+        assert record["payload_timestamp"] == "2026-01-01T00:00:00+00:00"
+        assert record["retry_count"] == 0
+        assert "timestamp" in record
+
+    def test_accepted_derived_from_status_code(self, tmp_path):
+        """Acceptance is derived from the HTTP status when not supplied."""
+        log = SubmissionLog(log_path=tmp_path / "subs.jsonl")
+        log.append(endpoint="https://x/telemetry", status_code=500)
+        log.append(endpoint="https://x/telemetry", status_code=None)
+
+        records = log.read_all()
+        assert records[0]["accepted"] is False
+        assert records[1]["accepted"] is False
+
+    def test_explicit_accepted_wins(self, tmp_path):
+        """An explicitly supplied acceptance is kept as-is."""
+        log = SubmissionLog(log_path=tmp_path / "subs.jsonl")
+        log.append(endpoint="https://x/telemetry", status_code=None, accepted=True)
+
+        records = log.read_all()
+        assert records[0]["accepted"] is True
+
+    def test_read_all_empty_when_missing(self, tmp_path):
+        """A missing log file yields no records."""
+        log = SubmissionLog(log_path=tmp_path / "missing.jsonl")
+        assert log.read_all() == []
+
+    def test_clear_removes_records(self, tmp_path):
+        """Clearing removes all recorded attempts."""
+        log = SubmissionLog(log_path=tmp_path / "subs.jsonl")
+        log.append(endpoint="https://x/telemetry", status_code=201)
+        log.clear()
+        assert log.read_all() == []
+
+    def test_records_are_json_lines(self, tmp_path):
+        """Each appended record is a single JSON line."""
+        log = SubmissionLog(log_path=tmp_path / "subs.jsonl")
+        log.append(endpoint="https://x/telemetry", status_code=201)
+        log.append(endpoint="https://x/telemetry", status_code=500)
+
+        lines = log.path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 2
+        for line in lines:
+            parsed = json.loads(line)
+            assert "endpoint" in parsed
+
+
+class TestPostJsonSubmissionLog:
+    """Tests that ``post_json`` records attempts in the submission log."""
+
+    def test_success_records_accepted(self, tmp_path):
+        """A 2xx response records an accepted submission."""
+
+        def _handler(request):
+            return httpx.Response(201, json={})
+
+        async def _run():
+            log = SubmissionLog(log_path=tmp_path / "subs.jsonl")
+            transport = httpx.MockTransport(_handler)
+            async with httpx.AsyncClient(transport=transport) as client:
+                ok = await post_json(
+                    client,
+                    "https://x/api/v1/agent/telemetry",
+                    {"device_id": "dev-1", "timestamp": "2026-01-01T00:00:00+00:00"},
+                    {"X-Device-ID": "dev-1"},
+                    submission_log=log,
+                )
+            records = log.read_all()
+            return ok, records
+
+        ok, records = asyncio.run(_run())
+        assert ok is True
+        assert len(records) == 1
+        assert records[0]["accepted"] is True
+        assert records[0]["status_code"] == 201
+        assert records[0]["payload_timestamp"] == "2026-01-01T00:00:00+00:00"
+
+    def test_failure_records_rejected(self, tmp_path):
+        """A failed request records a rejected submission."""
+        import httpx as _httpx
+
+        def _handler(request):
+            raise _httpx.ConnectError("connection refused")
+
+        async def _run():
+            log = SubmissionLog(log_path=tmp_path / "subs.jsonl")
+            transport = httpx.MockTransport(_handler)
+            async with httpx.AsyncClient(transport=transport) as client:
+                ok = await post_json(
+                    client,
+                    "https://x/api/v1/agent/telemetry",
+                    {"device_id": "dev-1"},
+                    {"X-Device-ID": "dev-1"},
+                    submission_log=log,
+                )
+            records = log.read_all()
+            return ok, records
+
+        ok, records = asyncio.run(_run())
+        assert ok is False
+        assert len(records) == 1
+        assert records[0]["accepted"] is False
+        assert records[0]["status_code"] is None

--- a/backend/utils/real_device_agent.py
+++ b/backend/utils/real_device_agent.py
@@ -61,6 +61,8 @@ async def register_device(client: httpx.AsyncClient) -> Optional[str]:
 async def collect_and_send_metrics(client: httpx.AsyncClient, api_key: str):
     """Collect system metrics and send to backend."""
     headers = {"X-Device-ID": DEVICE_ID, "X-API-Key": api_key}
+    # Reported on the next sample; the first sample reports None.
+    latency_ms = None
 
     while True:
         try:
@@ -69,35 +71,36 @@ async def collect_and_send_metrics(client: httpx.AsyncClient, api_key: str):
             memory = psutil.virtual_memory()
             disk = psutil.disk_usage("/")
             net_io = psutil.net_io_counters()
-
-            # Calculate network latency (simple ping to localhost or gateway)
-            # For simplicity, we'll simulate latency or use a placeholder
-            latency = 0.5  # Placeholder
+            uptime_seconds = max(0.0, time.time() - psutil.boot_time())
 
             metrics_payload = {
                 "device_id": DEVICE_ID,
                 "cpu_percent": cpu_percent,
                 "memory_percent": memory.percent,
                 "disk_percent": disk.percent,
-                "network_latency_ms": latency,
+                "network_latency_ms": latency_ms,
                 "transaction_count": 0,  # Not applicable for a generic server
                 "transaction_volume": 0.0,
                 "error_rate": 0.0,
                 "active_connections": len(psutil.net_connections()),
                 "collection_interval_seconds": COLLECTION_INTERVAL_SECONDS,
                 "extra_metrics": {
+                    "uptime_seconds": uptime_seconds,
                     "boot_time": psutil.boot_time(),
                     "bytes_sent": net_io.bytes_sent,
                     "bytes_recv": net_io.bytes_recv,
                 },
             }
 
-            # Send to Backend
+            # Send to Backend; the POST round-trip is the measured network
+            # latency reported on the following sample.
+            start = time.monotonic()
             response = await client.post(
                 f"{BASE_URL}/analytics/device-metrics",
                 json=metrics_payload,
                 headers=headers,
             )
+            latency_ms = (time.monotonic() - start) * 1000.0
 
             if response.status_code == 201:
                 logger.info(f"Sent metrics: CPU={cpu_percent}%, RAM={memory.percent}%")
@@ -166,7 +169,7 @@ async def poll_commands(client: httpx.AsyncClient, api_key: str):
 
 
 async def main():
-    """Main agent loop."""
+    """Run the real device agent loop."""
     print("\n" + "=" * 60)
     print(f"Real Device Agent for {DEVICE_ID}")
     print("To stop the agent, press Ctrl+C in this terminal.")


### PR DESCRIPTION
## Summary

Gives the real device agent genuine network latency, OS uptime, device sample timestamps, and an audit trail of submission attempts, so PF-02 (end-to-end telemetry latency), PF-04 (device uptime), and PF-01 (ingestion success) have real inputs instead of placeholders (roadmap Phase 1 P1).

## Changes

- **telemetry.py** — `collect_system_telemetry` now reports `uptime_seconds` (OS uptime via boot time); new `measure_network_latency_ms` returns the backend round-trip in ms (None on transport error); `build_telemetry_payload` carries `network_latency_ms` and `collection_interval_seconds` alongside the existing device sample `timestamp`.
- **submission_log.py** (new) — append-only JSONL log under the agent identity dir recording every backend submission attempt (endpoint, payload sample time, HTTP status, acceptance) for PF-01.
- **real_device_agent.py** — `telemetry_loop` measures latency, sends collection interval, and exposes a config-gated POS-signal seam; heartbeat/telemetry/retry loops record submissions in the submission log.
- **utils/real_device_agent.py** (legacy) — removes the fabricated `latency = 0.5` placeholder; reports measured POST round-trip latency and OS uptime.
- **agent-config.json** — adds `pos_signals_source` (null default) and `submission_log_path`.

Operational POS KPIs remain **excluded** until a data-source agreement and side-by-side source validation exist (roadmap PR 3 P1 note); the seam is inert by default and never fabricates data.

## Verification

- New known-value tests: uptime/latency/payload fields, POS-signal seam, submission log recording — 44 passed
- All agent suites: 304 passed
- Full suite: 975 passed (up from 955); the 16 failures (`test_live_api.py`, `test_performance.py`) are the pre-existing environment-dependent set
- `flake8`, `black --check`, `isort --check-only` clean on all changed files