### PR TITLE
docs: align analytics telemetry and pilot documentation

### DIFF
--- a/docs/KPI-evaluation-roadmap.md
+++ b/docs/KPI-evaluation-roadmap.md
@@ -49,7 +49,7 @@ Every device, metric row, result, chart, and export must carry or inherit one of
 | `CONTROLLED` | Produced by a deterministic emulator or injected fault under a recorded test protocol | May support functional and resilience claims, with the test conditions stated |
 | `SIMULATED` | Random or seeded demonstration data | Pipeline rehearsal only; must not support a real-world performance claim |
 
-The `Device.is_simulated` field is a starting point, but the evaluation export must preserve provenance after data are aggregated. Historical rows must not silently inherit a device’s current classification.
+`Device.is_simulated` and the configured `device_source` are combined by `derive_provenance()`, and the class is snapshotted onto each telemetry and event row at write time, so historical rows do not silently inherit a device’s later classification. See [Evidence Recording](provenance-and-outcomes.md).
 
 ### 3.2 Claim maturity
 
@@ -82,13 +82,13 @@ The repository has useful evaluation infrastructure, but most KPI claims are not
 | API request timing and status logging | Implemented | Can support API latency and failure calculations after aggregation and test-traffic filtering are added |
 | Basic dashboard counts | Implemented | Supports live status display, not a time-bounded KPI result |
 | Device metrics schema | Implemented | CPU, memory, and disk are available; several operational fields remain unpopulated by the real agent |
-| Real device telemetry | Partial | Real agent does not currently collect network latency, uptime, or genuine POS/application signals |
-| Error analytics | Partial | Frontend uses `message`/`extra_data`; backend contract expects `error_message`/`context` |
-| Device state history | Partial | `metadata`/`extra_data` naming is inconsistent and needs an end-to-end contract test |
-| Configuration history | Partial | Schema supports before/after performance, success, and rollback; closed-loop post-change evidence is incomplete |
-| Real/simulated distinction | Partial | Device-level `is_simulated` exists, but provenance is not preserved consistently in metric aggregates or exports |
-| KPI aggregation | Partial | Average/minimum/maximum API timing and job status counts exist; percentiles, rates, freshness, connectivity, and health compliance are missing |
-| KPI dashboard/export | Missing | No time-bounded, site/device-filtered evidence export with provenance and calculation metadata |
+| Real device telemetry | Implemented | Real agent collects network latency, uptime, and collection metadata; POS signals remain config-gated |
+| Error analytics | Implemented | Frontend and backend aligned on `error_message`/`context` with a contract test |
+| Device state history | Implemented | Standardised on `extra_data` with an end-to-end contract test |
+| Configuration history | Implemented | Before/after performance, success, and rollback outcome fields captured; closed-loop evidence for MW-03 to MW-05 |
+| Real/simulated distinction | Implemented | Provenance snapshotted on telemetry and event rows via `derive_provenance()` |
+| KPI aggregation | Implemented | EQ-01, MW-01 to MW-05, and PF-LAT computed by the export; freshness, connectivity, and health KPIs remain future work |
+| KPI dashboard/export | Implemented | Versioned, filtered export with manifest, provenance scopes, raw evidence, REST API, and CLI |
 | Validation gates for AI context | Implemented | Gates A-C can report contract, data-integrity, and context-readiness status for AI queries |
 | Real pilot evidence | Not established | A controlled pilot run and signed run log are still required |
 
@@ -97,6 +97,8 @@ Relevant baselines are documented in [Architecture Compliance Matrix](architectu
 ## 5. KPI Register
 
 Thresholds must be agreed with the UK use-case owner before the formal run. Values marked **TBD** are deliberately not invented after observing results. Baseline values may be collected during the rehearsal, but acceptance targets must then be frozen before the pilot evaluation.
+
+**Implemented calculations:** EQ-01, MW-01 to MW-05, and PF-LAT are computed by the versioned export. See [KPI Export](kpi-export.md) for their stable definitions, formulas, units, manifest contract, and limitations. The remaining register items below are defined but not yet computed.
 
 ### 5.1 Evidence-quality KPIs
 
@@ -178,21 +180,22 @@ UK-E08 is blocked until the UK partner confirms the external system, event contr
 
 ### Phase 1 — Make Instrumentation Trustworthy
 
-| Priority | Work package | Acceptance evidence |
-| --- | --- | --- |
-| P0 | Align frontend error payload with backend `error_message` and `context` fields | Frontend/backend contract test proves message and context persistence |
-| P0 | Standardise device-state history on `extra_data` | Endpoint test proves request-to-database-to-response round trip |
-| P0 | Preserve real/controlled/simulated provenance on telemetry and events | Exported rows retain source classification independently of later device changes |
-| P1 | Add real-agent network latency, uptime, sample timestamp, and submission-attempt telemetry | Known-value tests plus observations from each pilot OS/device type |
-| P1 | Integrate permitted real POS/application signals | Data-source agreement and side-by-side source validation; otherwise exclude operational POS KPIs |
-| P1 | Complete post-change and rollback outcome capture | Integration test populates before/after health, success, and rollback fields |
-| P1 | Record command attempt and terminal outcome timestamps | Full queue-to-agent-to-dashboard integration test |
+| Priority | Work package | Status | Acceptance evidence |
+| --- | --- | --- | --- |
+| P0 | Align frontend error payload with backend `error_message` and `context` fields | Done | Frontend/backend contract test proves message and context persistence |
+| P0 | Standardise device-state history on `extra_data` | Done | Endpoint test proves request-to-database-to-response round trip |
+| P0 | Preserve real/controlled/simulated provenance on telemetry and events | Done | Exported rows retain source classification independently of later device changes |
+| P1 | Add real-agent network latency, uptime, sample timestamp, and submission-attempt telemetry | Done | Known-value tests plus observations from each pilot OS/device type |
+| P1 | Integrate permitted real POS/application signals | Config-gated | Data-source agreement and side-by-side source validation; otherwise exclude operational POS KPIs |
+| P1 | Complete post-change and rollback outcome capture | Done | Integration test populates before/after health, success, and rollback fields |
+| P1 | Record command attempt and terminal outcome timestamps | Done | Full queue-to-agent-to-dashboard integration test |
 
 **Exit gate:** A 24-hour rehearsal produces traceable, non-null inputs for all in-scope KPI calculations.
 
 ### Phase 2 — Build Reproducible KPI Calculations
 
-Add a versioned API or command-line export that supports:
+Delivered as `GET /api/v1/kpi/export` and `homepot-client kpi-export`. The
+versioned export supports:
 
 - `start`, `end`, `site_id`, `device_id`, `device_type`, and provenance filters;
 - numerator, denominator, exclusions, and sample count;
@@ -201,7 +204,9 @@ Add a versioned API or command-line export that supports:
 - calculation version, Git commit, units, timezone, and generation timestamp;
 - separate results for `REAL`, `CONTROLLED`, and `SIMULATED` evidence.
 
-Add automated tests for empty windows, boundary timestamps, mixed provenance, missing samples, percentile calculations, failed requests, and site/device isolation.
+Automated tests cover empty windows, boundary timestamps, mixed provenance,
+missing samples, percentile calculations, failed requests, and site/device
+isolation. See [KPI Export](kpi-export.md) for the full contract.
 
 **Exit gate:** A reviewer can regenerate every KPI value from a clean database snapshot and the evidence manifest.
 
@@ -259,17 +264,17 @@ evidence/uk-homepot/<run-id>/
 └── limitations.md
 ```
 
-The manifest should include the run ID, protocol version, Git commit, deployment versions, window, timezone, sites, devices, provenance, scenario IDs, file hashes, exclusions, and operator/reviewer identities. Screenshots illustrate a result but do not replace machine-readable evidence.
+The manifest should include the run ID, protocol version, Git commit, deployment versions, window, timezone, sites, devices, provenance, scenario IDs, file hashes, exclusions, and operator/reviewer identities. Screenshots illustrate a result but do not replace machine-readable evidence. See [Pilot Operator Protocol](operator-protocol.md) for the contents of each item and the operator procedure.
 
 ## 9. Completion Checklist
 
 - [ ] UK requirement scope and exclusions approved.
 - [ ] KPI formulas, thresholds, sample, duration, and owners frozen.
 - [ ] Privacy and operational-safety review completed.
-- [ ] Frontend/backend analytics contracts fixed and tested.
-- [ ] Real-agent telemetry and immutable provenance complete.
-- [ ] Command and configuration outcomes close the loop.
-- [ ] KPI export and reproducible calculations implemented and tested.
+- [x] Frontend/backend analytics contracts fixed and tested.
+- [x] Real-agent telemetry and immutable provenance complete.
+- [x] Command and configuration outcomes close the loop.
+- [x] KPI export and reproducible calculations implemented and tested.
 - [ ] Controlled rehearsal passes evidence-quality gates.
 - [ ] Real pilot meets the agreed sample and duration.
 - [ ] UK-E01 to UK-E07 completed; UK-E08 completed or explicitly excluded.
@@ -278,14 +283,14 @@ The manifest should include the run ID, protocol version, Git commit, deployment
 
 ## 10. Immediate PR Sequence
 
-| Order | Proposed PR | Outcome |
-| --- | --- | --- |
-| 1 | `fix: align analytics event contracts end to end` | Reliable error and state-history records with contract tests |
-| 2 | `feat: preserve telemetry provenance and collection metadata` | Real, controlled, and simulated evidence cannot be mixed silently |
-| 3 | `feat: capture real-agent latency uptime and operational signals` | Real inputs for PF-02, PF-04, and agreed POS KPIs |
-| 4 | `feat: close configuration and command outcome tracking` | Reproducible MW-01 to MW-05 evidence |
-| 5 | `feat: add UK demonstrator KPI calculations and export` | Time-bounded, filtered, versioned evidence output |
-| 6 | `test: add KPI data-quality and scenario integration coverage` | Automated protection for formulas and end-to-end evidence flow |
-| 7 | `docs: align analytics telemetry and pilot documentation` | Stable definitions, units, limitations, and operator protocol |
+| Order | Proposed PR | Status | Outcome |
+| --- | --- | --- | --- |
+| 1 | `fix: align analytics event contracts end to end` | Merged | Reliable error and state-history records with contract tests |
+| 2 | `feat: preserve telemetry provenance and collection metadata` | Merged | Real, controlled, and simulated evidence cannot be mixed silently |
+| 3 | `feat: capture real-agent latency uptime and operational signals` | Merged | Real inputs for PF-02, PF-04, and agreed POS KPIs |
+| 4 | `feat: close configuration and command outcome tracking` | Merged | Reproducible MW-01 to MW-05 evidence |
+| 5 | `feat: add UK demonstrator KPI calculations and export` | Merged | Time-bounded, filtered, versioned evidence output |
+| 6 | `test: add KPI data-quality and scenario integration coverage` | Merged | Automated protection for formulas and end-to-end evidence flow |
+| 7 | `docs: align analytics telemetry and pilot documentation` | This PR | Stable definitions, units, limitations, and operator protocol |
 
 Phase 0 protocol decisions can proceed in parallel with PRs 1–2. The formal pilot must wait for PRs 1–6 and a successful controlled rehearsal.

--- a/docs/analytics-data-collection.md
+++ b/docs/analytics-data-collection.md
@@ -9,9 +9,6 @@ HOMEPOT Client automatically collects operational data to enable AI-powered insi
 - **5 operational analytics tables**: API requests, device states, job outcomes, errors, user activities
 - **3 AI-focused tables**: Device metrics, configuration history, site schedules
 
-- **5 Core Analytics Tables:** API requests, device states, job outcomes, errors, user activities
-- **3 AI-Focused Tables:** Device performance metrics, configuration history, site schedules
-
 **Current Status:** (Verified Dec 18, 2025)
 - Database tables created (all 8 tables, verified in PostgreSQL)
 - API request logging (automatic via middleware, **123 rows actively collecting**)
@@ -273,8 +270,7 @@ except Exception as e:
         user_id=current_user.id if current_user else None,
         device_id=device_id if device_id else None,
         context={"additional": "context", "data": "here"}
-````
-    ))
+    )
     db.commit()
     raise
 ```
@@ -327,7 +323,7 @@ Frontend developers need to add tracking calls. See [Frontend Analytics Integrat
 ## 6. Device Performance Metrics
 
 **Table:** `device_metrics`  
-**Collection Status:** Needs periodic collection (recommended: every 5 minutes)
+**Collection Status:** Agent telemetry (real agent default: every 30 seconds)
 
 ### What It Stores
 
@@ -339,12 +335,14 @@ Tracks device performance metrics over time for predictive maintenance and optim
 - `memory_percent`: Memory usage percentage
 - `disk_percent`: Disk usage percentage
 - `network_latency_ms`: Network latency in milliseconds
+- `collection_interval_seconds`: Agent-reported interval between samples (snapshotted)
 - `transaction_count`: Number of transactions processed
 - `transaction_volume`: Dollar amount of transactions
 - `error_rate`: Error rate percentage
 - `active_connections`: Number of active connections
 - `queue_depth`: Number of queued items
 - `extra_metrics`: Additional JSON metrics
+- `provenance`: Evidence class snapshotted at write time (`real`, `controlled`, or `simulated`)
 
 ### Example Data
 
@@ -371,7 +369,7 @@ Add periodic metrics collection (e.g., in a background task):
 ```python
 from homepot.app.models.AnalyticsModel import DeviceMetrics
 
-# Every 5 minutes
+# Real agent default: every 30 seconds
 async def collect_device_metrics(device_id: str):
     metrics = await get_device_performance(device_id)
     
@@ -413,6 +411,10 @@ Tracks configuration changes and their impact for AI learning:
 - `was_successful`: Whether change achieved desired result
 - `was_rolled_back`: Whether change was reverted
 - `rollback_reason`: Why it was rolled back
+- `rollback_success`: Whether the rollback restored the baseline
+- `rollback_performance`: Performance metrics after rollback (JSON)
+- `rolled_back_at`: Timestamp of the rollback
+- `provenance`: Evidence class snapshotted at write time (`real`, `controlled`, or `simulated`)
 
 ### Implementation Details
 
@@ -506,39 +508,6 @@ config_history = ConfigurationHistory(
     change_type="manual",
 )
 session.add(config_history)
-```
-
----
-
-## 5. User Activities
-
-**Table:** `user_activities`  
-**Collection Status:** Needs frontend implementation
-
-### What It Stores
-
-# Apply change
-await update_device_config(device_id, "max_connections", 15)
-
-# After change (wait a bit for metrics)
-await asyncio.sleep(60)
-after_metrics = await measure_performance(device_id)
-
-# Log the change
-db.add(ConfigurationHistory(
-    entity_type="device",
-    entity_id=device_id,
-    parameter_name="max_connections",
-    old_value={"value": 10},
-    new_value={"value": 15},
-    changed_by=current_user.id,
-    change_reason="Increased load during peak hours",
-    change_type="manual",
-    performance_before={"avg_response_time": 145, "error_rate": 1.2},
-    performance_after={"avg_response_time": 98, "error_rate": 0.3},
-    was_successful=True
-))
-await db.commit()
 ```
 
 ---

--- a/docs/backend-analytics.md
+++ b/docs/backend-analytics.md
@@ -18,17 +18,29 @@ This analytics infrastructure provides comprehensive data collection and queryin
 - Device ID, previous/new state
 - Changed by (user or system)
 - Reason and metadata
+- Provenance class snapshotted at write time
 
 **JobOutcome**: Tracks job execution results
 - Job type, device, status
 - Duration, error codes
 - Retry count, metadata
+- Provenance class snapshotted at write time
 
 **ErrorLog**: Categorized error tracking
 - Category (api, database, external_service, validation)
 - Severity (critical, error, warning, info)
 - Stack trace, context
 - Resolution status
+- Provenance class snapshotted at write time
+
+**DeviceMetrics**: Time-series device performance
+- CPU, memory, disk, network latency, transaction counters
+- `collection_interval_seconds` (agent-reported interval)
+- Provenance class snapshotted at write time
+
+**ConfigurationHistory**: Configuration changes and their outcome
+- Before/after performance, success, and rollback fields
+- Provenance class snapshotted at write time
 
 **UserActivity**: Tracks user behavior (frontend integration)
 - Activity type (page_view, click, search, interaction)
@@ -53,7 +65,7 @@ This analytics infrastructure provides comprehensive data collection and queryin
 To prevent database overload from high-frequency device metrics, the system implements a **Smart Data Filtering** mechanism (`SmartDataFilter`).
 
 **Logic:**
-1.  **Snapshot Interval**: A full snapshot of device metrics is stored every 5 minutes (configurable) regardless of changes, ensuring a heartbeat.
+1.  **Snapshot Interval**: A full snapshot of device metrics is stored every 5 minutes (configurable) regardless of changes, ensuring a heartbeat. The real agent instead reports at its configured `telemetry_interval_seconds` (default 30 s), recorded in `collection_interval_seconds`.
 2.  **Significant Change**: Metrics are stored immediately if they deviate by more than 5% (configurable) from the last stored value.
 3.  **First Contact**: The first data point received from a device (after system restart) is always stored.
 
@@ -296,7 +308,7 @@ db.commit()
 
 1. **Real-time Dashboard**: Connect to analytics endpoints for live monitoring
 2. **Alerting**: Set up alerts based on error rates, response times
-3. **Data Export**: Export analytics data for external analysis
+3. **Data Export**: Delivered — see [KPI Export](kpi-export.md) for the versioned, provenance-scoped, filterable export (API and CLI)
 4. **AI Integration**: Use collected data to train recommendation models
 5. **Aggregation Tables**: Create pre-computed hourly/daily aggregates for faster queries
 

--- a/docs/database-metrics-validation.md
+++ b/docs/database-metrics-validation.md
@@ -98,12 +98,14 @@ To retrieve actual records for verification:
 | `memory_percent` | double | Memory Usage % |
 | `disk_percent` | double | Disk Usage % |
 | `network_latency_ms` | double | Network Latency |
+| `collection_interval_seconds` | integer | Agent-reported interval between samples (snapshotted) |
 | `transaction_count` | integer | Daily transaction count |
 | `transaction_volume` | double | Value of transactions |
 | `error_rate` | double | Error frequency |
 | `active_connections` | integer | Connection count |
 | `queue_depth` | integer | Processing queue size |
 | `extra_metrics` | json | Additional flexible metrics |
+| `provenance` | varchar(20) | Evidence class snapshotted at write time (real/controlled/simulated) |
 
 ### Sample Data
 **Record ID:** 886  
@@ -210,6 +212,7 @@ To retrieve actual records for verification:
 | `changed_by` | varchar(255) | Actor (User/System) |
 | `reason` | varchar(500) | Explanation for change |
 | `extra_data` | json | Contextual data |
+| `provenance` | varchar(20) | Evidence class snapshotted at write time (real/controlled/simulated) |
 
 ### Sample Data
 **Record ID:** 209  
@@ -262,6 +265,11 @@ To retrieve actual records for verification:
 | `performance_after` | json | Metrics post-change |
 | `was_successful` | boolean | Outcome |
 | `was_rolled_back` | boolean | Rollback status |
+| `rollback_reason` | text | Why it was rolled back |
+| `rollback_success` | boolean | Whether the rollback restored the baseline |
+| `rollback_performance` | json | Metrics post-rollback |
+| `rolled_back_at` | timestamp | Rollback time |
+| `provenance` | varchar(20) | Evidence class snapshotted at write time (real/controlled/simulated) |
 
 ### Sample Data
 **Record ID:** 4  

--- a/docs/kpi-export.md
+++ b/docs/kpi-export.md
@@ -1,0 +1,284 @@
+# UK Demonstrator KPI Export
+
+## 1. Purpose
+
+This document is the stable reference for the implemented UK demonstrator KPI
+calculation and export ([roadmap §5 and Phase 2](KPI-evaluation-roadmap.md)). It
+defines each exported KPI, its formula, its unit, its population, and the exact
+behaviour of the export API and command-line tool. It is the source of truth for
+"definitions, units, and limitations" of the machine-readable evidence output.
+
+Every export is versioned and reproducible: it records the calculation version,
+the Git commit of the calculation code, the reporting timezone, the filters, and
+the generation timestamp, and it ships the raw evidence rows that back each
+value.
+
+!!! note "Scope"
+    Only the KPIs listed below are currently computed by the export. The rest of
+    the roadmap register (for example EQ-02 to EQ-05, PF-01 to PF-07, MW-06/07,
+    and AI-01 to AI-04) remains defined but **not yet computed** and is out of
+    scope for this export until its calculation and evidence source exist.
+
+## 2. Implemented KPI register
+
+| ID | KPI | Unit | Value definition |
+| --- | --- | --- | --- |
+| EQ-01 | Provenance coverage | `%` | rows with valid provenance / eligible rows × 100, per table |
+| MW-01 | Command completion rate | `%` | completed commands / terminal commands × 100 |
+| MW-02 | Command round-trip time | `seconds` | `executed_at − created_at`, by command type, p50/p95/max |
+| MW-03 | Configuration-change success | `%` | successful changes / attempted changes × 100 |
+| MW-04 | Verified improvement rate | `%` | improved changes / verified successful changes × 100 |
+| MW-05 | Rollback effectiveness | `%` | restoring rollbacks / attempted rollbacks × 100 |
+| PF-LAT | Device-reported network latency | `ms` | `network_latency_ms` percentiles from `device_metrics`, p50/p95/max |
+
+The unit map is recorded verbatim in every export manifest:
+
+```json
+{
+  "EQ-01": "%",
+  "MW-01": "%",
+  "MW-02": "seconds",
+  "MW-03": "%",
+  "MW-04": "%",
+  "MW-05": "%",
+  "PF-LAT": "ms"
+}
+```
+
+### 2.1 EQ-01 Provenance coverage
+
+- **Formula:** rows with a valid `provenance` value / eligible rows in the
+  window × 100.
+- **Population:** rows in `device_metrics`, `device_state_history`, and
+  `configuration_history` (entity type `device`) within the window.
+- **Grouping:** one result per table (`device_metrics`, `device_state_history`,
+  `configuration_history`).
+- **Unit:** `%`. Null when the denominator is 0.
+- **Gate:** no operational KPI may be labelled **Validated** when its underlying
+  evidence fails EQ-01 (roadmap §5.1).
+
+### 2.2 MW-01 Command completion rate
+
+- **Formula:** completed commands / terminal commands × 100.
+- **Population:** `device_commands` created within the window. Terminal statuses
+  are `COMPLETED`, `FAILED`, and `EXPIRED`. Non-terminal commands (for example
+  `PENDING`/`SENT`) are counted in `exclusions` and never form the denominator.
+- **Unit:** `%`. Null when there are no terminal commands.
+
+### 2.3 MW-02 Command round-trip time
+
+- **Formula:** `executed_at − created_at` in seconds, grouped by command type.
+- **Population:** terminal commands with both `created_at` and `executed_at`.
+  Commands without an `executed_at` are skipped.
+- **Statistics:** p50, p95, and maximum, using the linear-interpolation
+  percentile definition in §5.
+- **Unit:** `seconds`, rounded to 3 decimal places. Null for an empty group.
+- **Grouping:** `{"command_type": "<type>", "statistic": "p50"|"p95"|"max"}`.
+
+### 2.4 MW-03 Configuration-change success
+
+- **Formula:** successful changes / attempted changes × 100.
+- **Population:** `configuration_history` rows (entity type `device`) in the
+  window. Attempted changes are rows where `was_successful` is not null; rows
+  with `was_successful IS NULL` are counted in `exclusions`.
+- **Unit:** `%`. Null when there are no attempted changes.
+
+### 2.5 MW-04 Verified improvement rate
+
+- **Formula:** improved changes / verified successful changes × 100.
+- **Population:** successful changes (`was_successful = true`) that also have
+  both `performance_before` and `performance_after`. Successful changes lacking
+  a before/after window are counted in `exclusions`.
+- **"Improved" definition (`_is_improved`):** the after-state reports a healthy
+  status (`healthy`, `ok`, or `online`); otherwise, when no status is present,
+  the after-state response time did not regress (`response_time_ms` after ≤
+  before).
+- **Unit:** `%`. Null when there are no verified changes.
+
+### 2.6 MW-05 Rollback effectiveness
+
+- **Formula:** restoring rollbacks / attempted rollbacks × 100.
+- **Population:** `configuration_history` rows in the window with
+  `was_rolled_back = true`.
+- **"Restoring" definition:** `rollback_success = true`, or, when
+  `rollback_success` is null, `_is_improved(performance_before,
+  rollback_performance)`.
+- **Unit:** `%`. Null when there are no attempted rollbacks.
+
+### 2.7 PF-LAT Device-reported network latency
+
+- **Formula:** percentiles of `device_metrics.network_latency_ms`.
+- **Population:** `device_metrics` rows in the window with a non-null
+  `network_latency_ms`; rows with null latency are ignored.
+- **Statistics:** p50, p95, and maximum.
+- **Unit:** `ms`, rounded to 2 decimal places. Null for an empty population.
+- **Grouping:** `{"statistic": "p50"|"p95"|"max"}`.
+
+## 3. Provenance scoping
+
+Filters restrict the population to one provenance class. When no provenance
+filter is given, results are computed for **every** scope: `all`, `real`,
+`controlled`, and `simulated` (the roadmap §3.1 classes, lower-cased).
+
+Tables that snapshot a `provenance` column at write time
+(`device_metrics`, `device_state_history`, `configuration_history`) are filtered
+directly on that column. `device_commands` predates provenance snapshots, so
+command KPIs are scoped by deriving each device's classification **at export
+time** from the device record. The derivation is:
+
+1. `device.config["device_source"]` — `emulator` → `controlled`,
+   `simulation` → `simulated`, `physical` → `real`;
+2. otherwise `device.is_simulated` → `simulated`;
+3. otherwise `real`.
+
+See [Evidence recording](provenance-and-outcomes.md) for the write-time
+snapshot behaviour.
+
+## 4. Export formats
+
+### 4.1 JSON bundle
+
+`GET /api/v1/kpi/export` with `format=json` (default) returns a versioned
+bundle with three sections:
+
+- **`manifest`** — calculation metadata (see §6);
+- **`kpis`** — the machine-readable KPI summary (one object per KPI and group);
+- **`raw`** — the in-window raw evidence rows that back the calculations
+  (`device_metrics`, `device_state_history`, `configuration_history`, and
+  `device_commands`).
+
+Each KPI object carries:
+
+| Field | Meaning |
+| --- | --- |
+| `kpi_id` | Register ID, e.g. `MW-02` |
+| `name` | Human-readable KPI name |
+| `formula` | Plain-text calculation description |
+| `unit` | Reported unit (`%`, `seconds`, `ms`) |
+| `value` | Computed value, or `null` when the denominator is 0 |
+| `numerator` | Numerator count |
+| `denominator` | Denominator count |
+| `exclusions` | Rows excluded by the KPI's own definition |
+| `sample_count` | Rows used for the value |
+| `provenance` | Scope: `all`, `real`, `controlled`, or `simulated` |
+| `group` | Grouping keys, e.g. `{"command_type": "ping", "statistic": "p50"}` |
+
+### 4.2 CSV summary
+
+`format=csv` returns the KPI summary table as `kpi-summary.csv`, with the
+manifest embedded as `# manifest: {...}` comment rows so the file is
+self-describing for a reviewer. Columns: `kpi_id`, `name`, `formula`, `unit`,
+`value`, `numerator`, `denominator`, `exclusions`, `sample_count`,
+`provenance`, `group`.
+
+The CSV is a summary only — the raw evidence rows are available in the JSON
+bundle or directly from the database.
+
+## 5. Percentile definition
+
+Percentiles use linear interpolation between the two nearest ranks of the
+sorted sample (`p = (n − 1) · q`, lower and upper ranks, fractional
+interpolation), so p50/p95 are well defined for small samples. A single-value
+sample returns that value; an empty sample returns `null`.
+
+## 6. Manifest contract
+
+Every export includes the following metadata:
+
+| Field | Meaning |
+| --- | --- |
+| `generated_at` | Generation timestamp, UTC ISO-8601 |
+| `timezone` | Reporting timezone (`UTC`) |
+| `calculation_version` | Calculation code version (`1.0.0`) |
+| `git_commit` | Short Git commit of the calculation code (`unknown` when unavailable) |
+| `units` | The KPI unit map from §2 |
+| `provenance_scopes` | Scopes the export was computed for |
+| `filters` | `start`, `end`, `site_id`, `device_id`, `device_type`, `provenance` |
+
+A reviewer can pin every exported value to a specific revision of the
+calculation code via `calculation_version` + `git_commit`.
+
+## 7. Using the export
+
+### 7.1 REST API
+
+`GET /api/v1/kpi/export` (authenticated).
+
+| Query parameter | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `start` | ISO-8601 datetime | required | Window start (inclusive), UTC |
+| `end` | ISO-8601 datetime | required | Window end (inclusive), UTC |
+| `site_id` | string | — | Restrict to devices at this site |
+| `device_id` | string | — | Restrict to this device |
+| `device_type` | string | — | Restrict to this device type |
+| `provenance` | string | — | `real`, `controlled`, or `simulated` |
+| `format` | string | `json` | `json` (bundle) or `csv` (summary) |
+
+Validation: an invalid `format` or `provenance` returns `422`; `start` after
+`end` returns `400`.
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8000/api/v1/kpi/export?start=2026-08-01T00:00:00Z&end=2026-08-14T23:59:59Z&provenance=real&format=json"
+```
+
+### 7.2 Command-line tool
+
+```bash
+homepot-client kpi-export \
+  --start 2026-08-01T00:00:00Z \
+  --end 2026-08-14T23:59:59Z \
+  --provenance real \
+  --out-dir evidence/uk-homepot/demo-run/exports
+```
+
+Options mirror the API (`--site-id`, `--device-id`, `--device-type`,
+`--provenance`, `--format json|csv`, `--out-dir`). It writes
+`kpi-export.json` (bundle) or `kpi-summary.csv` (summary) into `--out-dir`
+and prints the calculation version and Git commit on completion.
+
+## 8. Reproducibility requirements
+
+For a value to be reproducible from a clean database snapshot:
+
+- timestamps are stored and compared in UTC and the reporting timezone is
+  recorded (`UTC`);
+- the evaluation window is frozen before calculating results;
+- site, device, type, and provenance filters are recorded in the manifest;
+- numerator, denominator, exclusions, and sample count are retained for every
+  rate;
+- the calculation code is versioned and the Git commit is recorded;
+- `REAL`, `CONTROLLED`, and `SIMULATED` results are never combined in one
+  headline value — they are reported per scope.
+
+## 9. Data-quality gates
+
+The roadmap defines evidence-quality gates EQ-01 to EQ-05 (§5.1). Of these, only
+**EQ-01 (provenance coverage)** is computed today and appears in every export.
+The remaining gates (telemetry completeness, freshness, continuity, and valid
+record rate) are defined but not yet calculated; their thresholds remain **TBD**
+until frozen in Phase 0.
+
+!!! warning "Gate language"
+    "Implemented" (code path + automated tests) does **not** imply
+    **Validated** (pre-agreed threshold met on `REAL` evidence). Apply the
+    claim-maturity labels from roadmap §3.2 when reporting results.
+
+## 10. Limitations
+
+- **No real pilot evidence yet:** until Phase 4, exported values are rehearsal
+  evidence at best (`CONTROLLED` or `SIMULATED`); do not present them as a
+  pilot result.
+- **Thresholds are not frozen:** acceptance thresholds in the register remain
+  **TBD** until the Phase 0 freeze with the UK use-case owner.
+- **EQ-02 to EQ-05 are not computed:** freshness, continuity, completeness, and
+  valid-record-rate gates have no implementation yet.
+- **`device_commands` provenance is derived at export time**, not snapshotted,
+  so command KPI scopes reflect the device's classification *today* rather than
+  at command time.
+- **MW-02 requires `executed_at`:** commands still in flight are excluded by the
+  terminal-status rule.
+- **A null `value` means an empty denominator**, not a failure — the
+  numerator/denominator counts distinguish "0%" from "no data".
+- **Percentiles on tiny samples:** with one value the p50/p95/max all equal
+  that value; report sample counts alongside percentiles.

--- a/docs/operator-protocol.md
+++ b/docs/operator-protocol.md
@@ -1,0 +1,159 @@
+# Pilot Operator Protocol
+
+## 1. Purpose
+
+This document turns the [evaluation roadmap](KPI-evaluation-roadmap.md) Phase 0
+outputs into a concrete, operator-facing protocol. It fixes the definitions,
+units, owners, evidence bundle, reviewer rubric, and limitations that the
+demonstrator operator and the evidence reviewer must follow during a formal UK
+pilot run. Decisions recorded here are frozen before the pilot and are not
+changed while results are being produced.
+
+## 2. Roles and owners
+
+| Role | Responsibility | Named owner |
+| --- | --- | --- |
+| UK use-case owner | Approves scope, thresholds, and exclusions | TBD (Phase 0) |
+| Demonstrator operator | Executes scenarios, records interventions | TBD (Phase 0) |
+| Data analyst | Runs exports and calculations | TBD (Phase 0) |
+| Evidence reviewer | Independent second-person review and sign-off | TBD (Phase 0) |
+| D2.3 author | Reports results with claim-maturity labels | TBD (Phase 0) |
+
+Names are recorded in `manifest.json` (operator/reviewer identities) and in the
+bundle's `protocol.md` before the run starts.
+
+## 3. Phase 0 decisions to freeze
+
+The following decisions are made and signed before any formal run. "TBD" values
+are a deliberate gap, not a post-hoc choice.
+
+| Decision | Value | Owner |
+| --- | --- | --- |
+| Requirement-to-scenario scope mapping and explicit exclusions | TBD | UK use-case owner |
+| KPI acceptance thresholds (from roadmap §5) | TBD | UK use-case owner |
+| Pilot duration and reporting window | TBD | UK use-case owner |
+| Number and types of pilot devices | TBD | Demonstrator operator |
+| Telemetry collection interval | TBD (real agent default 30 s) | Demonstrator operator |
+| Reporting timezone | `UTC` (fixed) | Data analyst |
+| Exclusions and their reasons | TBD (recorded before the run) | Data analyst |
+| Scenario scripts and fault catalogue | Frozen | Demonstrator operator |
+| Endpoint eligibility rules | Frozen | Data analyst |
+| Reviewer rubric | Frozen | Evidence reviewer |
+
+**Exit gate:** no KPI remains ambiguous about formula, population, window,
+provenance, or acceptance rule (roadmap §7 Phase 0).
+
+## 4. Operational protocol
+
+### 4.1 Before each run
+
+1. Confirm the frozen decisions in §3 are signed and unchanged.
+2. Deploy versioned agent and demonstrator builds; record deployment versions
+   in `environment.json`.
+3. Seed only setup data, labelled `SIMULATED` (roadmap §3.1).
+4. Verify clocks (device vs server), IDs, and expected sample counts.
+5. Freeze the reporting window; record `start`/`end` in `manifest.json`.
+
+### 4.2 During each run
+
+1. Execute scenarios exactly as approved (UK-E01 to UK-E07, roadmap §6).
+2. Record planned downtime and every operator intervention in the scenario log.
+3. Monitor evidence quality (EQ-01 coverage) **without changing thresholds**.
+4. Preserve raw logs and exports read-only at the end of each run.
+
+### 4.3 After each run
+
+1. Generate exports with the [KPI export](kpi-export.md) (API or
+   `homepot-client kpi-export`); do not transform results in spreadsheets.
+2. Record exclusions and their reasons; never delete raw evidence.
+3. Assemble the evidence bundle (§5) with the generated manifest.
+4. Request the independent evidence review (§7) before reporting.
+
+## 5. Evidence bundle
+
+One immutable bundle is stored per formal run (roadmap §8):
+
+```text
+evidence/uk-homepot/<run-id>/
+├── manifest.json
+├── protocol.md
+├── environment.json
+├── scenario-log.csv
+├── raw/
+├── exports/
+├── calculations/
+├── screenshots/
+├── reviewer-signoff.md
+└── limitations.md
+```
+
+| Item | Contents |
+| --- | --- |
+| `manifest.json` | Run ID, protocol version, Git commit, deployment versions, window, timezone, sites, devices, provenance, scenario IDs, file hashes, exclusions, operator/reviewer identities |
+| `protocol.md` | The frozen §3 decisions and §4 procedure for this run |
+| `environment.json` | Deployment versions, database snapshot identifier, device types/OS, network conditions |
+| `scenario-log.csv` | Scenario ID, preconditions, operator, start/end, expected events, result, interventions |
+| `raw/` | Raw evidence rows (metrics, state history, config history, commands) — read-only |
+| `exports/` | `kpi-export.json` or `kpi-summary.csv` from the KPI export |
+| `calculations/` | Calculation code revision (Git commit) and generated manifests |
+| `screenshots/` | Illustrative dashboard captures (do not replace machine-readable evidence) |
+| `reviewer-signoff.md` | Second-person review outcome (§7) and audit log of discrepancies |
+| `limitations.md` | Limitations, exclusions, and missing UK workflows (§8) |
+
+## 6. Data-quality gates
+
+An export is only accepted when its underlying evidence passes the gates:
+
+| Gate | Rule | Status today |
+| --- | --- | --- |
+| EQ-01 | Provenance coverage = rows with valid provenance / eligible rows × 100 | **Computed in every export**; acceptance 100% |
+| EQ-02 | Telemetry completeness | Defined; not yet computed; threshold TBD |
+| EQ-03 | Telemetry freshness | Defined; not yet computed; threshold TBD |
+| EQ-04 | Continuity | Defined; not yet computed; threshold TBD |
+| EQ-05 | Valid record rate | Defined; not yet computed; threshold TBD |
+
+No operational KPI receives a **Validated** label when its evidence fails the
+EQ-01 to EQ-05 gates. See [KPI export](kpi-export.md) §9 for the gate
+definition and current coverage.
+
+## 7. Reviewer rubric
+
+Apply the claim-maturity labels from roadmap §3.2 when deciding whether a claim
+is reportable:
+
+| Label | Minimum evidence |
+| --- | --- |
+| **Implemented** | Code path and automated tests exist |
+| **Demonstrated** | Scenario completed with `CONTROLLED` evidence |
+| **Pilot-observed** | Scenario or KPI observed on `REAL` devices, but the target sample or duration was not met |
+| **Validated** | Pre-agreed threshold met using the required `REAL` sample, duration, and evidence-quality gates |
+| **Not evaluated** | No adequate scenario, instrumentation, or evidence |
+
+The reviewer:
+
+1. regenerates every headline value from the export bundle and the manifest;
+2. triples-checks numerator, denominator, exclusions, and sample counts;
+3. triangulates results with the scenario log and operator observations;
+4. resolves every discrepancy in the audit log and records it in
+   `reviewer-signoff.md`.
+
+## 8. Limitations template
+
+Every report must state, at minimum:
+
+- which KPIs rely on **REAL** evidence and which are **CONTROLLED** or
+  **SIMULATED** rehearsal output;
+- any threshold still marked **TBD** (i.e. not frozen in Phase 0);
+- the evidence-quality gates that were **not** met and their effect on each
+  affected KPI;
+- excluded rows, their reasons, and any scenarios that could not be executed;
+- provenance caveats (for example command KPIs whose provenance is derived at
+  export time rather than snapshotted);
+- whether any **REAL** and **CONTROLLED**/**SIMULATED** values were combined in
+  a headline number (which is prohibited by roadmap §3.3).
+
+## 9. Final exit gate
+
+Every reported number must resolve to a manifest entry, raw evidence,
+calculation version, and review decision. Only then is the bundle eligible for
+the UK D2.3 section (roadmap §7 Phase 5).

--- a/docs/provenance-and-outcomes.md
+++ b/docs/provenance-and-outcomes.md
@@ -1,0 +1,121 @@
+# Evidence Recording: Provenance and Outcome Tracking
+
+## 1. Purpose
+
+This document defines how evidence provenance and command/configuration
+outcomes are recorded, so that exported KPI values (see
+[KPI export](kpi-export.md)) are traceable to the telemetry and events that
+produced them. It aligns the analytics telemetry documentation with the
+implemented schema and the [evaluation roadmap](KPI-evaluation-roadmap.md) §3.1
+provenance principles.
+
+## 2. Provenance classes
+
+Every exported row carries one of three lower-case provenance classes:
+
+| Class | Meaning |
+| --- | --- |
+| `real` | Produced by a physical pilot device or an authoritative POS/application integration |
+| `controlled` | Produced by a deterministic emulator or injected fault under a recorded test protocol |
+| `simulated` | Random or seeded demonstration data |
+
+`real`, `controlled`, and `simulated` results are never combined in one
+headline value (roadmap §3.3).
+
+## 3. Derivation and snapshot
+
+The class is derived **at write time** from the device record by
+`derive_provenance()` and snapshotted onto the row, so historical rows never
+silently inherit a later change to the device's classification. The derivation
+order is:
+
+1. `device.config["device_source"]`:
+   - `"emulator"` → `controlled`;
+   - `"simulation"` → `simulated`;
+   - `"physical"` → `real`;
+2. otherwise, if `device.is_simulated` → `simulated`;
+3. otherwise → `real`.
+
+When the device record is not available, `derive_provenance` returns `None` and
+no classification is stored, rather than a guessed one.
+
+### 3.1 Snapshotted columns
+
+| Table | Column | Notes |
+| --- | --- | --- |
+| `device_metrics` | `provenance` | Also snapshots `collection_interval_seconds` |
+| `device_state_history` | `provenance` | |
+| `configuration_history` | `provenance` | |
+| `job_outcomes` | `provenance` | Present in schema; outside the EQ-01 tables |
+| `error_logs` | `provenance` | Present in schema; outside the EQ-01 tables |
+| `device_commands` | — | No snapshotted provenance; scoped at export time |
+
+### 3.2 Collection metadata
+
+`device_metrics.collection_interval_seconds` records the interval the reporting
+agent was configured to use (the real agent sends this with every telemetry
+sample; its default is 30 seconds). It is the source for the EQ-02
+(completeness) gate, which is defined but not yet computed.
+
+### 3.3 Export-time scoping
+
+`device_commands` predates provenance snapshots, so command KPIs are scoped by
+re-deriving each device's class at export time from the current device record.
+This means a command's reported scope reflects the device's classification
+today rather than at command time — see the limitation in
+[KPI export](kpi-export.md) §10.
+
+## 4. Command outcome tracking
+
+`device_commands` records the full queue-to-execution lifecycle:
+
+| Field | Meaning |
+| --- | --- |
+| `command_id` | Unique command identifier (UUID) |
+| `command_type` | e.g. `restart`, `update_config`, `ping` |
+| `payload` | Command arguments (JSON) |
+| `status` | `pending`, `sent`, `completed`, `failed`, or `expired` |
+| `result` | Execution result (JSON) |
+| `created_at` | Queue time (server clock) |
+| `sent_at` | Stamped when the command is handed to the agent (polling contract) |
+| `executed_at` | Stamped when a terminal status is reported (server clock fallback) |
+
+Terminal statuses are `completed`, `failed`, and `expired`; these form the
+denominator of MW-01 and MW-02.
+
+The agent polls for pending commands (`GET /api/v1/devices/{id}/pending` or
+equivalent), acknowledges each one (stamping `sent_at`), executes it, and
+reports the terminal result (stamping `executed_at`). Commands still in flight
+remain `pending`/`sent` and are excluded from MW-01/MW-02 as non-terminal.
+
+## 5. Configuration outcome tracking
+
+`configuration_history` records configuration changes and their closed-loop
+outcome, including rollback:
+
+| Field | Meaning |
+| --- | --- |
+| `performance_before` | Metrics before the change (JSON) |
+| `performance_after` | Metrics after the change (JSON) |
+| `was_successful` | Whether the change achieved its result (`true`/`false`/null) |
+| `was_rolled_back` | Whether the change was reverted |
+| `rollback_reason` | Why it was rolled back |
+| `rollback_success` | Whether the rollback restored the baseline (`true`/`false`/null) |
+| `rollback_performance` | Metrics after the rollback (JSON) |
+| `rolled_back_at` | Timestamp of the rollback |
+| `provenance` | Snapshotted evidence class |
+
+These fields back MW-03 (`was_successful`), MW-04 (improvement using
+`performance_before`/`performance_after` and the healthy-status/response-time
+rule), and MW-05 (restoring rollbacks using `rollback_success` or
+`performance_before` vs `rollback_performance`).
+
+## 6. Relationship to KPI calculations
+
+The recorded rows are consumed by the [KPI export](kpi-export.md):
+
+- `device_metrics` → EQ-01 (provenance coverage) and PF-LAT (latency
+  percentiles);
+- `device_state_history` → EQ-01;
+- `configuration_history` → EQ-01, MW-03, MW-04, MW-05;
+- `device_commands` → MW-01, MW-02.

--- a/docs/real-device-agent.md
+++ b/docs/real-device-agent.md
@@ -1,41 +1,72 @@
 # Real Device Agent
 
-The `homepot.agent` module is the backend-facing scaffold for a future real-device
-agent integration. It currently provides:
+The `homepot.agent` module is the backend-facing runtime for a real device
+(GetFudo POS terminal). The agent registers with the backend, streams telemetry,
+reports heartbeats, polls and executes approved commands, and retries failed
+submissions.
 
-- `POST /api/v1/agent/register` for pre-authorized device registration checks.
-- `homepot.agent.utils.device_dna` helpers that gather basic host identity data.
-- `homepot.agent.real_device_agent` as a starter config-loading entrypoint for the
-  GetFudo implementation team.
+## Registration and authentication
 
-## Authentication strategy
+- `POST /api/v1/agent/register` performs a pre-authorized registration check.
+  The `/register` endpoint validates `device_id` against an existing `Device`
+  record, `api_key` against the stored `Device.api_key_hash`, and `site_id`
+  against the site already associated with that device.
+- Subsequent authenticated requests use credentials from the agent configuration.
+- `homepot.agent.utils.device_dna` gathers host identity data used during
+  registration and reporting.
 
-Device registration is intentionally limited to pre-seeded devices. The
-`/register` endpoint validates:
+## Runtime loops
 
-- `device_id` against an existing `Device` record.
-- `api_key` against the stored `Device.api_key_hash`.
-- `site_id` against the site already associated with that device.
+`real_device_agent.py` (`run_agent`) runs several concurrent loops:
 
-This keeps registration aligned with the existing device authentication model
-used by other device-facing APIs in the backend.
+| Loop | Purpose |
+| --- | --- |
+| `telemetry_loop` | Sends device metrics to `POST /api/v1/agent/telemetry` on `telemetry_interval_seconds` (default 30 s) |
+| `heartbeat_loop` | Reports agent liveness |
+| `pending_commands_loop` | Polls for pending commands and acknowledges each one (`sent_at`) |
+| `command_result_loop` | Reports terminal command results (`executed_at`) |
+| `retry_flush_loop` | Flushes failed submissions with exponential backoff |
+| `_watchdog_loop` | Local watchdog supervision |
+
+### Telemetry payload
+
+The telemetry loop sends:
+
+```json
+{
+  "device_id": "android-pos-001",
+  "site_id": "site-1234",
+  "cpu_usage": 20.1,
+  "memory_usage": 55.4,
+  "disk_usage": 44.8,
+  "uptime_seconds": 86400,
+  "network_latency_ms": 8.4,
+  "collection_interval_seconds": 30,
+  "timestamp": "2026-04-13T12:00:30Z"
+}
+```
+
+- `network_latency_ms` comes from `measure_network_latency_ms` and backs the
+  PF-LAT KPI.
+- `uptime_seconds` and `collection_interval_seconds` support PF-04 and EQ-02.
+- A `pos` block is included only when `pos_signals_source` is configured; it is
+  gated so unverified POS signals cannot be presented as pilot evidence.
 
 ## External WAN IP dependency
 
 `device_dna.py` currently uses public IP discovery services to determine WAN IP
-information. The current implementation tries these providers in order and
-returns the first successful response:
+information, trying these providers in order:
 
 - `https://api.ipify.org`
 - `https://ifconfig.me/ip`
 - `https://icanhazip.com`
 
-This is still an external dependency and should be treated as best-effort
-metadata collection rather than a hard requirement for agent registration.
+This is a best-effort external dependency for metadata collection, not a hard
+requirement for agent registration.
 
-## Current scope
+## Evidence recording
 
-The agent runtime in `real_device_agent.py` is a placeholder by design. It is
-meant to provide a small, documented starting point while the full production
-agent lifecycle, command polling, telemetry, and deployment workflow are built
-in a separate implementation phase.
+Telemetry and events produced by the agent are recorded with provenance
+snapshotted at write time (`real`, `controlled`, or `simulated`). See
+[Evidence Recording](provenance-and-outcomes.md) for the derivation rules and
+the command/configuration outcome fields.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,9 @@ nav:
       - Product Vision: product-vision.md
       - Compliance Matrix: architecture-compliance-matrix.md
       - UK KPI Evaluation Roadmap: KPI-evaluation-roadmap.md
+      - KPI Export & Calculations: kpi-export.md
+      - Pilot Operator Protocol: operator-protocol.md
+      - Evidence Recording: provenance-and-outcomes.md
       - Getting Started:
           - Quick Start: getting-started.md
           - Running Locally: running-locally.md
@@ -171,6 +174,7 @@ nav:
           - Device Emulators: device-emulators.md
           - Agent Packaging & Identity: agent-packaging-and-identity.md
           - Fleet Load Testing: fleet-simulation.md
+          - Real Device Agent: real-device-agent.md
           - Real Device Transition: real-device-transition.md
           - Team Tasks (Readiness): real-device-readiness-tasks.md
 


### PR DESCRIPTION
Fixes #293 PR 7 of the roadmap PR sequence.

Delivers 'stable definitions, units, limitations, and operator protocol' for the UK demonstrator analytics/telemetry work implemented in PRs 1-6.

## New docs (registered in mkdocs nav)
- `docs/kpi-export.md` — stable KPI register (EQ-01, MW-01..MW-05, PF-LAT) with formulas, units, populations, percentile definition, provenance scoping, JSON/CSV formats, manifest contract, API + CLI usage, data-quality gates, and limitations.
- `docs/operator-protocol.md` — Phase 0 decisions to freeze, operator procedure, evidence-bundle contents, reviewer rubric, and limitations template.
- `docs/provenance-and-outcomes.md` — `derive_provenance()` semantics, snapshotted columns, collection metadata, and command/configuration outcome tracking.

## Updated docs (aligned with implemented code)
- `docs/KPI-evaluation-roadmap.md` — flipped 'Partial/Missing' baseline rows to Implemented, added status to Phase 1/PR-sequence tables, marked delivered Phase 2 export and completion-checklist items, linked new docs.
- `docs/analytics-data-collection.md` — added `provenance`/`collection_interval_seconds` (device_metrics) and `rollback_success`/`rollback_performance`/`rolled_back_at`/`provenance` (configuration_history); fixed duplicated intro, a broken code fence, and a duplicated 'User Activities' section.
- `docs/backend-analytics.md` — added provenance to model docs, corrected snapshot interval, marked Data Export delivered.
- `docs/database-metrics-validation.md` — added new columns to the three schema tables.
- `docs/real-device-agent.md` — rewrote to document the real agent's telemetry/command loops (was a placeholder description).
- `mkdocs.yml` — registered the new docs under Project Info and real-device-agent under Agents & Simulation.

Verified locally with `mkdocs build --strict` (passes).