### PR TITLE
fix: KPI evidence provenance and command round-trip timezone

### DIFF
--- a/backend/src/homepot/app/api/API_v1/Endpoints/DeviceCommandsEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DeviceCommandsEndpoint.py
@@ -235,7 +235,10 @@ async def update_command_status(
 
     executed_at = None
     if request.executed_at is not None:
-        executed_at = request.executed_at.astimezone(timezone.utc).replace(tzinfo=None)
+        # device_commands.executed_at is a TIMESTAMP WITH TIME ZONE column;
+        # store the aware UTC value so it does not get shifted by the server
+        # session timezone (which previously produced negative round-trip times).
+        executed_at = request.executed_at.astimezone(timezone.utc)
 
     updated_command = await db.update_command_status(
         command_id=command_id,

--- a/backend/utils/seed_data.py
+++ b/backend/utils/seed_data.py
@@ -67,6 +67,7 @@ from homepot.models import (
     LifecycleState,
     Site,
     User,
+    derive_provenance,
 )
 from homepot.seed_factories import (
     create_audit_log,
@@ -98,7 +99,9 @@ from sqlalchemy import select, text
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
-def generate_historical_metrics(device_id: int, hours: int = 24) -> list[DeviceMetrics]:
+def generate_historical_metrics(
+    device_id: int, hours: int = 24, provenance: str | None = None
+) -> list[DeviceMetrics]:
     """Generate historical metrics for a device."""
     metrics = []
     now = datetime.now(timezone.utc).replace(tzinfo=None)
@@ -133,6 +136,7 @@ def generate_historical_metrics(device_id: int, hours: int = 24) -> list[DeviceM
                 queue_depth=int(trans_count / 50),
                 timestamp=timestamp,
                 extra_metrics={"temperature_celsius": round(random.uniform(35, 55), 1)},
+                provenance=provenance,
             )
         )
     return metrics
@@ -200,7 +204,9 @@ def generate_historical_user_activity(
     return activities
 
 
-def generate_problematic_metrics(device_id: int) -> list[DeviceMetrics]:
+def generate_problematic_metrics(
+    device_id: int, provenance: str | None = None
+) -> list[DeviceMetrics]:
     """Generate recent metrics that justify the active alerts (High CPU)."""
     metrics = []
     now = datetime.now(timezone.utc).replace(tzinfo=None)
@@ -217,6 +223,7 @@ def generate_problematic_metrics(device_id: int) -> list[DeviceMetrics]:
                 network_latency_ms=round(random.uniform(20.0, 50.0), 2),
                 transaction_count=random.randint(0, 5),
                 timestamp=timestamp,
+                provenance=provenance,
             )
         )
     return metrics
@@ -748,6 +755,11 @@ async def init_database():
         result = await session.execute(select(Device).limit(1))
         first_device = result.scalar_one()
 
+        # Derive the provenance class once so every seeded analytics row
+        # carries a valid provenance snapshot (EQ-01 coverage).
+        first_device_prov = derive_provenance(first_device)
+        prov = first_device_prov.value if first_device_prov else None
+
         # Sample Job
         result = await session.execute(
             select(Job).where(Job.job_id == "job-sample-001")
@@ -822,6 +834,7 @@ async def init_database():
                     new_state="online",
                     changed_by="system",
                     reason="Device came online after reboot",
+                    provenance=prov,
                 )
             )
 
@@ -851,7 +864,9 @@ async def init_database():
             )
 
             # Generate historical metrics
-            historical_metrics = generate_historical_metrics(first_device.id)
+            historical_metrics = generate_historical_metrics(
+                first_device.id, provenance=prov
+            )
             session.add_all(historical_metrics)
 
             # Generate historical errors
@@ -869,7 +884,7 @@ async def init_database():
             session.add_all(active_alerts)
 
             # 2. Add the supporting data (High CPU metrics)
-            problem_metrics = generate_problematic_metrics(first_device.id)
+            problem_metrics = generate_problematic_metrics(first_device.id, provenance=prov)
             session.add_all(problem_metrics)
 
             # Generate historical user activity
@@ -886,10 +901,11 @@ async def init_database():
                     changed_by=str(admin_user.id),
                     change_reason="Increased load during peak hours",
                     change_type="manual",
-                    performance_before={"avg_response_time": 145, "error_rate": 1.2},
-                    performance_after={"avg_response_time": 98, "error_rate": 0.3},
+                    performance_before={"status": "degraded", "response_time_ms": 145},
+                    performance_after={"status": "healthy", "response_time_ms": 98},
                     was_successful=True,
                     was_rolled_back=False,
+                    provenance=prov,
                     timestamp=datetime.now(timezone.utc).replace(tzinfo=None)
                     - timedelta(hours=2),
                 )


### PR DESCRIPTION
Two fixes surfaced while inspecting the generated KPI evidence against PostgreSQL.

## 1. `fix: store command executed_at as timezone-aware`

`device_commands.executed_at` is a `TIMESTAMP WITH TIME ZONE` column, but the status endpoint (`DeviceCommandsEndpoint.py`) stripped the timezone before storing. Postgres then interpreted the naive value in the server session timezone (`Europe/London`), shifting it back an hour — so `executed_at < created_at` and MW-02 round-trip time reported **negative** (−3595s).

Verified end-to-end: a fresh `ping` command now reports `+5.27s` round-trip.

## 2. `fix: tag seed data with provenance and standard performance fields`

`seed_data.py` wrote `device_metrics`, `device_state_history`, and `configuration_history` rows **without** a `provenance` snapshot, so EQ-01 coverage was below 100% (39 null metric rows, 1 null state-history row, 1 null config row). It also used non-standard performance fields (`avg_response_time`/`error_rate`) that `_is_improved` does not recognise, so the seeded config change was never counted as improved (MW-04 = 80% instead of 100%).

Now the device provenance is derived once and stamped on every seeded analytics row, and the sample config uses `status`/`response_time_ms`.

Verified after a fresh `init-postgresql.sh` run: 0 NULL-provenance rows across `device_metrics`, `device_state_history`, and `configuration_history`, and the config row carries `{"status": "healthy", "response_time_ms": 98}`.

## Notes

- 28 KPI tests still pass.
- Works alongside PR #299 (the Postgres datetime fix); together they make EQ-01 report 100% and MW-04 report 100% in a fresh export.
