### PR TITLE
fix: make KPI export work on PostgreSQL and add run ID + evidence directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,6 +182,8 @@ temp/
 tmp/
 logs/*
 !logs/README.md
+kpi-evidence/*
+!kpi-evidence/README.md
 
 # PostgreSQL - Database managed by system service
 # Database location: /var/lib/postgresql/16/main/

--- a/backend/src/homepot/cli.py
+++ b/backend/src/homepot/cli.py
@@ -82,7 +82,13 @@ def kpi_export(
     provenance: Optional[str] = typer.Option(
         None, help="Restrict to a provenance class (real/controlled/simulated)"
     ),
-    out_dir: str = typer.Option(".", help="Directory to write the export into"),
+    run_id: Optional[str] = typer.Option(
+        None, help="Run ID (default: UTC timestamp, e.g. 20260816T220500Z)"
+    ),
+    out_dir: Optional[str] = typer.Option(
+        None,
+        help="Directory to write the export into (default: kpi-evidence/<run-id>)",
+    ),
     format: str = typer.Option(
         "json", "--format", help="json (bundle) or csv (KPI summary)"
     ),
@@ -90,7 +96,7 @@ def kpi_export(
     """Export a versioned, filtered UK demonstrator KPI calculation.
 
     Writes ``kpi-export.json`` (manifest + KPI summary + raw evidence) or
-    ``kpi-summary.csv`` into ``--out-dir``.
+    ``kpi-summary.csv`` into ``--out-dir`` (default ``kpi-evidence/<run-id>``).
     """
     if provenance is not None and provenance not in PROVENANCE_CLASSES:
         raise typer.BadParameter(
@@ -118,11 +124,15 @@ def kpi_export(
         db_service = await get_database_service()
         try:
             async with db_service.get_session() as session:
-                return await compute_kpi_bundle(session, filters)
+                return await compute_kpi_bundle(session, filters, run_id=run_id)
         finally:
             await db_service.close()
 
     bundle = asyncio.run(_run())
+
+    run_id_used = bundle.manifest["run_id"]
+    if out_dir is None:
+        out_dir = f"kpi-evidence/{run_id_used}"
 
     target = Path(out_dir)
     target.mkdir(parents=True, exist_ok=True)
@@ -139,6 +149,7 @@ def kpi_export(
     console.print(
         Panel(
             f"Exported {len(bundle.kpis)} KPI results to [green]{path}[/green]\n"
+            f"run_id: {bundle.manifest.get('run_id')}\n"
             f"calculation_version: {bundle.manifest.get('calculation_version')}\n"
             f"git_commit: {bundle.manifest.get('git_commit')}",
             title="KPI Export",

--- a/backend/src/homepot/kpi/calculator.py
+++ b/backend/src/homepot/kpi/calculator.py
@@ -38,15 +38,32 @@ _NAIVE = ""
 def _to_utc(dt: Any) -> Optional[datetime]:
     """Normalize a timestamp to an aware UTC datetime.
 
-    The analytics tables store naive UTC timestamps; existing endpoints compare
-    them against aware UTC values on SQLite, so this helper keeps window
-    comparisons consistent with that convention.
+    Used for ``device_commands`` timestamps, which are stored as
+    ``TIMESTAMP WITH TIME ZONE`` and therefore require aware comparison values.
     """
     if dt is None:
         return None
     if dt.tzinfo is None:
         return cast(datetime, dt.replace(tzinfo=timezone.utc))
     return cast(datetime, dt.astimezone(timezone.utc))
+
+
+def _to_naive_utc(dt: Any) -> Optional[datetime]:
+    """Normalize a timestamp to a NAIVE UTC datetime.
+
+    The analytics tables (``device_metrics``, ``device_state_history``,
+    ``configuration_history``) store naive UTC timestamps
+    (``TIMESTAMP WITHOUT TIME ZONE``). asyncpg rejects aware datetime
+    parameters against such columns ("can't subtract offset-naive and
+    offset-aware datetimes"), so window comparisons against those tables must
+    use naive UTC values. SQLite tolerates either, which is why the tests did
+    not catch this on the PostgreSQL path.
+    """
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return cast(datetime, dt)
+    return cast(datetime, dt.astimezone(timezone.utc).replace(tzinfo=None))
 
 
 def percentile(values: List[float], q: float) -> Optional[float]:
@@ -155,8 +172,8 @@ def _config_scope(
     device_id_strings: List[str],
 ) -> Select[tuple[ConfigurationHistory]]:
     """Apply window/device/provenance filters to a ConfigurationHistory query."""
-    start = _to_utc(filters.start)
-    end = _to_utc(filters.end)
+    start = _to_naive_utc(filters.start)
+    end = _to_naive_utc(filters.end)
     stmt = stmt.where(
         ConfigurationHistory.timestamp >= start,
         ConfigurationHistory.timestamp <= end,
@@ -355,8 +372,8 @@ async def compute_provenance_coverage(
     device_id_strings: List[str],
 ) -> List[KPIResult]:
     """EQ-01 provenance coverage = rows with valid provenance / eligible rows × 100."""
-    start = _to_utc(filters.start)
-    end = _to_utc(filters.end)
+    start = _to_naive_utc(filters.start)
+    end = _to_naive_utc(filters.end)
     results: List[KPIResult] = []
 
     definitions = [
@@ -446,8 +463,8 @@ async def compute_metric_network_latency(
     session: AsyncSession, filters: ExportFilters, pk_ids: List[int]
 ) -> List[KPIResult]:
     """PF-LAT device-reported network latency p50/p95/max from device_metrics."""
-    start = _to_utc(filters.start)
-    end = _to_utc(filters.end)
+    start = _to_naive_utc(filters.start)
+    end = _to_naive_utc(filters.end)
     stmt = select(DeviceMetrics).where(
         DeviceMetrics.timestamp >= start,
         DeviceMetrics.timestamp <= end,

--- a/backend/src/homepot/kpi/export.py
+++ b/backend/src/homepot/kpi/export.py
@@ -25,7 +25,7 @@ from homepot.kpi.calculator import (
     compute_rollback_effectiveness,
     compute_verified_improvement_rate,
 )
-from homepot.kpi.manifest import build_manifest
+from homepot.kpi.manifest import build_manifest, generate_run_id
 from homepot.kpi.models import ExportFilters, KPIExportBundle, KPIResult, RawTable
 from homepot.models import CommandStatus, DeviceCommand
 
@@ -236,9 +236,11 @@ async def _extract_raw(
 
 
 async def compute_kpi_bundle(
-    session: AsyncSession, filters: ExportFilters
+    session: AsyncSession, filters: ExportFilters, run_id: Optional[str] = None
 ) -> KPIExportBundle:
     """Compute every in-scope KPI and assemble a versioned export bundle."""
+    if run_id is None:
+        run_id = generate_run_id()
     pk_ids, device_id_strings = await _resolve_devices(session, filters)
     provenance_pks = await _provenance_device_pks(session)
 
@@ -285,7 +287,7 @@ async def compute_kpi_bundle(
     raw = await _extract_raw(
         session, filters, pk_ids, device_id_strings, provenance_pks
     )
-    manifest = build_manifest(filters, scopes)
+    manifest = build_manifest(filters, scopes, run_id)
     return KPIExportBundle(manifest=manifest, kpis=kpis, raw=raw)
 
 

--- a/backend/src/homepot/kpi/export.py
+++ b/backend/src/homepot/kpi/export.py
@@ -48,6 +48,20 @@ def _to_utc(dt: Any) -> Optional[datetime]:
     return cast(datetime, dt.astimezone(timezone.utc))
 
 
+def _to_naive_utc(dt: Any) -> Optional[datetime]:
+    """Normalize a timestamp to a NAIVE UTC datetime for analytics tables.
+
+    See ``homepot.kpi.calculator._to_naive_utc``: the analytics tables store
+    naive ``TIMESTAMP WITHOUT TIME ZONE`` values, so asyncpg requires naive
+    comparison parameters.
+    """
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return cast(datetime, dt)
+    return cast(datetime, dt.astimezone(timezone.utc).replace(tzinfo=None))
+
+
 async def _extract_raw(
     session: AsyncSession,
     filters: ExportFilters,
@@ -56,8 +70,10 @@ async def _extract_raw(
     provenance_pks: Dict[str, set],
 ) -> List[RawTable]:
     """Extract in-window raw evidence rows for the export bundle."""
-    start = _to_utc(filters.start)
-    end = _to_utc(filters.end)
+    start = _to_naive_utc(filters.start)
+    end = _to_naive_utc(filters.end)
+    command_start = _to_utc(filters.start)
+    command_end = _to_utc(filters.end)
     raw: List[RawTable] = []
 
     metrics_stmt = select(DeviceMetrics).where(
@@ -177,7 +193,8 @@ async def _extract_raw(
         for device_id in pks
     }
     command_stmt = select(DeviceCommand).where(
-        DeviceCommand.created_at >= start, DeviceCommand.created_at <= end
+        DeviceCommand.created_at >= command_start,
+        DeviceCommand.created_at <= command_end,
     )
     if filters.provenance is not None:
         scope_pks = provenance_pks.get(filters.provenance, set())

--- a/backend/src/homepot/kpi/manifest.py
+++ b/backend/src/homepot/kpi/manifest.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timezone
 import logging
 import subprocess  # noqa: S404 - fixed argv; reads a local Git revision only
+from typing import Optional
 
 from homepot.kpi.models import ExportFilters
 
@@ -43,13 +44,28 @@ def get_git_commit() -> str:
     return "unknown"
 
 
-def build_manifest(filters: ExportFilters, provenance_scopes: list[str]) -> dict:
+def generate_run_id(dt: Optional[datetime] = None) -> str:
+    """Generate a UTC timestamp run ID (e.g. ``20260816T220500Z``).
+
+    Used to name the evidence directory and pin every export to a unique,
+    sortable run identifier. Callers may pass an explicit ``dt`` for
+    deterministic tests.
+    """
+    moment = dt if dt is not None else datetime.now(timezone.utc)
+    return moment.strftime("%Y%m%dT%H%M%SZ")
+
+
+def build_manifest(
+    filters: ExportFilters, provenance_scopes: list[str], run_id: str
+) -> dict:
     """Build the export manifest dict.
 
-    Includes the window, filters, timezone, calculation version, Git commit,
-    and generation timestamp so every value resolves to a reproducible run.
+    Includes the run ID, window, filters, timezone, calculation version, Git
+    commit, and generation timestamp so every value resolves to a reproducible
+    run.
     """
     return {
+        "run_id": run_id,
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "timezone": REPORT_TIMEZONE,
         "calculation_version": KPI_CALCULATION_VERSION,

--- a/backend/tests/test_kpi_export.py
+++ b/backend/tests/test_kpi_export.py
@@ -312,10 +312,11 @@ def test_export_empty_window(client: TestClient) -> None:
 
 
 def test_manifest_metadata(client: TestClient) -> None:
-    """The manifest carries version, commit, timezone, and window metadata."""
+    """The manifest carries run ID, version, commit, timezone, and window metadata."""
     bundle = _export(client)
 
     manifest = bundle["manifest"]
+    assert manifest["run_id"]
     assert manifest["timezone"] == "UTC"
     assert manifest["calculation_version"]
     assert manifest["generated_at"]

--- a/docs/kpi-evaluation-roadmap.md
+++ b/docs/kpi-evaluation-roadmap.md
@@ -194,7 +194,7 @@ UK-E08 is blocked until the UK partner confirms the external system, event contr
 
 ### Phase 2 — Build Reproducible KPI Calculations
 
-Delivered as `GET /api/v1/kpi/export` and `homepot-client kpi-export`. The
+Delivered as `GET /api/v1/kpi/export` and `./scripts/kpi-export.sh`. The
 versioned export supports:
 
 - `start`, `end`, `site_id`, `device_id`, `device_type`, and provenance filters;
@@ -251,13 +251,13 @@ During the frozen pilot window:
 Store one immutable bundle per formal run:
 
 ```text
-evidence/uk-homepot/<run-id>/
+kpi-evidence/<run-id>/
+├── kpi-export.json
 ├── manifest.json
 ├── protocol.md
 ├── environment.json
 ├── scenario-log.csv
 ├── raw/
-├── exports/
 ├── calculations/
 ├── screenshots/
 ├── reviewer-signoff.md

--- a/docs/kpi-export.md
+++ b/docs/kpi-export.md
@@ -191,6 +191,7 @@ Every export includes the following metadata:
 
 | Field | Meaning |
 | --- | --- |
+| `run_id` | Unique run identifier (UTC timestamp, e.g. `20260816T220500Z`; overridable via `--run-id`) |
 | `generated_at` | Generation timestamp, UTC ISO-8601 |
 | `timezone` | Reporting timezone (`UTC`) |
 | `calculation_version` | Calculation code version (`1.0.0`) |
@@ -228,18 +229,27 @@ curl -H "Authorization: Bearer $TOKEN" \
 
 ### 7.2 Command-line tool
 
+Run from the repository root:
+
 ```bash
-homepot-client kpi-export \
+./scripts/kpi-export.sh \
   --start 2026-08-01T00:00:00Z \
   --end 2026-08-14T23:59:59Z \
-  --provenance real \
-  --out-dir evidence/uk-homepot/demo-run/exports
+  --provenance real
 ```
 
-Options mirror the API (`--site-id`, `--device-id`, `--device-type`,
-`--provenance`, `--format json|csv`, `--out-dir`). It writes
-`kpi-export.json` (bundle) or `kpi-summary.csv` (summary) into `--out-dir`
-and prints the calculation version and Git commit on completion.
+`scripts/kpi-export.sh` resolves the venv and database URL so the command works
+from the repo root; when the venv is active, `homepot-client kpi-export ...` is
+equivalent. Options mirror the API (`--site-id`, `--device-id`, `--device-type`,
+`--provenance`, `--run-id`, `--format json|csv`, `--out-dir`). It writes
+`kpi-export.json` (bundle) or `kpi-summary.csv` (summary) and prints the run ID,
+calculation version, and Git commit on completion.
+
+The default `--out-dir` is `kpi-evidence/<run-id>`, where `<run-id>` is a UTC
+timestamp generated per run (override with `--run-id`, e.g.
+`UK-E01-rehearsal-1`). `kpi-evidence/` is a repository-root directory that is
+gitignored except for its `README.md`, mirroring `logs/`. Pass an explicit
+`--out-dir` to write elsewhere. See `kpi-evidence/README.md`.
 
 ## 8. Reproducibility requirements
 

--- a/docs/operator-protocol.md
+++ b/docs/operator-protocol.md
@@ -64,7 +64,7 @@ provenance, or acceptance rule (roadmap §7 Phase 0).
 ### 4.3 After each run
 
 1. Generate exports with the [KPI export](kpi-export.md) (API or
-   `homepot-client kpi-export`); do not transform results in spreadsheets.
+   `./scripts/kpi-export.sh`); do not transform results in spreadsheets.
 2. Record exclusions and their reasons; never delete raw evidence.
 3. Assemble the evidence bundle (§5) with the generated manifest.
 4. Request the independent evidence review (§7) before reporting.
@@ -74,13 +74,13 @@ provenance, or acceptance rule (roadmap §7 Phase 0).
 One immutable bundle is stored per formal run (roadmap §8):
 
 ```text
-evidence/uk-homepot/<run-id>/
+kpi-evidence/<run-id>/
+├── kpi-export.json
 ├── manifest.json
 ├── protocol.md
 ├── environment.json
 ├── scenario-log.csv
 ├── raw/
-├── exports/
 ├── calculations/
 ├── screenshots/
 ├── reviewer-signoff.md
@@ -94,7 +94,7 @@ evidence/uk-homepot/<run-id>/
 | `environment.json` | Deployment versions, database snapshot identifier, device types/OS, network conditions |
 | `scenario-log.csv` | Scenario ID, preconditions, operator, start/end, expected events, result, interventions |
 | `raw/` | Raw evidence rows (metrics, state history, config history, commands) — read-only |
-| `exports/` | `kpi-export.json` or `kpi-summary.csv` from the KPI export |
+| `kpi-export.json` | Versioned KPI export bundle (or `kpi-summary.csv` with `--format csv`) from the KPI export |
 | `calculations/` | Calculation code revision (Git commit) and generated manifests |
 | `screenshots/` | Illustrative dashboard captures (do not replace machine-readable evidence) |
 | `reviewer-signoff.md` | Second-person review outcome (§7) and audit log of discrepancies |

--- a/kpi-evidence/README.md
+++ b/kpi-evidence/README.md
@@ -1,0 +1,41 @@
+# UK Demonstrator KPI Evidence
+
+This directory holds versioned KPI export bundles produced by the UK
+demonstrator calculation (`backend/src/homepot/kpi/`). The contents are
+**generated** and the directory is listed in `.gitignore` (only this
+`README.md` is tracked), mirroring the `logs/` convention.
+
+## Generating an export
+
+From the repository root:
+
+```bash
+./scripts/kpi-export.sh \
+  --start 2026-08-01T00:00:00Z \
+  --end 2026-08-31T23:59:59Z
+```
+
+The wrapper resolves the venv and the database URL so it works from the repo
+root without activating a virtualenv. When the venv is active you can call the
+CLI directly: `homepot-client kpi-export ...`.
+
+Each run writes a self-contained directory named by its **run ID** (a UTC
+timestamp, e.g. `20260816T220500Z`, or an explicit `--run-id`):
+
+```
+kpi-evidence/
+└── <run-id>/
+    ├── kpi-export.json   # manifest + kpis + raw evidence
+    └── kpi-summary.csv   # machine-readable KPI summary (--format csv)
+```
+
+Pass `--out-dir` to write elsewhere.
+
+## Reproducibility
+
+Every export records its `calculation_version`, `git_commit`, reporting
+timezone (`UTC`), filters, and the raw evidence rows backing each value, so a
+reviewer can pin any number to an exact code revision and data snapshot.
+
+See [docs/kpi-export.md](../docs/kpi-export.md) for the full register of KPIs,
+their formulas, units, and the manifest contract.

--- a/scripts/kpi-export.sh
+++ b/scripts/kpi-export.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# kpi-export.sh — run the versioned UK demonstrator KPI export from the repo
+# root. Writes into kpi-evidence/ by default (gitignored, see
+# kpi-evidence/README.md).
+#
+# Usage: ./scripts/kpi-export.sh --start <ISO> --end <ISO> [--out-dir DIR] [...]
+set -euo pipefail
+
+# Run from the repo root regardless of the caller's cwd.
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Resolve the venv python (same pattern as init-postgresql.sh).
+if [ -f ".venv/bin/python3" ]; then
+    PYTHON=".venv/bin/python3"
+elif [ -f "backend/.venv/bin/python3" ]; then
+    PYTHON="backend/.venv/bin/python3"
+else
+    PYTHON="python3"
+fi
+
+# Load the database URL from backend/.env when the caller has not provided one
+# (pydantic-settings only auto-loads ".env" from the current working directory).
+if [ -z "${DATABASE__URL:-}" ] && [ -z "${DATABASE_URL:-}" ] && [ -f "backend/.env" ]; then
+    DB_URL="$(grep -E '^DATABASE__URL=' backend/.env | head -1 | cut -d= -f2-)"
+    if [ -n "$DB_URL" ]; then
+        export DATABASE__URL="$DB_URL"
+    fi
+fi
+
+PYTHONPATH=backend/src "$PYTHON" -m homepot.cli kpi-export "$@"


### PR DESCRIPTION
Two fixes for the UK demonstrator KPI export, discovered while running it against PostgreSQL.

## 1. `fix: make KPI export work on PostgreSQL`

The export 500'd against PostgreSQL with:

```
asyncpg DataError: can't subtract offset-naive and offset-aware datetimes
```

`_to_utc()` returned **aware** datetimes, but the analytics tables (`device_metrics`, `device_state_history`, `configuration_history`) store **naive** `TIMESTAMP WITHOUT TIME ZONE`. SQLite tolerates the mismatch (why all 28 tests passed), PostgreSQL does not. Added `_to_naive_utc()` for the analytics-table window filters while keeping `_to_utc()` for `device_commands` (stored as `TIMESTAMP WITH TIME ZONE`).

## 2. `feat: add run ID and kpi-evidence directory to KPI export`

The docs referenced a `<run-id>` concept (`operator-protocol.md`, `kpi-evaluation-roadmap.md`) that the code never implemented, and the evidence directory didn't exist. Now:

- **`manifest.py`**: `generate_run_id()` (UTC timestamp, e.g. `20260816T211427Z`) + `run_id` field in the manifest.
- **`export.py`**: `compute_kpi_bundle` accepts an optional `run_id`.
- **`cli.py`**: `--run-id` option; `--out-dir` defaults to `kpi-evidence/<run-id>/`.
- **`scripts/kpi-export.sh`**: run the export from the repo root (resolves venv + DB URL).
- **`kpi-evidence/`**: gitignored evidence directory with a README (mirrors `logs/`).
- **docs**: aligned evidence-directory and command references across `kpi-export.md`, `operator-protocol.md`, `kpi-evaluation-roadmap.md`.
- **test**: `test_manifest_metadata` asserts the manifest carries a `run_id`.

## Verification

- 28 KPI tests pass; mypy + flake8 clean.
- Export runs end-to-end against PostgreSQL: 37 KPI results, provenance correctly scoped (`real`/`controlled`/`simulated`).
- `./scripts/kpi-export.sh --start ... --end ...` → `kpi-evidence/20260816T211427Z/kpi-export.json`.
- `--run-id UK-E01-rehearsal-1` → `kpi-evidence/UK-E01-rehearsal-1/kpi-summary.csv`.
