### PR TITLE
feat: relax Gate B thresholds for the testing phase

### DIFF
--- a/ai/gates/envelope.py
+++ b/ai/gates/envelope.py
@@ -169,6 +169,7 @@ def build_default_envelope(**overrides: Any) -> ValidationEnvelope:
             "freshness_max_age_seconds",
             "continuity_gap_seconds",
             "sustained_gap_seconds",
+            "completeness_max_null_ratio",
         )
     }
     gate_c_kwargs = {

--- a/ai/gates/gate_b.py
+++ b/ai/gates/gate_b.py
@@ -44,7 +44,9 @@ from .base import (
 )
 
 DEFAULT_FRESHNESS_MAX_AGE_SECONDS = 300  # 5-minute heartbeat baseline (paper Sec. 3.3)
-DEFAULT_CONTINUITY_GAP_SECONDS = 1800  # TESTING: relaxed 30 min (paper Table 1 says 60s)
+DEFAULT_CONTINUITY_GAP_SECONDS = (
+    1800  # TESTING: relaxed 30 min (paper Table 1 says 60s)
+)
 DEFAULT_SUSTAINED_GAP_SECONDS = 3600  # paper Sec. 6.3 ("gaps > 60 min")
 DEFAULT_COMPLETENESS_MAX_NULL_RATIO = 0.01  # TESTING: allow up to 1% nulls (real: 0)
 

--- a/ai/gates/gate_b.py
+++ b/ai/gates/gate_b.py
@@ -144,14 +144,24 @@ class DataIntegrityGate(Gate):
             "disk_percent": total - disk_n,
             "network_latency_ms": total - lat_n,
         }
-        completeness_ratio = 1 - (sum(null_counts.values()) / (total * 4))
-        passed = all(n == 0 for n in null_counts.values())
+        total_nulls = sum(null_counts.values())
+        passed = total_nulls == 0
+
+        if passed:
+            message = f"Non-null completeness 100.0% over {total} rows."
+        else:
+            missing = ", ".join(
+                f"{col}={n}" for col, n in null_counts.items() if n
+            )
+            message = (
+                f"{total_nulls} null value(s) detected ({missing}) over {total} rows."
+            )
 
         return CheckResult(
             check_id="B.completeness",
             name="Completeness",
             passed=passed,
-            message=f"Non-null completeness {completeness_ratio:.1%} over {total} rows.",
+            message=message,
             evidence=[
                 EvidenceRef(
                     table="device_metrics",

--- a/ai/gates/gate_b.py
+++ b/ai/gates/gate_b.py
@@ -150,9 +150,7 @@ class DataIntegrityGate(Gate):
         if passed:
             message = f"Non-null completeness 100.0% over {total} rows."
         else:
-            missing = ", ".join(
-                f"{col}={n}" for col, n in null_counts.items() if n
-            )
+            missing = ", ".join(f"{col}={n}" for col, n in null_counts.items() if n)
             message = (
                 f"{total_nulls} null value(s) detected ({missing}) over {total} rows."
             )

--- a/ai/gates/gate_b.py
+++ b/ai/gates/gate_b.py
@@ -10,12 +10,19 @@ Thresholds default to the values reported in the paper's Table 1 / Sec. 6.3
 (freshness ~5 min baseline heartbeat, continuity gaps <=60s, sustained
 discontinuity >60 min) but are configurable per deployment.
 
-TUNABLE: the three DEFAULT_* constants below are the single source of truth
+TUNABLE: the DEFAULT_* constants below are the single source of truth
 for these thresholds. Adjust them here for a global default, or override
 per-call via ``DataIntegrityGate(freshness_max_age_seconds=..., ...)`` /
 ``build_default_envelope(freshness_max_age_seconds=..., ...)`` -- see
 envelope.py's ``build_default_envelope``. None of these are yet validated
 against real deployment data.
+
+TESTING NOTE: the ``continuity_gap_seconds`` and ``completeness_max_null_ratio``
+defaults are deliberately relaxed for the current development/testing phase so
+Gate B passes on rehearsal data and the downstream gates (C/D/E) can be
+exercised. Before real-device testing, restore the paper's values
+(continuity gaps <= 60s, completeness null ratio 0) so Gate B actually rejects
+stale/incomplete telemetry.
 """
 
 from __future__ import annotations
@@ -37,8 +44,9 @@ from .base import (
 )
 
 DEFAULT_FRESHNESS_MAX_AGE_SECONDS = 300  # 5-minute heartbeat baseline (paper Sec. 3.3)
-DEFAULT_CONTINUITY_GAP_SECONDS = 300  # paper Table 1
+DEFAULT_CONTINUITY_GAP_SECONDS = 1800  # TESTING: relaxed 30 min (paper Table 1 says 60s)
 DEFAULT_SUSTAINED_GAP_SECONDS = 3600  # paper Sec. 6.3 ("gaps > 60 min")
+DEFAULT_COMPLETENESS_MAX_NULL_RATIO = 0.01  # TESTING: allow up to 1% nulls (real: 0)
 
 
 class DataIntegrityGate(Gate):
@@ -49,6 +57,7 @@ class DataIntegrityGate(Gate):
         freshness_max_age_seconds: int = DEFAULT_FRESHNESS_MAX_AGE_SECONDS,
         continuity_gap_seconds: int = DEFAULT_CONTINUITY_GAP_SECONDS,
         sustained_gap_seconds: int = DEFAULT_SUSTAINED_GAP_SECONDS,
+        completeness_max_null_ratio: float = DEFAULT_COMPLETENESS_MAX_NULL_RATIO,
     ) -> None:
         """Configure Gate B's tunable thresholds and Mode 2 failure fallback."""
         super().__init__(
@@ -57,6 +66,7 @@ class DataIntegrityGate(Gate):
         self.freshness_max_age_seconds = freshness_max_age_seconds
         self.continuity_gap_seconds = continuity_gap_seconds
         self.sustained_gap_seconds = sustained_gap_seconds
+        self.completeness_max_null_ratio = completeness_max_null_ratio
 
     async def evaluate(self, context: GateContext) -> GateResult:
         """Check completeness, freshness, continuity, gaps, and value validity."""
@@ -145,10 +155,16 @@ class DataIntegrityGate(Gate):
             "network_latency_ms": total - lat_n,
         }
         total_nulls = sum(null_counts.values())
-        passed = total_nulls == 0
+        null_ratio = total_nulls / (total * 4) if total else 0.0
+        passed = null_ratio <= self.completeness_max_null_ratio
 
-        if passed:
+        if total_nulls == 0:
             message = f"Non-null completeness 100.0% over {total} rows."
+        elif passed:
+            message = (
+                f"{total_nulls} null value(s) within {self.completeness_max_null_ratio:.1%} "
+                f"tolerance over {total} rows."
+            )
         else:
             missing = ", ".join(f"{col}={n}" for col, n in null_counts.items() if n)
             message = (
@@ -165,7 +181,7 @@ class DataIntegrityGate(Gate):
                     table="device_metrics",
                     query_id="B.completeness",
                     observed=null_counts,
-                    threshold=0,
+                    threshold=self.completeness_max_null_ratio,
                 )
             ],
         )


### PR DESCRIPTION
Gate B was failing on completeness (2 null metric values) and continuity (973.9s inter-arrival gap), which stops the envelope before Gates C/D/E are evaluated (envelope.py runs gates in sequence and stops at the first failure).

Relax the defaults for the current development/testing phase so downstream gates can be exercised:

- `continuity_gap_seconds`: 300s → 1800s (30 min)
- new `completeness_max_null_ratio = 0.01` (allow up to 1% nulls; previously strict 0)
- thread `completeness_max_null_ratio` through `DataIntegrityGate` and `build_default_envelope`

Both relaxed values are marked `TESTING` in the constants and the module docstring, with a note to restore the paper's values (continuity ≤ 60s, null ratio 0) before real-device testing.

Verified live against PostgreSQL — Gate B now passes:
- `B.completeness`: 2 null value(s) within 1.0% tolerance over 271940 rows.
- `B.continuity`: Max inter-arrival gap 973.9s (threshold 1800s).

18 gate tests pass; flake8 clean.

Depends on #305 (the completeness message fix).