### PR TITLE
feat: close configuration and command outcome tracking

### DIFF
--- a/backend/src/homepot/agent/utils/command_poller.py
+++ b/backend/src/homepot/agent/utils/command_poller.py
@@ -1,5 +1,6 @@
 """Command polling and processing for the real device agent."""
 
+from datetime import datetime, timezone
 import logging
 import re
 import shlex
@@ -293,7 +294,10 @@ def build_status_update_payload(
     command_id: str, status: str, result: Optional[Dict[str, Any]] = None
 ) -> Dict[str, Any]:
     """Build the JSON body for ``PUT /api/v1/devices/{command_id}/status``."""
-    payload: Dict[str, Any] = {"status": status}
+    payload: Dict[str, Any] = {
+        "status": status,
+        "executed_at": datetime.now(timezone.utc).isoformat(),
+    }
     if result is not None:
         payload["result"] = result
     return payload

--- a/backend/src/homepot/agents.py
+++ b/backend/src/homepot/agents.py
@@ -341,6 +341,11 @@ class DeviceAgentSimulator:
                     new_val = {"version": config_version, "url": config_url}
 
                 async with db_service.get_session() as session:
+                    device_row = await session.execute(
+                        select(Device).where(Device.device_id == self.device_id)
+                    )
+                    device_obj = device_row.scalar_one_or_none()
+                    provenance = derive_provenance(device_obj)
                     config_history = ConfigurationHistory(
                         timestamp=datetime.utcnow(),
                         entity_type="device",
@@ -351,6 +356,7 @@ class DeviceAgentSimulator:
                         changed_by="system",
                         change_reason="Push notification config update",
                         change_type="automated",
+                        provenance=provenance.value if provenance else None,
                         performance_before={
                             "status": health_result.get("status"),
                             "response_time_ms": health_result.get("response_time_ms"),

--- a/backend/src/homepot/app/api/API_v1/Endpoints/AgentConfigHistoryEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/AgentConfigHistoryEndpoint.py
@@ -15,7 +15,7 @@ from homepot.app.auth_utils import get_current_device
 from homepot.app.models.AnalyticsModel import ConfigurationHistory
 from homepot.app.schemas.agent import AgentConfigHistoryRequest
 from homepot.database import get_database_service
-from homepot.models import Device
+from homepot.models import Device, derive_provenance
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -39,6 +39,7 @@ async def report_config_history(
         )
     try:
         db_service = await get_database_service()
+        provenance = derive_provenance(current_device)
         async with db_service.get_session() as session:
             entry = ConfigurationHistory(
                 timestamp=payload.timestamp.astimezone(timezone.utc).replace(
@@ -53,6 +54,18 @@ async def report_config_history(
                 change_reason=payload.change_reason,
                 change_type="automated",
                 was_successful=payload.success,
+                performance_before=payload.performance_before,
+                performance_after=payload.performance_after,
+                was_rolled_back=payload.was_rolled_back,
+                rollback_reason=payload.rollback_reason,
+                rollback_success=payload.rollback_success,
+                rollback_performance=payload.rollback_performance,
+                rolled_back_at=(
+                    payload.rolled_back_at.astimezone(timezone.utc).replace(tzinfo=None)
+                    if payload.rolled_back_at is not None
+                    else None
+                ),
+                provenance=provenance.value if provenance is not None else None,
             )
             session.add(entry)
         return {"status": "success", "message": "Push history record stored"}

--- a/backend/src/homepot/app/api/API_v1/Endpoints/DeviceCommandsEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DeviceCommandsEndpoint.py
@@ -1,5 +1,6 @@
 """API endpoints for managing device commands."""
 
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -40,6 +41,7 @@ class CommandHistoryResponse(BaseModel):
     status: CommandStatus
     result: Optional[Dict[str, Any]] = None
     created_at: str
+    sent_at: Optional[str] = None
     executed_at: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
@@ -50,6 +52,7 @@ class UpdateCommandStatusRequest(BaseModel):
 
     status: CommandStatus
     result: Optional[Dict[str, Any]] = None
+    executed_at: Optional[datetime] = None
 
 
 class CommandResponse(BaseModel):
@@ -200,6 +203,17 @@ async def ack_command(
     if updated is None:
         raise HTTPException(status_code=404, detail="Command not found")
 
+    audit_logger = get_audit_logger()
+    await audit_logger.log_event(
+        AuditEventType.COMMAND_SENT,
+        f"Device '{device_id}' acknowledged command '{command_id}'",
+        device_id=current_device.id,  # type: ignore
+        new_values={
+            "command_id": command_id,
+            "sent_at": updated.sent_at.isoformat() if updated.sent_at else None,  # type: ignore
+        },
+    )
+
     return CommandResponse(
         command_id=updated.command_id,  # type: ignore
         command_type=updated.command_type,  # type: ignore
@@ -219,15 +233,44 @@ async def update_command_status(
     """Update the status of a command (e.g., COMPLETED, FAILED)."""
     db = await get_database_service()
 
+    executed_at = None
+    if request.executed_at is not None:
+        executed_at = request.executed_at.astimezone(timezone.utc).replace(tzinfo=None)
+
     updated_command = await db.update_command_status(
         command_id=command_id,
         status=request.status,
         result=request.result,
         device_id=cast(int, current_device.id),
+        executed_at=executed_at,
     )
 
     if not updated_command:
         raise HTTPException(status_code=404, detail="Command not found")
+
+    audit_logger = get_audit_logger()
+    if request.status == CommandStatus.COMPLETED:
+        event_type = AuditEventType.COMMAND_COMPLETED
+    elif request.status == CommandStatus.FAILED:
+        event_type = AuditEventType.COMMAND_FAILED
+    else:
+        event_type = None
+    if event_type is not None:
+        await audit_logger.log_event(
+            event_type,
+            f"Device '{current_device.device_id}' reported command '{command_id}' "
+            f"as {request.status.value}",
+            device_id=current_device.id,  # type: ignore
+            new_values={
+                "command_id": command_id,
+                "status": request.status.value,
+                "executed_at": (
+                    updated_command.executed_at.isoformat()
+                    if updated_command.executed_at  # type: ignore
+                    else None
+                ),
+            },
+        )
 
     return CommandResponse(
         command_id=updated_command.command_id,  # type: ignore
@@ -271,6 +314,7 @@ async def get_device_command_history(
             status=cmd.status,  # type: ignore
             result=cmd.result,  # type: ignore
             created_at=cmd.created_at.isoformat(),  # type: ignore
+            sent_at=cmd.sent_at.isoformat() if cmd.sent_at else None,  # type: ignore
             executed_at=cmd.executed_at.isoformat() if cmd.executed_at else None,  # type: ignore
         )
         for cmd in commands

--- a/backend/src/homepot/app/models/AnalyticsModel.py
+++ b/backend/src/homepot/app/models/AnalyticsModel.py
@@ -238,6 +238,13 @@ class ConfigurationHistory(Base):
     was_successful = Column(Boolean, nullable=True)
     was_rolled_back = Column(Boolean, default=False)
     rollback_reason = Column(Text, nullable=True)
+    rollback_performance = Column(JSON, nullable=True)  # Metrics after rollback
+    rollback_success = Column(Boolean, nullable=True)
+    rolled_back_at = Column(DateTime, nullable=True)
+
+    # Evidence provenance (snapshotted at write time so historical rows do
+    # not silently inherit a later change to the device's classification)
+    provenance = Column(String(20), nullable=True, index=True)
 
     __table_args__ = (
         Index("idx_entity_timestamp", "entity_type", "entity_id", "timestamp"),

--- a/backend/src/homepot/app/schemas/agent.py
+++ b/backend/src/homepot/app/schemas/agent.py
@@ -308,6 +308,30 @@ class AgentConfigHistoryRequest(BaseModel):
     timestamp: datetime = Field(
         default_factory=utc_now, description="Event timestamp in UTC"
     )
+    performance_before: Optional[dict] = Field(
+        default=None,
+        description="Device health/performance metrics captured before the change",
+    )
+    performance_after: Optional[dict] = Field(
+        default=None,
+        description="Device health/performance metrics captured after the change",
+    )
+    was_rolled_back: bool = Field(
+        default=False, description="Whether the change was subsequently rolled back"
+    )
+    rollback_reason: Optional[str] = Field(
+        default=None, description="Reason the change had to be rolled back"
+    )
+    rollback_success: Optional[bool] = Field(
+        default=None, description="Whether the rollback completed successfully"
+    )
+    rollback_performance: Optional[dict] = Field(
+        default=None,
+        description="Device health/performance metrics captured after rollback",
+    )
+    rolled_back_at: Optional[datetime] = Field(
+        default=None, description="When the rollback was applied (UTC)"
+    )
 
     model_config = ConfigDict(
         json_schema_extra={
@@ -317,6 +341,8 @@ class AgentConfigHistoryRequest(BaseModel):
                 "parameter_name": "push_command:APPLY_CONFIG",
                 "new_value": {"command": "APPLY_CONFIG", "version": "2.1.0"},
                 "success": True,
+                "performance_before": {"response_time_ms": 45},
+                "performance_after": {"response_time_ms": 40},
                 "change_reason": "Push command APPLY_CONFIG executed",
             }
         }

--- a/backend/src/homepot/audit.py
+++ b/backend/src/homepot/audit.py
@@ -52,6 +52,12 @@ class AuditEventType(str, Enum):
     JOB_FAILED = "job_failed"
     JOB_CANCELLED = "job_cancelled"
 
+    # Command lifecycle transitions
+    COMMAND_SENT = "command_sent"
+    COMMAND_COMPLETED = "command_completed"
+    COMMAND_FAILED = "command_failed"
+    COMMAND_EXPIRED = "command_expired"
+
     # Agent interactions
     AGENT_STARTED = "agent_started"
     AGENT_STOPPED = "agent_stopped"

--- a/backend/src/homepot/database.py
+++ b/backend/src/homepot/database.py
@@ -730,8 +730,15 @@ class DatabaseService:
         status: CommandStatus,
         result: Optional[Dict[str, Any]] = None,
         device_id: Optional[int] = None,
+        executed_at: Optional[datetime.datetime] = None,
     ) -> Optional[DeviceCommand]:
-        """Update command status."""
+        """Update command status, stamping lifecycle timestamps.
+
+        Moving a command to ``SENT`` records the agent acknowledgement time in
+        ``sent_at`` (once). Terminal statuses (COMPLETED/FAILED/EXPIRED) record
+        ``executed_at`` using the device-reported value when provided, otherwise
+        the server clock.
+        """
         from datetime import datetime, timezone
 
         from sqlalchemy import select
@@ -745,11 +752,16 @@ class DatabaseService:
             command = exec_result.scalar_one_or_none()
 
             if command:
+                now = datetime.now(timezone.utc)
+                if status == CommandStatus.SENT and command.sent_at is None:
+                    command.sent_at = now  # type: ignore
+                if status in (CommandStatus.COMPLETED, CommandStatus.FAILED):
+                    command.executed_at = executed_at or now  # type: ignore
+                if status == CommandStatus.EXPIRED and command.executed_at is None:
+                    command.executed_at = now  # type: ignore
                 command.status = status  # type: ignore
                 if result:
                     command.result = result  # type: ignore
-                if status in (CommandStatus.COMPLETED, CommandStatus.FAILED):
-                    command.executed_at = datetime.now(timezone.utc)  # type: ignore
 
                 await session.commit()
                 await session.refresh(command)
@@ -790,6 +802,10 @@ class DatabaseService:
             commands = list(result.scalars().all())
             for cmd in commands:
                 cmd.status = CommandStatus.EXPIRED  # type: ignore[assignment]
+                if cmd.executed_at is None:
+                    cmd.executed_at = datetime.datetime.now(  # type: ignore
+                        datetime.timezone.utc
+                    )
             await session.commit()
             return len(commands)
 

--- a/backend/src/homepot/migrations/versions/20260816_add_command_and_config_outcome_tracking.py
+++ b/backend/src/homepot/migrations/versions/20260816_add_command_and_config_outcome_tracking.py
@@ -1,0 +1,56 @@
+"""Track command delivery timestamps and configuration outcome metadata.
+
+Revision ID: 20260816_add_command_and_config_outcome_tracking
+Revises: 20260815_add_provenance_and_collection_metadata
+Create Date: 2026-08-16
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20260816_add_command_and_config_outcome_tracking"
+down_revision = "20260815_add_provenance_and_collection_metadata"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add command sent_at and configuration outcome/rollback columns.
+
+    ``device_commands.sent_at`` records when the agent acknowledged a queued
+    command, so round-trip latency can be computed as the gap between
+    ``sent_at`` and ``executed_at``. The new ``configuration_history`` columns
+    close the loop on whether a change succeeded, whether it had to be rolled
+    back, and how the device performed before/after/at-rollback, together with
+    the provenance of the reporting device.
+    """
+    op.add_column(
+        "device_commands",
+        sa.Column("sent_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "configuration_history",
+        sa.Column("rollback_performance", sa.JSON(), nullable=True),
+    )
+    op.add_column(
+        "configuration_history",
+        sa.Column("rollback_success", sa.Boolean(), nullable=True),
+    )
+    op.add_column(
+        "configuration_history",
+        sa.Column("rolled_back_at", sa.DateTime(), nullable=True),
+    )
+    op.add_column(
+        "configuration_history",
+        sa.Column("provenance", sa.String(length=20), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Rollback the command and configuration outcome tracking columns."""
+    op.drop_column("configuration_history", "provenance")
+    op.drop_column("configuration_history", "rolled_back_at")
+    op.drop_column("configuration_history", "rollback_success")
+    op.drop_column("configuration_history", "rollback_performance")
+    op.drop_column("device_commands", "sent_at")

--- a/backend/src/homepot/models.py
+++ b/backend/src/homepot/models.py
@@ -584,6 +584,7 @@ class DeviceCommand(Base):
     result = Column(JSON, nullable=True)
 
     created_at = Column(DateTime(timezone=True), default=utc_now)
+    sent_at = Column(DateTime(timezone=True), nullable=True)
     executed_at = Column(DateTime(timezone=True), nullable=True)
 
     # Relationships

--- a/backend/tests/test_agent_command_polling.py
+++ b/backend/tests/test_agent_command_polling.py
@@ -1,5 +1,6 @@
 """Tests for command polling and push wake-up utilities."""
 
+from datetime import datetime
 from unittest.mock import patch
 
 from homepot.agent.utils.command_poller import (
@@ -232,6 +233,8 @@ class TestBuildStatusUpdatePayload:
         """Payload with just command_id and status."""
         payload = build_status_update_payload("c1", "completed")
         assert payload["status"] == "completed"
+        assert "executed_at" in payload
+        datetime.fromisoformat(payload["executed_at"])  # must be parseable
 
     def test_payload_with_result(self):
         """Payload includes result dict when provided."""

--- a/backend/tests/test_config_outcome_tracking.py
+++ b/backend/tests/test_config_outcome_tracking.py
@@ -1,0 +1,214 @@
+"""Tests for configuration outcome and rollback tracking.
+
+Covers the agent-reported push-history endpoint persisting before/after
+performance, success, rollback outcome, and evidence provenance, so MW-03 to
+MW-05 evidence is reproducible.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+import os
+import secrets
+import tempfile
+
+from fastapi.testclient import TestClient
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from homepot.app.auth_utils import hash_password
+from homepot.app.models.AnalyticsModel import ConfigurationHistory
+from homepot.config import reload_settings
+import homepot.database
+from homepot.models import Base, Device, LifecycleState, Site, User
+
+CONFIG_HISTORY_URL = "/api/v1/agent/config-history"
+
+
+@pytest.fixture(autouse=True)
+def mock_db_url(monkeypatch):
+    """Use a temporary database for these tests to avoid file locking issues."""
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    db_url = f"sqlite:///{path}"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    monkeypatch.setenv("DATABASE__URL", db_url)
+
+    reload_settings()
+
+    if homepot.database._db_service is not None:
+        try:
+            asyncio.run(homepot.database._db_service.close())
+        except Exception:
+            pass
+        homepot.database._db_service = None
+
+    new_engine = create_engine(
+        db_url, connect_args={"check_same_thread": False}, pool_pre_ping=True
+    )
+    Base.metadata.create_all(bind=new_engine)
+    NewSessionLocal = sessionmaker(bind=new_engine, autocommit=False, autoflush=False)
+
+    monkeypatch.setattr(homepot.database, "sync_engine", new_engine)
+    monkeypatch.setattr(homepot.database, "SessionLocal", NewSessionLocal)
+
+    yield
+
+    new_engine.dispose()
+    if os.path.exists(path):
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def _create_device(device_id: str, config: dict) -> str:
+    """Create an admin, site, and device; return the device API key."""
+    db = homepot.database.SessionLocal()
+    try:
+        admin = User(
+            email=f"admin-{device_id}@test.local",
+            username=f"admin_{device_id}",
+            hashed_password=hash_password("pass"),
+            is_admin=True,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        db.add(admin)
+        db.commit()
+
+        site = Site(site_id=f"site-{device_id}", name=f"Site {device_id}")
+        db.add(site)
+        db.commit()
+
+        api_key = secrets.token_urlsafe(32)
+        device = Device(
+            device_id=device_id,
+            name=f"Device {device_id}",
+            device_type="pos_terminal",
+            site_id=site.id,
+            api_key_hash=hash_password(api_key),
+            is_active=True,
+            lifecycle_state=LifecycleState.ACTIVE.value,
+            config=config,
+        )
+        db.add(device)
+        db.commit()
+        return api_key
+    finally:
+        db.close()
+
+
+def _device_headers(device_id: str, api_key: str) -> dict:
+    return {"X-Device-ID": device_id, "X-API-Key": api_key}
+
+
+def _latest_history(session) -> ConfigurationHistory:
+    result = session.execute(
+        select(ConfigurationHistory).order_by(ConfigurationHistory.id.desc()).limit(1)
+    )
+    return result.scalar_one()
+
+
+def test_config_history_persists_outcome_and_rollback(client: TestClient) -> None:
+    """A full report stores before/after performance, success and rollback."""
+    api_key = _create_device("real-pos-outcome", {"device_source": "physical"})
+    headers = _device_headers("real-pos-outcome", api_key)
+
+    rolled_back_at = datetime.now(timezone.utc)
+    resp = client.post(
+        CONFIG_HISTORY_URL,
+        json={
+            "device_id": "real-pos-outcome",
+            "action": "update_pos_payment_config",
+            "parameter_name": "push_command:APPLY_CONFIG",
+            "old_value": {"version": "2.0.0"},
+            "new_value": {"version": "2.1.0"},
+            "success": False,
+            "performance_before": {"status": "healthy", "response_time_ms": 48},
+            "performance_after": {"status": "degraded", "response_time_ms": 210},
+            "was_rolled_back": True,
+            "rollback_reason": "Performance regression after change",
+            "rollback_success": True,
+            "rollback_performance": {"status": "healthy", "response_time_ms": 47},
+            "rolled_back_at": rolled_back_at.isoformat(),
+            "change_reason": "Push command APPLY_CONFIG executed",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    db = homepot.database.SessionLocal()
+    try:
+        entry = _latest_history(db)
+        assert entry.entity_id == "real-pos-outcome"
+        assert entry.parameter_name == "push_command:APPLY_CONFIG"
+        assert entry.was_successful is False
+        assert entry.performance_before == {
+            "status": "healthy",
+            "response_time_ms": 48,
+        }
+        assert entry.performance_after == {
+            "status": "degraded",
+            "response_time_ms": 210,
+        }
+        assert entry.was_rolled_back is True
+        assert entry.rollback_reason == "Performance regression after change"
+        assert entry.rollback_success is True
+        assert entry.rollback_performance == {
+            "status": "healthy",
+            "response_time_ms": 47,
+        }
+        assert entry.rolled_back_at is not None
+        assert entry.provenance == "real"
+    finally:
+        db.close()
+
+
+def test_config_history_derives_simulated_provenance(client: TestClient) -> None:
+    """Simulated devices are labelled simulated in the persisted row."""
+    api_key = _create_device("sim-pos-outcome", {"device_source": "simulation"})
+    headers = _device_headers("sim-pos-outcome", api_key)
+
+    resp = client.post(
+        CONFIG_HISTORY_URL,
+        json={
+            "device_id": "sim-pos-outcome",
+            "action": "update_pos_payment_config",
+            "parameter_name": "push_command:APPLY_CONFIG",
+            "new_value": {"version": "9.9.9"},
+            "success": True,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    db = homepot.database.SessionLocal()
+    try:
+        entry = _latest_history(db)
+        assert entry.entity_id == "sim-pos-outcome"
+        assert entry.provenance == "simulated"
+        assert entry.was_successful is True
+        assert entry.was_rolled_back is False
+    finally:
+        db.close()
+
+
+def test_config_history_rejects_mismatched_device(client: TestClient) -> None:
+    """A device cannot report history for a different device_id."""
+    api_key = _create_device("real-pos-match", {"device_source": "physical"})
+    headers = _device_headers("real-pos-match", api_key)
+
+    resp = client.post(
+        CONFIG_HISTORY_URL,
+        json={
+            "device_id": "some-other-device",
+            "action": "update_pos_payment_config",
+            "parameter_name": "push_command:APPLY_CONFIG",
+            "new_value": {"version": "1.0.0"},
+            "success": True,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 403

--- a/backend/tests/test_device_commands.py
+++ b/backend/tests/test_device_commands.py
@@ -249,6 +249,7 @@ def _setup_site_and_device(client: TestClient) -> Dict[str, Any]:
     return {
         "site_id": site_id,
         "device_id": device_id,
+        "api_key": api_key,
         "auth_headers": auth_headers,
     }
 
@@ -543,3 +544,126 @@ def test_agent_detail_includes_modern_state_fields(client: TestClient) -> None:
     )
     assert data["connectivity_state"] in ("unknown", "online", "offline")
     assert data["device_id"] == device_id
+
+
+def _device_headers(ctx: Dict[str, Any]) -> Dict[str, str]:
+    """Build the device auth headers for a setup context."""
+    return {
+        "X-Device-ID": ctx["device_id"],
+        "X-API-Key": ctx["api_key"],
+    }
+
+
+def _history_for(client: TestClient, ctx: Dict[str, Any]) -> list:
+    """Return the command history list for the setup device."""
+    resp = client.get(
+        f"/api/v1/devices/device/{ctx['device_id']}/commands",
+        headers=ctx["auth_headers"],
+    )
+    assert resp.status_code == 200
+    return resp.json()
+
+
+def test_command_lifecycle_timestamps(client: TestClient) -> None:
+    """PENDING → SENT → COMPLETED records sent_at and executed_at."""
+    ctx = _setup_site_and_device(client)
+    device_id = ctx["device_id"]
+    dheaders = _device_headers(ctx)
+
+    cmd_id = _queue_command(client, device_id, ctx["auth_headers"], "ping")
+
+    history = _history_for(client, ctx)
+    row = next(c for c in history if c["command_id"] == cmd_id)
+    assert row["sent_at"] is None
+    assert row["executed_at"] is None
+
+    # Ack the command → SENT, sent_at stamped
+    resp = client.post(
+        f"/api/v1/devices/{device_id}/commands/{cmd_id}/ack", headers=dheaders
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "sent"
+
+    history = _history_for(client, ctx)
+    row = next(c for c in history if c["command_id"] == cmd_id)
+    assert row["sent_at"] is not None
+    assert row["executed_at"] is None
+
+    # Report COMPLETED with a device-reported executed_at
+    executed_at = datetime.now(timezone.utc).isoformat()
+    resp = client.put(
+        f"/api/v1/devices/{cmd_id}/status",
+        json={
+            "status": "completed",
+            "result": {"message": "pong"},
+            "executed_at": executed_at,
+        },
+        headers=dheaders,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "completed"
+
+    history = _history_for(client, ctx)
+    row = next(c for c in history if c["command_id"] == cmd_id)
+    assert row["sent_at"] is not None
+    stored = datetime.fromisoformat(row["executed_at"])
+    expected = (
+        datetime.fromisoformat(executed_at)
+        .astimezone(timezone.utc)
+        .replace(tzinfo=None)
+    )
+    assert abs((stored - expected).total_seconds()) < 5
+
+
+def test_command_status_defaults_executed_at_to_server_time(client: TestClient) -> None:
+    """PUT /status without executed_at records the server clock."""
+    ctx = _setup_site_and_device(client)
+    device_id = ctx["device_id"]
+    dheaders = _device_headers(ctx)
+
+    cmd_id = _queue_command(client, device_id, ctx["auth_headers"], "ping")
+
+    resp = client.put(
+        f"/api/v1/devices/{cmd_id}/status",
+        json={"status": "failed", "result": {"error": "boom"}},
+        headers=dheaders,
+    )
+    assert resp.status_code == 200
+
+    history = _history_for(client, ctx)
+    row = next(c for c in history if c["command_id"] == cmd_id)
+    assert row["status"] == "failed"
+    assert row["executed_at"] is not None
+
+
+def test_command_expiry_records_executed_at(client: TestClient) -> None:
+    """Expired commands are stamped with executed_at."""
+    ctx = _setup_site_and_device(client)
+    device_id = ctx["device_id"]
+
+    cmd_id = _queue_command(client, device_id, ctx["auth_headers"], "ping")
+
+    db = homepot.database.SessionLocal()
+    try:
+        cmd = db.query(DeviceCommand).filter(DeviceCommand.command_id == cmd_id).first()
+        assert cmd is not None
+        cmd.created_at = datetime.now(timezone.utc) - timedelta(hours=1)
+        db.commit()
+    finally:
+        db.close()
+
+    async def _expire():
+        svc = await homepot.database.get_database_service()
+        return await svc.expire_stale_commands(ttl_seconds=60)
+
+    expired_count = asyncio.run(_expire())
+    assert expired_count >= 1
+
+    db = homepot.database.SessionLocal()
+    try:
+        cmd = db.query(DeviceCommand).filter(DeviceCommand.command_id == cmd_id).first()
+        assert cmd is not None
+        assert cmd.status == CommandStatus.EXPIRED
+        assert cmd.executed_at is not None
+    finally:
+        db.close()


### PR DESCRIPTION
Closes the roadmap Phase 1 P1 work packages MW-01 to MW-05 from `docs/KPI-evaluation-roadmap.md` Section 5.3, so command round-trip timing and configuration-change outcomes are fully captured for KPI export.

## What changed

**Command delivery & outcome timestamps (MW-01/MW-02)**
- New `device_commands.sent_at` column (migration `20260816_add_command_and_config_outcome_tracking`).
- `update_command_status` records `sent_at` when a command moves PENDING→SENT (ack) and stamps `executed_at` on terminal statuses, honouring the device-reported `executed_at` when provided (defaults to server clock).
- Expired commands now get an `executed_at` too.
- Agent status payload (`build_status_update_payload`) now includes `executed_at` (ISO-8601 UTC), and `PUT /api/v1/devices/{command_id}/status` accepts an optional `executed_at`.
- `GET /devices/device/{device_id}/commands` history exposes `sent_at`.
- New audit event types: `command_sent`, `command_completed`, `command_failed`.

**Configuration outcome & rollback capture (MW-03/MW-04/MW-05)**
- `configuration_history` gains `rollback_performance`, `rollback_success`, `rolled_back_at`, and evidence `provenance` columns.
- `POST /api/v1/agent/config-history` persists `performance_before`/`performance_after`, `success`, and the rollback outcome fields, and snapshots the device's provenance classification.
- The in-process simulator agent now snapshots provenance on its configuration-history writes.

## Verification
- `pytest`: 981 passed, 16 failed — the 16 are the pre-existing environment-dependent failures in `test_live_api.py` (live server) and `test_performance.py` (timing), identical on `main`.
- New tests: `test_config_outcome_tracking.py` (outcome/rollback persistence, provenance derivation, mismatched-device rejection) and command-timestamp lifecycle tests in `test_device_commands.py`.
- `flake8`, `black --check`, `isort --check-only`, `alembic heads` all clean; new migration is the head.