### PR TITLE
docs: warn emulator users to disable the in-process agent simulator

### DIFF
--- a/docs/device-emulators.md
+++ b/docs/device-emulators.md
@@ -4,6 +4,19 @@ Standalone Python scripts that simulate real hardware devices for end-to-end tes
 
 Each emulator runs as an independent process that provisions itself with the backend, then sends heartbeats, telemetry, and responds to commands — just like a real device would.
 
+!!! warning "Disable the in-process agent simulator before emulating"
+    The backend's in-process agent simulator (`ENABLE_AGENT_SIMULATION=true`, the
+    default in `backend/.env`) starts a simulated agent for **every** active
+    POS/IoT device on startup. If it is left on while an emulator runs, it writes
+    additional fake telemetry into the emulated device — and into any `real`
+    device — which corrupts the `real`/`controlled`/`simulated` provenance that
+    the KPI export relies on.
+
+    Before starting an emulator, set `ENABLE_AGENT_SIMULATION=false` in
+    `backend/.env` (or the environment) and restart the backend. See
+    [Getting started — Simulation](getting-started.md) for what the simulator
+    does when enabled.
+
 ## Quick start
 
 ```bash

--- a/emulators/README.md
+++ b/emulators/README.md
@@ -15,8 +15,13 @@ polling) against the HOMEPOT backend without physical hardware.
 | `*.json`                 | Default per-OS emulator configuration |
 
 Emulation is one of the **three test integration modes** (Simulation, Emulation,
-Real Devices); when running an emulator, keep `ENABLE_AGENT_SIMULATION=false` in
-the environment so simulated agents do not compete with the emulated device.
+Real Devices).
+
+> ⚠️ **Disable the in-process agent simulator first.** Keep
+> `ENABLE_AGENT_SIMULATION=false` in the environment (or `backend/.env`) when
+> running an emulator, otherwise the backend's built-in simulator writes fake
+> telemetry into the emulated device — and into any `real` device — corrupting
+> the `real`/`controlled`/`simulated` provenance used by the KPI export.
 
 ## Quick start
 


### PR DESCRIPTION
Makes the `ENABLE_AGENT_SIMULATION=false` requirement prominent in the emulator documentation.

The backend's in-process agent simulator (`ENABLE_AGENT_SIMULATION=true`, the default) writes fake telemetry into **every** active POS/IoT device on startup — including emulated and real devices. Left on during emulation, it corrupts the `real`/`controlled`/`simulated` provenance separation that the KPI export depends on.

Changes:
- `docs/device-emulators.md`: add a `!!! warning` admonition at the top explaining the risk and how to disable it.
- `emulators/README.md`: upgrade the existing one-line mention to a prominent callout.