### PR TITLE
fix: watch the ai/ package in uvicorn --reload

### DIFF
--- a/docs/ai-infrastructure.md
+++ b/docs/ai-infrastructure.md
@@ -978,7 +978,7 @@ alembic upgrade head
 python -m homepot.ai.init_chromadb
 
 # 9. Start backend with AI service
-uvicorn homepot.main:app --reload --host 0.0.0.0 --port 8000
+uvicorn homepot.main:app --reload --reload-dir src --reload-dir ../ai --host 0.0.0.0 --port 8000
 ```
 
 ---

--- a/docs/complete-dashboard-setup.md
+++ b/docs/complete-dashboard-setup.md
@@ -62,7 +62,7 @@ cd backend
 source ../.venv/bin/activate
 
 # Start the backend server
-python -m uvicorn homepot.app.main:app --host 0.0.0.0 --port 8000 --reload
+python -m uvicorn homepot.app.main:app --host 0.0.0.0 --port 8000 --reload --reload-dir src --reload-dir ../ai
 ```
 
 **Expected Output:**

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -58,13 +58,17 @@ This creates the PostgreSQL database `homepot_db` with demo data (3 sites, 12 de
 
 ```bash
 # Option 1: Using Python module
-python -m uvicorn homepot.main:app --reload --host 0.0.0.0 --port 8000
+python -m uvicorn homepot.main:app --reload --reload-dir src --reload-dir ../ai --host 0.0.0.0 --port 8000
 
 # Option 2: Using uvicorn command directly (if in PATH)
-uvicorn homepot.main:app --reload --host 0.0.0.0 --port 8000
+uvicorn homepot.main:app --reload --reload-dir src --reload-dir ../ai --host 0.0.0.0 --port 8000
 ```
 
 The `--reload` flag enables auto-restart on code changes (development mode).
+The `--reload-dir` flags additionally watch the `ai/` package (which lives
+outside `backend/`), so edits to the AI gates/context code also trigger a
+restart. Run the command from the `backend/` directory so the relative paths
+(`src`, `../ai`) resolve correctly.
 
 ### 6. Verify Backend is Running
 

--- a/scripts/start-dashboard.sh
+++ b/scripts/start-dashboard.sh
@@ -192,7 +192,9 @@ cd "$REPO_ROOT/backend"
 # Use bash -c to activate venv in the subshell
 # Redirect stdout/stderr to backend.out (overwritten on start)
 # The application handles backend.log with rotation
-nohup bash -c "source $REPO_ROOT/.venv/bin/activate && python -m uvicorn homepot.app.main:app --host 0.0.0.0 --port 8000 --reload" \
+# --reload-dir watches the ai/ package (outside backend/) too, so edits to the
+# AI gates/context code trigger an auto-restart alongside backend changes.
+nohup bash -c "source $REPO_ROOT/.venv/bin/activate && python -m uvicorn homepot.app.main:app --host 0.0.0.0 --port 8000 --reload --reload-dir src --reload-dir ../ai" \
     > "$REPO_ROOT/logs/backend.out" 2>&1 &
 BACKEND_PID=$!
 echo $BACKEND_PID > "$REPO_ROOT/logs/backend.pid"


### PR DESCRIPTION
uvicorn `--reload` only watches the backend directory, so edits to `ai/gates/`, `ai/context_builder.py`, etc. did not trigger an auto-restart — the running backend kept stale AI code (which is why the Gate B fixes weren't picked up until a manual restart).

Add `--reload-dir src --reload-dir ../ai` to:
- `scripts/start-dashboard.sh` (the canonical startup)
- `docs/running-locally.md`
- `docs/ai-infrastructure.md`
- `docs/complete-dashboard-setup.md`

Verified `--reload-dir` is supported by the installed uvicorn, and the commands run from `backend/` so the relative paths resolve to `backend/src` and `<repo>/ai`.