### PR TITLE
fix: KPI export CLI output (UTF-8 + write both JSON and CSV)

### DIFF
--- a/backend/src/homepot/cli.py
+++ b/backend/src/homepot/cli.py
@@ -142,7 +142,7 @@ def kpi_export(
     else:
         path = target / "kpi-export.json"
         path.write_text(
-            json.dumps(bundle.model_dump(mode="json"), indent=2),
+            json.dumps(bundle.model_dump(mode="json"), indent=2, ensure_ascii=False),
             encoding="utf-8",
         )
 

--- a/backend/src/homepot/cli.py
+++ b/backend/src/homepot/cli.py
@@ -89,21 +89,17 @@ def kpi_export(
         None,
         help="Directory to write the export into (default: kpi-evidence/<run-id>)",
     ),
-    format: str = typer.Option(
-        "json", "--format", help="json (bundle) or csv (KPI summary)"
-    ),
 ) -> None:
     """Export a versioned, filtered UK demonstrator KPI calculation.
 
-    Writes ``kpi-export.json`` (manifest + KPI summary + raw evidence) or
-    ``kpi-summary.csv`` into ``--out-dir`` (default ``kpi-evidence/<run-id>``).
+    Writes both ``kpi-export.json`` (manifest + KPI summary + raw evidence)
+    and ``kpi-summary.csv`` (machine-readable KPI summary) into ``--out-dir``
+    (default ``kpi-evidence/<run-id>``).
     """
     if provenance is not None and provenance not in PROVENANCE_CLASSES:
         raise typer.BadParameter(
             f"provenance must be one of: {', '.join(PROVENANCE_CLASSES)}"
         )
-    if format not in ("json", "csv"):
-        raise typer.BadParameter("format must be json or csv")
 
     try:
         start_dt = datetime.fromisoformat(start)
@@ -136,19 +132,20 @@ def kpi_export(
 
     target = Path(out_dir)
     target.mkdir(parents=True, exist_ok=True)
-    if format == "csv":
-        path = target / "kpi-summary.csv"
-        path.write_text(render_csv_summary(bundle), encoding="utf-8")
-    else:
-        path = target / "kpi-export.json"
-        path.write_text(
-            json.dumps(bundle.model_dump(mode="json"), indent=2, ensure_ascii=False),
-            encoding="utf-8",
-        )
+
+    json_path = target / "kpi-export.json"
+    json_path.write_text(
+        json.dumps(bundle.model_dump(mode="json"), indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    csv_path = target / "kpi-summary.csv"
+    csv_path.write_text(render_csv_summary(bundle), encoding="utf-8")
 
     console.print(
         Panel(
-            f"Exported {len(bundle.kpis)} KPI results to [green]{path}[/green]\n"
+            f"Exported {len(bundle.kpis)} KPI results to:\n"
+            f"  [green]{json_path}[/green]\n"
+            f"  [green]{csv_path}[/green]\n"
             f"run_id: {bundle.manifest.get('run_id')}\n"
             f"calculation_version: {bundle.manifest.get('calculation_version')}\n"
             f"git_commit: {bundle.manifest.get('git_commit')}",

--- a/docs/kpi-export.md
+++ b/docs/kpi-export.md
@@ -241,8 +241,8 @@ Run from the repository root:
 `scripts/kpi-export.sh` resolves the venv and database URL so the command works
 from the repo root; when the venv is active, `homepot-client kpi-export ...` is
 equivalent. Options mirror the API (`--site-id`, `--device-id`, `--device-type`,
-`--provenance`, `--run-id`, `--format json|csv`, `--out-dir`). It writes
-`kpi-export.json` (bundle) or `kpi-summary.csv` (summary) and prints the run ID,
+`--provenance`, `--run-id`, `--out-dir`). It writes both
+`kpi-export.json` (bundle) and `kpi-summary.csv` (summary) and prints the run ID,
 calculation version, and Git commit on completion.
 
 The default `--out-dir` is `kpi-evidence/<run-id>`, where `<run-id>` is a UTC

--- a/docs/operator-protocol.md
+++ b/docs/operator-protocol.md
@@ -94,7 +94,7 @@ kpi-evidence/<run-id>/
 | `environment.json` | Deployment versions, database snapshot identifier, device types/OS, network conditions |
 | `scenario-log.csv` | Scenario ID, preconditions, operator, start/end, expected events, result, interventions |
 | `raw/` | Raw evidence rows (metrics, state history, config history, commands) — read-only |
-| `kpi-export.json` | Versioned KPI export bundle (or `kpi-summary.csv` with `--format csv`) from the KPI export |
+| `kpi-export.json` | Versioned KPI export bundle and its `kpi-summary.csv` companion from the KPI export |
 | `calculations/` | Calculation code revision (Git commit) and generated manifests |
 | `screenshots/` | Illustrative dashboard captures (do not replace machine-readable evidence) |
 | `reviewer-signoff.md` | Second-person review outcome (§7) and audit log of discrepancies |

--- a/kpi-evidence/README.md
+++ b/kpi-evidence/README.md
@@ -26,7 +26,7 @@ timestamp, e.g. `20260816T220500Z`, or an explicit `--run-id`):
 kpi-evidence/
 └── <run-id>/
     ├── kpi-export.json   # manifest + kpis + raw evidence
-    └── kpi-summary.csv   # machine-readable KPI summary (--format csv)
+    └── kpi-summary.csv   # machine-readable KPI summary
 ```
 
 Pass `--out-dir` to write elsewhere.


### PR DESCRIPTION
Two related fixes to the KPI export CLI output.

## 1. Write JSON with literal UTF-8 characters

`json.dumps` defaulted to `ensure_ascii=True`, escaping the typographic formula characters (`×` and `−`) as `\u00d7` and `\u2212`. Now writes literal UTF-8, consistent with the REST API response and the CSV export.

## 2. Write both `kpi-export.json` and `kpi-summary.csv` per run

The evidence-bundle layout documents both files in a run directory, but the CLI's `--format` flag wrote only one at a time (`json` by default). Dropped `--format` and now always writes:
- `kpi-export.json` — full manifest + KPI summary + raw evidence (reproducible bundle)
- `kpi-summary.csv` — machine-readable KPI summary (human-review companion)

The REST API keeps its `format` query param (it returns a single response).

## Verification

- `./scripts/kpi-export.sh` produces both files in `kpi-evidence/<run-id>/`.
- 0 `\uXXXX` escapes; literal `×`/`−` present.
- flake8 + mypy clean.
