### PR TITLE
fix: report null counts in Gate B completeness message

### DIFF
--- a/ai/gates/gate_b.py
+++ b/ai/gates/gate_b.py
@@ -144,14 +144,24 @@ class DataIntegrityGate(Gate):
             "disk_percent": total - disk_n,
             "network_latency_ms": total - lat_n,
         }
-        completeness_ratio = 1 - (sum(null_counts.values()) / (total * 4))
-        passed = all(n == 0 for n in null_counts.values())
+        total_nulls = sum(null_counts.values())
+        passed = total_nulls == 0
+
+        if passed:
+            message = f"Non-null completeness 100.0% over {total} rows."
+        else:
+            missing = ", ".join(
+                f"{col}={n}" for col, n in null_counts.items() if n
+            )
+            message = (
+                f"{total_nulls} null value(s) detected ({missing}) over {total} rows."
+            )
 
         return CheckResult(
             check_id="B.completeness",
             name="Completeness",
             passed=passed,
-            message=f"Non-null completeness {completeness_ratio:.1%} over {total} rows.",
+            message=message,
             evidence=[
                 EvidenceRef(
                     table="device_metrics",

--- a/ai/gates/gate_b.py
+++ b/ai/gates/gate_b.py
@@ -150,9 +150,7 @@ class DataIntegrityGate(Gate):
         if passed:
             message = f"Non-null completeness 100.0% over {total} rows."
         else:
-            missing = ", ".join(
-                f"{col}={n}" for col, n in null_counts.items() if n
-            )
+            missing = ", ".join(f"{col}={n}" for col, n in null_counts.items() if n)
             message = (
                 f"{total_nulls} null value(s) detected ({missing}) over {total} rows."
             )


### PR DESCRIPTION
The Gate B completeness check failed whenever any cpu/memory/disk/latency value was null, but its message rounded the ratio to `100.0%` — so a FAIL displayed alongside a '100% complete' figure, which is confusing for technicians.

Example before: `FAIL B.completeness: Non-null completeness 100.0% over 120655 rows.`

After: `FAIL B.completeness: 2 null value(s) detected (memory_percent=1, disk_percent=1) over 120655 rows.`

The pass case still reads `Non-null completeness 100.0% over N rows.`. Evidence still carries the per-column null counts and threshold=0.

- flake8 clean; 18 gate tests pass.
- Verified live against PostgreSQL.