### PR TITLE
test: add KPI data-quality and scenario integration coverage

### DIFF
--- a/backend/tests/test_kpi_data_quality.py
+++ b/backend/tests/test_kpi_data_quality.py
@@ -1,0 +1,446 @@
+"""KPI data-quality edge cases and degenerate sample protection.
+
+Protects the KPI formulas against degenerate inputs: all-failed command
+windows, in-flight (non-terminal) commands, missing outcome flags, missing
+performance evidence, unresolved rollbacks, missing provenance, and null
+latency samples. Also guards export reproducibility by pinning the manifest
+``git_commit`` to the repository HEAD.
+"""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+import os
+import secrets
+import tempfile
+
+from fastapi.testclient import TestClient
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from homepot.app.auth_utils import create_access_token, hash_password
+from homepot.app.models.AnalyticsModel import (
+    ConfigurationHistory,
+    DeviceMetrics,
+    DeviceStateHistory,
+)
+from homepot.config import reload_settings
+import homepot.database
+from homepot.kpi.manifest import get_git_commit
+from homepot.models import (
+    Base,
+    CommandStatus,
+    Device,
+    DeviceCommand,
+    LifecycleState,
+    Site,
+    User,
+)
+
+EXPORT_URL = "/api/v1/kpi/export"
+ADMIN_EMAIL = "admin.quality@test.local"
+
+
+@pytest.fixture(autouse=True)
+def mock_db_url(monkeypatch):
+    """Use a temporary database for these tests."""
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    db_url = f"sqlite:///{path}"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    monkeypatch.setenv("DATABASE__URL", db_url)
+
+    reload_settings()
+
+    if homepot.database._db_service is not None:
+        try:
+            asyncio.run(homepot.database._db_service.close())
+        except Exception:
+            pass
+        homepot.database._db_service = None
+
+    new_engine = create_engine(
+        db_url, connect_args={"check_same_thread": False}, pool_pre_ping=True
+    )
+    Base.metadata.create_all(bind=new_engine)
+    NewSessionLocal = sessionmaker(bind=new_engine, autocommit=False, autoflush=False)
+
+    monkeypatch.setattr(homepot.database, "sync_engine", new_engine)
+    monkeypatch.setattr(homepot.database, "SessionLocal", NewSessionLocal)
+
+    yield
+
+    new_engine.dispose()
+    if os.path.exists(path):
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def _seed_admin() -> None:
+    db = homepot.database.SessionLocal()
+    try:
+        if not db.query(User).filter(User.email == ADMIN_EMAIL).first():
+            db.add(
+                User(
+                    email=ADMIN_EMAIL,
+                    username="admin_quality",
+                    hashed_password=hash_password("pass"),
+                    is_admin=True,
+                    created_at=datetime.now(timezone.utc),
+                    updated_at=datetime.now(timezone.utc),
+                )
+            )
+            db.commit()
+    finally:
+        db.close()
+
+
+def _seed_device(
+    device_id: str,
+    site_id: str = "site-quality-1",
+    device_type: str = "pos_terminal",
+    config: dict | None = None,
+) -> None:
+    db = homepot.database.SessionLocal()
+    try:
+        site = db.query(Site).filter(Site.site_id == site_id).first()
+        if not site:
+            site = Site(site_id=site_id, name=f"Site {site_id}")
+            db.add(site)
+            db.commit()
+        device = db.query(Device).filter(Device.device_id == device_id).first()
+        if not device:
+            db.add(
+                Device(
+                    device_id=device_id,
+                    name=f"Device {device_id}",
+                    device_type=device_type,
+                    site_id=site.id,
+                    api_key_hash=hash_password(secrets.token_urlsafe(32)),
+                    is_active=True,
+                    lifecycle_state=LifecycleState.ACTIVE.value,
+                    config=config or {},
+                )
+            )
+            db.commit()
+    finally:
+        db.close()
+
+
+def _seed_command(
+    device_id: str,
+    command_type: str = "ping",
+    status: CommandStatus = CommandStatus.COMPLETED,
+    created_at: datetime | None = None,
+    executed_at: datetime | None = None,
+) -> None:
+    db = homepot.database.SessionLocal()
+    try:
+        device = db.query(Device).filter(Device.device_id == device_id).first()
+        db.add(
+            DeviceCommand(
+                command_id=f"cmd-{secrets.token_hex(4)}",
+                device_id=device.id,
+                command_type=command_type,
+                status=status,
+                created_at=created_at or datetime.now(timezone.utc),
+                executed_at=executed_at,
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
+def _seed_config(
+    device_id: str,
+    was_successful: bool | None = True,
+    before: dict | None = None,
+    after: dict | None = None,
+    rolled_back: bool = False,
+    rollback_success: bool | None = None,
+    rollback_performance: dict | None = None,
+    provenance: str | None = "real",
+    timestamp: datetime | None = None,
+) -> None:
+    db = homepot.database.SessionLocal()
+    try:
+        db.add(
+            ConfigurationHistory(
+                timestamp=timestamp or datetime.now(timezone.utc),
+                entity_type="device",
+                entity_id=device_id,
+                parameter_name="push_command:APPLY_CONFIG",
+                new_value={"version": "2.0.0"},
+                changed_by="agent",
+                change_reason="test",
+                change_type="automated",
+                was_successful=was_successful,
+                performance_before=before,
+                performance_after=after,
+                was_rolled_back=rolled_back,
+                rollback_success=rollback_success,
+                rollback_performance=rollback_performance,
+                provenance=provenance,
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
+def _seed_metric(
+    device_id: str,
+    latency_ms: float | None,
+    provenance: str | None = "real",
+    timestamp: datetime | None = None,
+) -> None:
+    db = homepot.database.SessionLocal()
+    try:
+        device = db.query(Device).filter(Device.device_id == device_id).first()
+        db.add(
+            DeviceMetrics(
+                timestamp=timestamp or datetime.now(timezone.utc),
+                device_id=device.id,
+                network_latency_ms=latency_ms,
+                provenance=provenance,
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
+def _seed_state(
+    device_id: str,
+    provenance: str | None = "real",
+    new_state: str = "online",
+    timestamp: datetime | None = None,
+) -> None:
+    db = homepot.database.SessionLocal()
+    try:
+        device = db.query(Device).filter(Device.device_id == device_id).first()
+        db.add(
+            DeviceStateHistory(
+                timestamp=timestamp or datetime.now(timezone.utc),
+                device_id=device.id,
+                new_state=new_state,
+                provenance=provenance,
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
+def _auth_headers() -> dict:
+    _seed_admin()
+    token = create_access_token({"sub": ADMIN_EMAIL})
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _export(client: TestClient, **params) -> dict:
+    params.setdefault("start", "2026-01-01T00:00:00Z")
+    params.setdefault("end", "2026-12-31T23:59:59Z")
+    resp = client.get(EXPORT_URL, params=params, headers=_auth_headers())
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _result(bundle: dict, kpi_id: str, provenance: str = "all", **group) -> dict:
+    for kpi in bundle["kpis"]:
+        if kpi["kpi_id"] != kpi_id or kpi["provenance"] != provenance:
+            continue
+        if group and kpi.get("group") != group:
+            continue
+        return kpi
+    raise AssertionError(
+        f"No KPI {kpi_id} for provenance {provenance} group {group} in {bundle['kpis']}"
+    )
+
+
+def test_mw01_all_failed_commands_zero_completion(client: TestClient) -> None:
+    """Every terminal command failing still yields a valid 0% completion rate."""
+    _seed_device("quality-pos-001")
+    for _ in range(3):
+        _seed_command("quality-pos-001", status=CommandStatus.FAILED)
+
+    kpi = _result(_export(client), "MW-01")
+    assert kpi["value"] == 0.0
+    assert kpi["numerator"] == 0
+    assert kpi["denominator"] == 3
+    assert kpi["exclusions"] == 0
+
+
+def test_mw01_in_flight_commands_yield_null_value(client: TestClient) -> None:
+    """Commands still in flight (non-terminal) are excluded, not counted."""
+    _seed_device("quality-pos-002")
+    _seed_command("quality-pos-002", status=CommandStatus.PENDING)
+    _seed_command("quality-pos-002", status=CommandStatus.SENT)
+
+    kpi = _result(_export(client), "MW-01")
+    assert kpi["value"] is None
+    assert kpi["denominator"] == 0
+    assert kpi["exclusions"] == 2
+
+
+def test_mw02_two_sample_round_trip_percentiles(client: TestClient) -> None:
+    """Round-trip p50/p95/max interpolate correctly on a two-sample window."""
+    _seed_device("quality-pos-003")
+    now = datetime.now(timezone.utc)
+    _seed_command(
+        "quality-pos-003",
+        created_at=now,
+        executed_at=now + timedelta(seconds=1),
+    )
+    _seed_command(
+        "quality-pos-003",
+        created_at=now,
+        executed_at=now + timedelta(seconds=3),
+    )
+
+    bundle = _export(client)
+    group = {"command_type": "ping", "statistic": "p50"}
+    assert _result(bundle, "MW-02", **group)["value"] == 2.0
+    group["statistic"] = "p95"
+    assert _result(bundle, "MW-02", **group)["value"] == 2.9
+    group["statistic"] = "max"
+    assert _result(bundle, "MW-02", **group)["value"] == 3.0
+
+
+def test_mw02_single_sample_all_stats_equal(client: TestClient) -> None:
+    """A single observed round-trip makes p50, p95 and max identical."""
+    _seed_device("quality-pos-004")
+    now = datetime.now(timezone.utc)
+    _seed_command(
+        "quality-pos-004",
+        created_at=now,
+        executed_at=now + timedelta(seconds=2.5),
+    )
+
+    bundle = _export(client)
+    for stat in ("p50", "p95", "max"):
+        kpi = _result(bundle, "MW-02", **{"command_type": "ping", "statistic": stat})
+        assert kpi["value"] == 2.5
+        assert kpi["numerator"] == 1
+        assert kpi["denominator"] == 1
+
+
+def test_mw03_missing_outcome_yields_null_value(client: TestClient) -> None:
+    """Configuration changes without an outcome flag are excluded, not counted."""
+    _seed_device("quality-pos-005")
+    _seed_config("quality-pos-005", was_successful=None)
+    _seed_config("quality-pos-005", was_successful=None)
+
+    kpi = _result(_export(client), "MW-03")
+    assert kpi["value"] is None
+    assert kpi["denominator"] == 0
+    assert kpi["exclusions"] == 2
+
+
+def test_mw04_success_without_evidence_not_verified(client: TestClient) -> None:
+    """Successful changes without before/after windows cannot be verified."""
+    _seed_device("quality-pos-006")
+    _seed_config("quality-pos-006", was_successful=True, before=None, after=None)
+
+    kpi = _result(_export(client), "MW-04")
+    assert kpi["value"] is None
+    assert kpi["denominator"] == 0
+    assert kpi["exclusions"] == 1
+
+
+def test_mw05_mixed_rollback_outcomes_restored(client: TestClient) -> None:
+    """Rollbacks restoring the health target count regardless of flag source."""
+    _seed_device("quality-pos-007")
+    _seed_config(
+        "quality-pos-007",
+        rolled_back=True,
+        rollback_success=True,
+        before={"status": "degraded"},
+        after={"status": "online"},
+    )
+    _seed_config(
+        "quality-pos-007",
+        rolled_back=True,
+        rollback_success=None,
+        rollback_performance={"status": "healthy"},
+        before={"status": "degraded"},
+        after={"status": "degraded"},
+    )
+
+    kpi = _result(_export(client), "MW-05")
+    assert kpi["value"] == 100.0
+    assert kpi["numerator"] == 2
+    assert kpi["denominator"] == 2
+
+
+def test_mw05_failed_rollback_excluded(client: TestClient) -> None:
+    """A rollback explicitly reported as failed counts as not restored."""
+    _seed_device("quality-pos-008")
+    _seed_config(
+        "quality-pos-008",
+        rolled_back=True,
+        rollback_success=False,
+        before={"status": "degraded"},
+        after={"status": "degraded"},
+    )
+
+    kpi = _result(_export(client), "MW-05")
+    assert kpi["value"] == 0.0
+    assert kpi["numerator"] == 0
+    assert kpi["denominator"] == 1
+
+
+def test_eq01_missing_provenance_zero_coverage(client: TestClient) -> None:
+    """Rows with no provenance class yield 0% coverage on every table."""
+    _seed_device("quality-pos-009")
+    _seed_metric("quality-pos-009", 100.0, provenance=None)
+    _seed_state("quality-pos-009", provenance=None)
+    _seed_config("quality-pos-009", provenance=None)
+
+    bundle = _export(client)
+    for table in ("device_metrics", "device_state_history", "configuration_history"):
+        kpi = _result(bundle, "EQ-01", **{"table": table})
+        assert kpi["value"] == 0.0
+        assert kpi["numerator"] == 0
+        assert kpi["denominator"] == 1
+
+
+def test_eq01_valid_provenance_full_coverage(client: TestClient) -> None:
+    """Every row carrying a provenance class yields 100% coverage per table."""
+    _seed_device("quality-pos-010")
+    _seed_metric("quality-pos-010", 100.0, provenance="real")
+    _seed_state("quality-pos-010", provenance="real")
+    _seed_config("quality-pos-010", provenance="real")
+
+    bundle = _export(client)
+    for table in ("device_metrics", "device_state_history", "configuration_history"):
+        kpi = _result(bundle, "EQ-01", **{"table": table})
+        assert kpi["value"] == 100.0
+        assert kpi["numerator"] == 1
+        assert kpi["denominator"] == 1
+
+
+def test_pf_lat_null_latency_rows_ignored(client: TestClient) -> None:
+    """Rows without network_latency_ms are excluded from every PF-LAT stat."""
+    _seed_device("quality-pos-011")
+    _seed_metric("quality-pos-011", 100.0, provenance="real")
+    _seed_metric("quality-pos-011", 200.0, provenance="real")
+    _seed_metric("quality-pos-011", None, provenance="real")
+
+    bundle = _export(client)
+    for stat, expected in (("p50", 150.0), ("p95", 195.0), ("max", 200.0)):
+        kpi = _result(bundle, "PF-LAT", **{"statistic": stat})
+        assert kpi["value"] == expected
+        assert kpi["numerator"] == 2
+        assert kpi["denominator"] == 2
+
+
+def test_manifest_git_commit_tracks_repo_head(client: TestClient) -> None:
+    """Exported manifests pin the exact repository commit for reproducibility."""
+    bundle = _export(client)
+    assert bundle["manifest"]["git_commit"] == get_git_commit()
+    assert bundle["manifest"]["git_commit"] not in (None, "unknown", "")

--- a/backend/tests/test_kpi_scenario_integration.py
+++ b/backend/tests/test_kpi_scenario_integration.py
@@ -1,0 +1,409 @@
+"""End-to-end KPI evidence-flow scenario coverage.
+
+Exercises the full write pipeline (device telemetry, state changes, command
+queuing/ack/status, agent config-history) through the public API and then
+verifies the KPI export reflects the produced evidence: MW-01/02 completion
+and round-trip, MW-03/04/05 config outcomes, PF-LAT latency percentiles and
+EQ-01 provenance coverage. Also verifies provenance classes stay separated
+across the API boundary.
+"""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+import os
+import secrets
+import tempfile
+
+from fastapi.testclient import TestClient
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from homepot.app.auth_utils import create_access_token, hash_password
+from homepot.config import reload_settings
+import homepot.database
+from homepot.models import (
+    Base,
+    Device,
+    LifecycleState,
+    Site,
+    User,
+)
+
+EXPORT_URL = "/api/v1/kpi/export"
+ADMIN_EMAIL = "admin.scenario@test.local"
+WIDE_START = "2020-01-01T00:00:00Z"
+WIDE_END = "2099-12-31T23:59:59Z"
+
+
+@pytest.fixture(autouse=True)
+def mock_db_url(monkeypatch):
+    """Use a temporary database for these tests.
+
+    The app's async ``DatabaseService`` is created here on the test event
+    loop (not inside the TestClient lifespan portal), which avoids a SQLite
+    write-lock race between the sync engine and the portal's async engine.
+    """
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    db_url = f"sqlite:///{path}"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    monkeypatch.setenv("DATABASE__URL", db_url)
+
+    reload_settings()
+
+    if homepot.database._db_service is not None:
+        try:
+            asyncio.run(homepot.database._db_service.close())
+        except Exception:
+            pass
+        homepot.database._db_service = None
+
+    new_engine = create_engine(
+        db_url, connect_args={"check_same_thread": False}, pool_pre_ping=True
+    )
+    Base.metadata.create_all(bind=new_engine)
+    NewSessionLocal = sessionmaker(bind=new_engine, autocommit=False, autoflush=False)
+
+    monkeypatch.setattr(homepot.database, "sync_engine", new_engine)
+    monkeypatch.setattr(homepot.database, "SessionLocal", NewSessionLocal)
+
+    asyncio.run(homepot.database.get_database_service())
+
+    yield
+
+    asyncio.run(homepot.database.close_database_service())
+    new_engine.dispose()
+    for suffix in ("", "-wal", "-shm"):
+        if os.path.exists(path + suffix):
+            try:
+                os.unlink(path + suffix)
+            except OSError:
+                pass
+
+
+@pytest.fixture
+def client():
+    """Create a TestClient without the app lifespan (the async DB init race).
+
+    The async database service is pre-created by ``mock_db_url`` above, so
+    running the startup lifespan here would only recreate it inside the
+    TestClient portal and re-trigger the lock race.
+    """
+    from homepot.main import app
+
+    return TestClient(app)
+
+
+def _seed_admin() -> None:
+    db = homepot.database.SessionLocal()
+    try:
+        if not db.query(User).filter(User.email == ADMIN_EMAIL).first():
+            db.add(
+                User(
+                    email=ADMIN_EMAIL,
+                    username="admin_scenario",
+                    hashed_password=hash_password("pass"),
+                    is_admin=True,
+                    created_at=datetime.now(timezone.utc),
+                    updated_at=datetime.now(timezone.utc),
+                )
+            )
+            db.commit()
+    finally:
+        db.close()
+
+
+def _seed_site_device(device_id: str, site_id: str, device_source: str) -> str:
+    """Create a site + device and return the device's plaintext API key."""
+    db = homepot.database.SessionLocal()
+    try:
+        site = db.query(Site).filter(Site.site_id == site_id).first()
+        if not site:
+            site = Site(site_id=site_id, name=f"Site {site_id}")
+            db.add(site)
+            db.commit()
+        api_key = secrets.token_urlsafe(32)
+        device = db.query(Device).filter(Device.device_id == device_id).first()
+        if not device:
+            db.add(
+                Device(
+                    device_id=device_id,
+                    name=f"Device {device_id}",
+                    device_type="pos_terminal",
+                    site_id=site.id,
+                    api_key_hash=hash_password(api_key),
+                    is_active=True,
+                    lifecycle_state=LifecycleState.ACTIVE.value,
+                    config={"device_source": device_source},
+                )
+            )
+            db.commit()
+        return api_key
+    finally:
+        db.close()
+
+
+def _device_headers(device_id: str, api_key: str) -> dict:
+    return {"X-Device-ID": device_id, "X-API-Key": api_key}
+
+
+def _user_headers() -> dict:
+    _seed_admin()
+    token = create_access_token({"sub": ADMIN_EMAIL})
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _result(bundle: dict, kpi_id: str, provenance: str = "all", **group) -> dict:
+    for kpi in bundle["kpis"]:
+        if kpi["kpi_id"] != kpi_id or kpi["provenance"] != provenance:
+            continue
+        if group and kpi.get("group") != group:
+            continue
+        return kpi
+    raise AssertionError(
+        f"No KPI {kpi_id} for provenance {provenance} group {group} in {bundle['kpis']}"
+    )
+
+
+def test_end_to_end_evidence_flow_yields_kpis(client: TestClient) -> None:
+    """Telemetry, commands and config events through the API drive every KPI."""
+    api_key = _seed_site_device("e2e-pos-001", "site-e2e-1", "physical")
+    device_headers = _device_headers("e2e-pos-001", api_key)
+    user_headers = _user_headers()
+
+    # 1. Device telemetry: two distinct latency samples.
+    for latency in (100.0, 200.0):
+        resp = client.post(
+            "/api/v1/analytics/device-metrics",
+            json={
+                "device_id": "e2e-pos-001",
+                "network_latency_ms": latency,
+                "cpu_percent": 20.0,
+                "collection_interval_seconds": 5,
+            },
+            headers=device_headers,
+        )
+        assert resp.status_code == 201, resp.text
+
+    # 2. A state transition.
+    resp = client.post(
+        "/api/v1/analytics/device-state-change",
+        json={
+            "device_id": "e2e-pos-001",
+            "previous_state": "provisioning",
+            "new_state": "online",
+            "reason": "agent online",
+        },
+        headers=user_headers,
+    )
+    assert resp.status_code == 201, resp.text
+
+    # 3. Queue, ack and complete a ping command with a known executed_at.
+    resp = client.post(
+        "/api/v1/devices/e2e-pos-001/commands",
+        json={"command_type": "ping", "payload": {}},
+        headers=user_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    command_id = resp.json()["command_id"]
+
+    resp = client.post(
+        f"/api/v1/devices/e2e-pos-001/commands/{command_id}/ack",
+        headers=device_headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    executed_at = (datetime.now(timezone.utc) + timedelta(seconds=5)).isoformat()
+    resp = client.put(
+        f"/api/v1/devices/{command_id}/status",
+        json={"status": "completed", "executed_at": executed_at},
+        headers=device_headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    # 4. Config-history: one successful verified change and one rollback.
+    resp = client.post(
+        "/api/v1/agent/config-history",
+        json={
+            "device_id": "e2e-pos-001",
+            "action": "update_config",
+            "parameter_name": "push_command:APPLY_CONFIG",
+            "new_value": {"version": "2.0.0"},
+            "success": True,
+            "change_reason": "apply config",
+            "performance_before": {"status": "degraded", "response_time_ms": 90},
+            "performance_after": {"status": "healthy", "response_time_ms": 40},
+            "was_rolled_back": False,
+        },
+        headers=device_headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = client.post(
+        "/api/v1/agent/config-history",
+        json={
+            "device_id": "e2e-pos-001",
+            "action": "update_config",
+            "parameter_name": "push_command:APPLY_CONFIG",
+            "new_value": {"version": "2.1.0"},
+            "success": True,
+            "change_reason": "apply config then rollback",
+            "performance_before": {"status": "degraded", "response_time_ms": 90},
+            "performance_after": {"status": "online", "response_time_ms": 35},
+            "was_rolled_back": True,
+            "rollback_reason": "unstable",
+            "rollback_success": True,
+            "rollback_performance": {"status": "healthy", "response_time_ms": 38},
+        },
+        headers=device_headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    # 5. Export and assert the whole evidence chain.
+    resp = client.get(
+        EXPORT_URL,
+        params={"start": WIDE_START, "end": WIDE_END},
+        headers=user_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    bundle = resp.json()
+
+    # MW-01: one completed ping out of one terminal command.
+    kpi = _result(bundle, "MW-01", "real")
+    assert kpi["value"] == 100.0
+    assert kpi["numerator"] == 1
+    assert kpi["denominator"] == 1
+
+    # MW-02: executed_at was queued +5s, so round-trip ≈ 5s.
+    kpi = _result(
+        bundle, "MW-02", "real", **{"command_type": "ping", "statistic": "max"}
+    )
+    assert kpi["value"] is not None
+    assert 4.5 <= kpi["value"] <= 6.5
+    assert kpi["numerator"] == 1
+
+    # MW-03: both config changes succeeded.
+    kpi = _result(bundle, "MW-03", "real")
+    assert kpi["value"] == 100.0
+    assert kpi["numerator"] == 2
+    assert kpi["denominator"] == 2
+
+    # MW-04: both successful changes carry before/after evidence and improved.
+    kpi = _result(bundle, "MW-04", "real")
+    assert kpi["value"] == 100.0
+    assert kpi["numerator"] == 2
+    assert kpi["denominator"] == 2
+    assert kpi["exclusions"] == 0
+
+    # MW-05: the one attempted rollback was reported successful.
+    kpi = _result(bundle, "MW-05", "real")
+    assert kpi["value"] == 100.0
+    assert kpi["numerator"] == 1
+    assert kpi["denominator"] == 1
+
+    # PF-LAT: 100 and 200 ms → p50 150, p95 195, max 200.
+    for stat, expected in (("p50", 150.0), ("p95", 195.0), ("max", 200.0)):
+        kpi = _result(bundle, "PF-LAT", "real", **{"statistic": stat})
+        assert kpi["value"] == expected
+        assert kpi["numerator"] == 2
+
+    # EQ-01: every row written through the API carries a provenance class.
+    for table in ("device_metrics", "device_state_history", "configuration_history"):
+        kpi = _result(bundle, "EQ-01", **{"table": table})
+        assert kpi["value"] == 100.0, f"EQ-01 coverage for {table}"
+
+
+def test_provenance_classes_stay_separated_via_api(client: TestClient) -> None:
+    """Real and simulated devices keep their KPI scopes isolated end-to-end."""
+    real_key = _seed_site_device("e2e-real-001", "site-e2e-real", "physical")
+    sim_key = _seed_site_device("e2e-sim-001", "site-e2e-sim", "simulation")
+    real_headers = _device_headers("e2e-real-001", real_key)
+    sim_headers = _device_headers("e2e-sim-001", sim_key)
+    user_headers = _user_headers()
+
+    for latency, headers, device_id in (
+        (100.0, real_headers, "e2e-real-001"),
+        (300.0, sim_headers, "e2e-sim-001"),
+    ):
+        resp = client.post(
+            "/api/v1/analytics/device-metrics",
+            json={
+                "device_id": device_id,
+                "network_latency_ms": latency,
+                "collection_interval_seconds": 5,
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 201, resp.text
+
+    def _latency(provenance: str) -> float:
+        resp = client.get(
+            EXPORT_URL,
+            params={"start": WIDE_START, "end": WIDE_END, "provenance": provenance},
+            headers=user_headers,
+        )
+        assert resp.status_code == 200, resp.text
+        return _result(resp.json(), "PF-LAT", provenance, **{"statistic": "max"})[
+            "value"
+        ]
+
+    assert _latency("real") == 100.0
+    assert _latency("simulated") == 300.0
+
+    # The unfiltered export reports both provenance classes.
+    resp = client.get(
+        EXPORT_URL,
+        params={"start": WIDE_START, "end": WIDE_END},
+        headers=user_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    bundle = resp.json()
+    stats = {
+        (kpi["provenance"], kpi["group"]["statistic"])
+        for kpi in bundle["kpis"]
+        if kpi["group"] is not None and "statistic" in kpi["group"]
+    }
+    assert ("real", "max") in stats
+    assert ("simulated", "max") in stats
+
+
+def test_site_isolation_via_api(client: TestClient) -> None:
+    """Exporting one site never leaks evidence from another site."""
+    key_a = _seed_site_device("e2e-a-001", "site-e2e-a", "physical")
+    key_b = _seed_site_device("e2e-b-001", "site-e2e-b", "physical")
+    headers_a = _device_headers("e2e-a-001", key_a)
+    headers_b = _device_headers("e2e-b-001", key_b)
+    user_headers = _user_headers()
+
+    for latency, headers, device_id in (
+        (50.0, headers_a, "e2e-a-001"),
+        (900.0, headers_b, "e2e-b-001"),
+    ):
+        resp = client.post(
+            "/api/v1/analytics/device-metrics",
+            json={
+                "device_id": device_id,
+                "network_latency_ms": latency,
+                "collection_interval_seconds": 5,
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 201, resp.text
+
+    resp = client.get(
+        EXPORT_URL,
+        params={
+            "start": WIDE_START,
+            "end": WIDE_END,
+            "site_id": "site-e2e-a",
+        },
+        headers=user_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    bundle = resp.json()
+
+    kpi = _result(bundle, "PF-LAT", "all", **{"statistic": "max"})
+    assert kpi["value"] == 50.0
+    assert kpi["numerator"] == 1


### PR DESCRIPTION
Implements roadmap PR 6: automated protection for KPI formulas and an end-to-end evidence-flow scenario.

**Data-quality coverage** (`tests/test_kpi_data_quality.py`)
- MW-01: all-failed -> 0% completion; in-flight (non-terminal) commands excluded, not counted.
- MW-02: two-sample and single-sample p50/p95/max interpolation.
- MW-03: missing outcome flags excluded from the denominator.
- MW-04: successful changes without before/after evidence cannot be verified.
- MW-05: rollbacks restoring the health target count (flag + performance evidence), failed rollbacks excluded.
- EQ-01: all-missing provenance -> 0% coverage; all-valid -> 100% per table.
- PF-LAT: null latency rows ignored in every statistic.
- Manifest reproducibility: exported `git_commit` pins the repo HEAD.

**Scenario integration** (`tests/test_kpi_scenario_integration.py`)
- End-to-end evidence flow: device telemetry, state change, command queue/ack/status, agent config-history through the public API, then the export reflects MW-01/02/03/04/05, PF-LAT percentiles and EQ-01 coverage.
- Provenance separation across the API boundary (real vs simulated).
- Site isolation across the API boundary.

Note: the scenario tests pre-create the async database service on the test event loop and use a TestClient without the app lifespan to avoid a SQLite write-lock race between the sync engine and the lifespan portal's async engine (the async DB init runs in a different event loop in the portal, which intermittently holds a write lock). The async service is otherwise exercised identically.