### PR TITLE
feat: archive/purge modes for site and device deletion

### DIFF
--- a/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any, Dict, List, Optional, cast
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.security import HTTPAuthorizationCredentials
 import jwt
 from pydantic import BaseModel, ConfigDict
@@ -662,20 +662,34 @@ async def update_device(
 @router.delete("/device/{device_id}", tags=["Devices"])
 async def delete_device(
     device_id: str,
+    mode: str = Query("archive", pattern="^(archive|purge)$"),
+    confirm: bool = Query(False, description="Required for purge"),
     db: SASession = Depends(get_db),
     current_user: UserDict = Depends(require_user()),
 ) -> Dict[str, Any]:
-    """Unpair a device and archive its associated data.
+    """Archive or purge a device.
+
+    - ``archive`` (default): unpair the device and retain its historical data.
+    - ``purge``: permanently delete the device and ALL its associated data
+      (telemetry, commands, history). Destructive and irreversible; requires
+      ``confirm=true``. Applies regardless of whether the device is simulated,
+      emulated, or real.
 
     Requires operator-level access on the device's site.
     """
+    if mode == "purge" and not confirm:
+        raise HTTPException(
+            status_code=400,
+            detail="Purge requires confirm=true (it permanently deletes the device and all associated data).",
+        )
+
     try:
         db_user = cast(
             User, db.query(User).filter(User.email == current_user["email"]).first()
         )
         db_service = await get_database_service()
 
-        # Verify access before unpairing — operator role required
+        # Verify access before deletion — operator role required
         device = await db_service.get_device_by_device_id(device_id)
         if not device:
             raise HTTPException(
@@ -683,14 +697,18 @@ async def delete_device(
             )
         verify_device_belongs_to_user(db_user, device, db, minimum_role="operator")
 
-        success = await db_service.delete_device(device_id)
+        if mode == "purge":
+            success = await db_service.purge_device(device_id)
+        else:
+            success = await db_service.delete_device(device_id)
 
         if not success:
             raise HTTPException(
                 status_code=404, detail=f"Device '{device_id}' not found"
             )
 
-        return {"message": f"Device '{device_id}' unpaired and archived successfully"}
+        action = "purged" if mode == "purge" else "archived"
+        return {"message": f"Device '{device_id}' {action} successfully"}
 
     except HTTPException:
         raise

--- a/backend/src/homepot/app/api/API_v1/Endpoints/SitesEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/SitesEndpoint.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any, Dict, List, Optional, cast
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import select
 from sqlalchemy.orm import Session as SASession
@@ -336,13 +336,29 @@ async def get_site(
 @router.delete("/{site_id}", tags=["Sites"])
 async def delete_site(
     site_id: str,
+    mode: str = Query("archive", pattern="^(archive|purge)$"),
+    confirm: bool = Query(False, description="Required for purge"),
     db: SASession = Depends(get_db),
     current_user: UserDict = Depends(require_user()),
 ) -> Dict[str, str]:
-    """Delete a site and ALL associated resources (metrics, logs, history).
+    """Archive or purge a site.
+
+    - ``archive`` (default): hide the site and its devices from the Dashboard,
+      retaining all historical data. Safe and reversible (set ``is_active``
+      back to true to restore).
+    - ``purge``: delete the site and ALL associated data (metrics, logs,
+      history, devices). Destructive and irreversible; requires
+      ``confirm=true``. Applies regardless of whether devices are simulated,
+      emulated, or real.
 
     Requires operator-level access on the site.
     """
+    if mode == "purge" and not confirm:
+        raise HTTPException(
+            status_code=400,
+            detail="Purge requires confirm=true (it permanently deletes the site and all associated data).",
+        )
+
     try:
         db_user = cast(
             User, db.query(User).filter(User.email == current_user["email"]).first()
@@ -350,15 +366,16 @@ async def delete_site(
         verify_site_access_for_user(db_user, site_id, db, minimum_role="operator")
 
         db_service = await get_database_service()
-        from sqlalchemy import delete, select
+        from sqlalchemy import delete, select, update
 
         # Import analytics models for comprehensive cleanup
-        from homepot.app.models.AnalyticsModel import (  # ErrorLog,  # Unused; PushNotificationLog,  # Unused
+        from homepot.app.models.AnalyticsModel import (
             APIRequestLog,
             ConfigurationHistory,
             DeviceMetrics,
             DeviceStateHistory,
             JobOutcome,
+            PushNotificationLog,
             SiteOperatingSchedule,
         )
         from homepot.models import (
@@ -385,6 +402,36 @@ async def delete_site(
             site_name = site.name
             site_str_id = site.site_id
 
+            if mode == "archive":
+                # --- ARCHIVE: hide the site and its devices, keep all data ---
+                site.is_active = False  # type: ignore[assignment]
+                # Mark the site's devices as inactive so they disappear from the
+                # Dashboard too, while preserving their data.
+                await session.execute(
+                    update(Device)
+                    .where(Device.site_id == site.id)
+                    .values(is_active=False)
+                )
+                await session.commit()
+
+                audit_logger = get_audit_logger()
+                await audit_logger.log_event(
+                    AuditEventType.SITE_DELETED,
+                    f"Site '{site_name}' archived (hidden from Dashboard, data retained)",
+                    site_id=None,
+                    old_values={
+                        "site_id": site_str_id,
+                        "name": site_name,
+                        "db_id": site_pk,
+                        "cleanup_policy": "archive",
+                    },
+                )
+                return {
+                    "message": f"Site {site_id} archived (data retained; set is_active=true to restore)"
+                }
+
+            # --- PURGE: delete the site and ALL associated data ---
+
             # Get all devices for this site to clean up their related data
             # We need both Integer IDs (for FKs) and String IDs (for Analytics)
             devices_result = await session.execute(
@@ -410,16 +457,6 @@ async def delete_site(
                 )
 
             if device_str_ids:
-                # Push Notification Logs - Disabled due to missing device_id column
-                # await session.execute(
-                #     delete(PushNotificationLog).where(
-                #         PushNotificationLog.device_id.in_(device_str_ids)
-                #     )
-                # )
-                # Error Logs (linked to devices) - Disabled due to missing device_id column
-                # await session.execute(
-                #     delete(ErrorLog).where(ErrorLog.device_id.in_(device_str_ids))
-                # )
                 # Job Outcomes (linked to devices)
                 await session.execute(
                     delete(JobOutcome).where(JobOutcome.device_id.in_(device_str_ids))
@@ -431,6 +468,11 @@ async def delete_site(
                         ConfigurationHistory.entity_id.in_(device_str_ids),
                     )
                 )
+                # Error Logs: no device/site FK exists on error_logs, and the
+                # device id only lives inside the context JSON (unreliable to
+                # query across backends), so error_logs are intentionally
+                # retained -- they are operational error records, not
+                # site-scoped data.
 
             # --- PHASE 2: Clean up Site-Specific Analytics & History ---
             # Site Operating Schedules
@@ -474,16 +516,25 @@ async def delete_site(
             # Delete AuditLogs for the site
             await session.execute(delete(AuditLog).where(AuditLog.site_id == site.id))
 
-            # Get associated Jobs to delete their AuditLogs
+            # Get associated Jobs to delete their AuditLogs and Push logs
             jobs_result = await session.execute(
-                select(Job.id).where(Job.site_id == site.id)
+                select(Job.id, Job.job_id).where(Job.site_id == site.id)
             )
-            job_ids = jobs_result.scalars().all()
+            job_rows = jobs_result.all()
+            job_pk_ids = [r[0] for r in job_rows]
+            job_str_ids = [r[1] for r in job_rows]
 
-            if job_ids:
+            if job_pk_ids:
                 # Delete AuditLogs for jobs
                 await session.execute(
-                    delete(AuditLog).where(AuditLog.job_id.in_(job_ids))
+                    delete(AuditLog).where(AuditLog.job_id.in_(job_pk_ids))
+                )
+            if job_str_ids:
+                # Delete Push Notification Logs linked to this site's jobs
+                await session.execute(
+                    delete(PushNotificationLog).where(
+                        PushNotificationLog.job_id.in_(job_str_ids)
+                    )
                 )
 
             # Delete associated Jobs
@@ -507,12 +558,12 @@ async def delete_site(
                     "site_id": site_str_id,
                     "name": site_name,
                     "db_id": site_pk,
-                    "cleanup_policy": "hard_delete_all_associated_data",
+                    "cleanup_policy": "purge",
                 },
             )
 
             return {
-                "message": f"Site {site_id} and all associated data deleted successfully"
+                "message": f"Site {site_id} and all associated data purged successfully"
             }
 
     except HTTPException:

--- a/backend/src/homepot/database.py
+++ b/backend/src/homepot/database.py
@@ -530,6 +530,75 @@ class DatabaseService:
             await session.commit()
             return True
 
+    async def purge_device(self, device_id: str) -> bool:
+        """Permanently delete a device and all its associated data (hard purge).
+
+        Removes telemetry, state history, health checks, commands, credentials,
+        assignments, lifecycle events/epochs, alerts, job outcomes,
+        configuration history, audit logs, and the device row itself.
+        Irreversible -- only call after an explicit ``confirm``.
+        """
+        from sqlalchemy import delete
+
+        from homepot.models import DeviceAssignment, DeviceLifecycleEvent
+
+        async with self.get_session() as session:
+            result = await session.execute(
+                select(Device).where(Device.device_id == device_id)
+            )
+            device = result.scalars().first()
+            if not device:
+                return False
+            pk = device.id
+
+            # Children that reference the device by integer PK (delete before
+            # the device row to satisfy foreign keys).
+            for model in (
+                DeviceLifecycleEvent,
+                DeviceAssignment,
+                DeviceCredential,
+                DeviceMetrics,
+                DeviceStateHistory,
+                HealthCheck,
+                DeviceCommand,
+                AuditLog,
+            ):
+                await session.execute(delete(model).where(model.device_id == pk))
+
+            # Jobs for this device (and their audit logs)
+            job_ids = (
+                (await session.execute(select(Job.id).where(Job.device_id == pk)))
+                .scalars()
+                .all()
+            )
+            if job_ids:
+                await session.execute(
+                    delete(AuditLog).where(AuditLog.job_id.in_(job_ids))
+                )
+            await session.execute(delete(Job).where(Job.device_id == pk))
+
+            # Lifecycle epochs for this device (after lifecycle events above)
+            await session.execute(
+                delete(LifecycleEpoch).where(LifecycleEpoch.device_id == pk)
+            )
+
+            # Rows that reference the device by its public string id
+            await session.execute(delete(Alert).where(Alert.device_id == device_id))
+            await session.execute(
+                delete(JobOutcome).where(JobOutcome.device_id == device_id)
+            )
+            await session.execute(
+                delete(ConfigurationHistory).where(
+                    ConfigurationHistory.entity_type == "device",
+                    ConfigurationHistory.entity_id == device_id,
+                )
+            )
+
+            # Finally the device row itself
+            await session.delete(device)
+            await session.commit()
+            return True
+
     async def get_devices_by_site_and_segment(
         self, site_id: str, segment: Optional[str] = None
     ) -> List[Device]:

--- a/backend/tests/test_site_delete.py
+++ b/backend/tests/test_site_delete.py
@@ -1,4 +1,9 @@
-"""Tests for site delete."""
+"""Tests for site/device archive and purge.
+
+Archive (default) hides the entity and retains data; purge (with confirm=true)
+permanently deletes the entity and all associated data. Applies regardless of
+whether devices are simulated, emulated, or real.
+"""
 
 import asyncio
 from datetime import datetime, timezone
@@ -54,31 +59,29 @@ def file_db(monkeypatch: Any) -> Generator[None, None, None]:
             pass
 
 
-def test_api_site_delete(file_db: Any) -> None:
-    """Test backend site cascade deletion logic via the API."""
+def _seed_site_device_admin() -> tuple[str, str, int]:
+    """Create a site + device + admin; return (site_id, device_id, site_pk)."""
     sync_db = homepot.database.SessionLocal()
     try:
-        site = Site(
-            site_id="test-site-delete", name="Test Company Delete", is_active=True
-        )
+        site = Site(site_id="test-arch-purge", name="Test Co", is_active=True)
         sync_db.add(site)
         sync_db.commit()
         sync_db.refresh(site)
 
         device = Device(
-            device_id="dev-delete-001",
+            device_id="dev-ap-001",
             name="Test POS",
             device_type="pos_terminal",
             site_id=site.id,
-            is_active=False,
-            status=DeviceStatus.UNPAIRED,
+            is_active=True,
+            status=DeviceStatus.ONLINE,
         )
         sync_db.add(device)
         sync_db.commit()
 
         admin = User(
-            email="admin@delete.test",
-            username="admin_delete",
+            email="admin@arch-purge.test",
+            username="admin_ap",
             hashed_password=hash_password("pass"),
             is_admin=True,
             created_at=datetime.now(timezone.utc),
@@ -86,13 +89,121 @@ def test_api_site_delete(file_db: Any) -> None:
         )
         sync_db.add(admin)
         sync_db.commit()
+        return site.site_id, device.device_id, site.id
     finally:
         sync_db.close()
 
-    token = create_access_token({"sub": "admin@delete.test"})
-    headers = {"Authorization": f"Bearer {token}"}
 
+def _headers() -> dict:
+    token = create_access_token({"sub": "admin@arch-purge.test"})
+    return {"Authorization": f"Bearer {token}"}
+
+
+# --------------------------------------------------------------------------
+# Site
+# --------------------------------------------------------------------------
+
+
+def test_site_archive_default_retains_data(file_db: Any) -> None:
+    """Default delete archives the site + devices (data retained, hidden)."""
+    site_id, device_id, _ = _seed_site_device_admin()
     client = TestClient(app)
-    response = client.delete("/api/v1/sites/test-site-delete", headers=headers)
+    response = client.delete(f"/api/v1/sites/{site_id}", headers=_headers())
     assert response.status_code == 200
-    assert "deleted" in response.json()["message"].lower()
+    assert "archived" in response.json()["message"].lower()
+
+    sync_db = homepot.database.SessionLocal()
+    try:
+        site = sync_db.query(Site).filter(Site.site_id == site_id).first()
+        device = sync_db.query(Device).filter(Device.device_id == device_id).first()
+        assert site is not None and site.is_active is False
+        assert device is not None and device.is_active is False
+    finally:
+        sync_db.close()
+
+
+def test_site_purge_requires_confirm(file_db: Any) -> None:
+    """Purge without confirm=true is rejected."""
+    site_id, _, _ = _seed_site_device_admin()
+    client = TestClient(app)
+    response = client.delete(
+        f"/api/v1/sites/{site_id}", params={"mode": "purge"}, headers=_headers()
+    )
+    assert response.status_code == 400
+    assert "confirm" in response.json()["detail"].lower()
+
+
+def test_site_purge_with_confirm_deletes_everything(file_db: Any) -> None:
+    """Purge with confirm=true deletes the site and its devices."""
+    site_id, device_id, _ = _seed_site_device_admin()
+    client = TestClient(app)
+    response = client.delete(
+        f"/api/v1/sites/{site_id}",
+        params={"mode": "purge", "confirm": "true"},
+        headers=_headers(),
+    )
+    assert response.status_code == 200
+    assert "purged" in response.json()["message"].lower()
+
+    sync_db = homepot.database.SessionLocal()
+    try:
+        site = sync_db.query(Site).filter(Site.site_id == site_id).first()
+        device = sync_db.query(Device).filter(Device.device_id == device_id).first()
+        assert site is None
+        assert device is None
+    finally:
+        sync_db.close()
+
+
+# --------------------------------------------------------------------------
+# Device
+# --------------------------------------------------------------------------
+
+
+def test_device_archive_default_retains_data(file_db: Any) -> None:
+    """Default delete archives the device (unpaired, data retained)."""
+    _, device_id, _ = _seed_site_device_admin()
+    client = TestClient(app)
+    response = client.delete(f"/api/v1/devices/device/{device_id}", headers=_headers())
+    assert response.status_code == 200
+    assert "archived" in response.json()["message"].lower()
+
+    sync_db = homepot.database.SessionLocal()
+    try:
+        device = sync_db.query(Device).filter(Device.device_id == device_id).first()
+        assert device is not None and device.is_active is False
+    finally:
+        sync_db.close()
+
+
+def test_device_purge_requires_confirm(file_db: Any) -> None:
+    """Device purge without confirm=true is rejected."""
+    _, device_id, _ = _seed_site_device_admin()
+    client = TestClient(app)
+    response = client.delete(
+        f"/api/v1/devices/device/{device_id}",
+        params={"mode": "purge"},
+        headers=_headers(),
+    )
+    assert response.status_code == 400
+    assert "confirm" in response.json()["detail"].lower()
+
+
+def test_device_purge_with_confirm_deletes(file_db: Any) -> None:
+    """Device purge with confirm=true deletes the device row."""
+    _, device_id, _ = _seed_site_device_admin()
+    client = TestClient(app)
+    response = client.delete(
+        f"/api/v1/devices/device/{device_id}",
+        params={"mode": "purge", "confirm": "true"},
+        headers=_headers(),
+    )
+    assert response.status_code == 200
+    assert "purged" in response.json()["message"].lower()
+
+    sync_db = homepot.database.SessionLocal()
+    try:
+        device = sync_db.query(Device).filter(Device.device_id == device_id).first()
+        assert device is None
+    finally:
+        sync_db.close()

--- a/docs/device-lifecycle-and-ownership.md
+++ b/docs/device-lifecycle-and-ownership.md
@@ -180,6 +180,15 @@ The request must include authentication, authorisation, an optional reason, and 
 
 Hard deletion is a separate data-governance operation and is outside ordinary device unpairing.
 
+### Delete modes map to lifecycle concepts
+
+The device `DELETE` endpoints (`DELETE /api/v1/devices/device/{id}`) use **archive / purge** modes that map to the lifecycle model above:
+
+- **`archive`** (default) — performs the **unpair** lifecycle transition: revokes credentials, expires outstanding commands, sets `lifecycle_state = 'unpaired'` and `is_active = false`, while **retaining all data**. Restorable by re-activating the device.
+- **`purge`** — the separate hard-deletion data-governance operation (requires `confirm=true`): permanently deletes the device row and all associated data.
+
+So "archive" is the `DELETE`-method alias for the `unpaired` lifecycle state; "purge" is the hard-deletion path that sits outside the lifecycle model (line above). Sites follow the same pattern (`DELETE /api/v1/sites/{id}?mode=archive|purge`), where archiving a site also archives its devices. These apply uniformly regardless of whether a device is simulated, emulated, or real.
+
 ## API representation
 
 Device responses should expose the independent state dimensions:


### PR DESCRIPTION
Introduce explicit **archive** vs **purge** deletion semantics for sites and devices (previously site was always hard-deleted and device always soft-deleted, with no user-selectable mode).

## Design

- `DELETE /sites/{id}?mode=archive|purge` — default **archive**; purge requires `confirm=true`
- `DELETE /devices/device/{id}?mode=archive|purge` — default **archive**; purge requires `confirm=true`

**archive** (safe, data retained):
- Site: hide the site and its devices (`is_active=false`), keep all data (restorable)
- Device: existing unpair behaviour, data retained

**purge** (destructive, requires `confirm=true`):
- Site: cascade-delete the site, its devices and all associated data
- Device: new `purge_device()` removes telemetry, state history, health checks, commands, credentials, assignments, lifecycle events/epochs, alerts, job outcomes, configuration history, audit logs, and the device row

Semantics are uniform for simulated, emulated, and real devices.

## Notes

- Site purge now also cleans `PushNotificationLog` (via the site's job ids). `error_logs` are intentionally retained and documented as such — the table has no device/site FK and the device id only lives in a context JSON column (unreliable to query across backends).
- `cleanup_policy` in the audit event now reflects `archive` or `purge`.

## Verification

- 6 new archive/purge tests (site + device, incl. confirm guard) pass.
- Related suites pass: device_unpair, lifecycle, authorization, device_commands.
- black / isort / flake8 / mypy clean.