### PR TITLE
feat: scope AI context and gates to live (non-archived) devices

### DIFF
--- a/ai/context_builder.py
+++ b/ai/context_builder.py
@@ -92,14 +92,16 @@ class ContextBuilder:
                 )
             return f"Job {job_id} not found."
 
-        # Fetch recent failed jobs
+        # Fetch recent failed jobs (only for active, non-archived devices)
         cutoff = datetime.utcnow() - timedelta(hours=24)
+        active_device_ids = select(Device.device_id).where(Device.is_active.is_(True))
         stmt = (
             select(JobOutcome)
             .where(
                 and_(
                     JobOutcome.status == "failed",
                     JobOutcome.timestamp >= cutoff,
+                    JobOutcome.device_id.in_(active_device_ids),
                 )
             )
             .order_by(JobOutcome.timestamp.desc())

--- a/ai/device_resolver.py
+++ b/ai/device_resolver.py
@@ -35,7 +35,9 @@ class DeviceResolver:
         if device_id_str in self._cache:
             return self._cache[device_id_str]
 
-        stmt = select(Device.id).where(Device.device_id == device_id_str)
+        stmt = select(Device.id).where(
+            Device.device_id == device_id_str, Device.is_active.is_(True)
+        )
         result = await self.session.execute(stmt)
         device_int_id = result.scalar_one_or_none()
 

--- a/ai/gates/gate_b.py
+++ b/ai/gates/gate_b.py
@@ -89,25 +89,35 @@ class DataIntegrityGate(Gate):
             )
 
         from homepot.app.models.AnalyticsModel import DeviceMetrics
-        from homepot.models import HealthCheck
+        from homepot.models import Device, HealthCheck
 
         window_start = datetime.utcnow() - timedelta(seconds=context.window_seconds)
         device_int_id = context.device_int_id
 
+        # Scope every check to live (non-archived, non-retired) devices only, so
+        # telemetry from unpaired/archived devices never influences trust.
+        active_pks = (
+            (await session.execute(select(Device.id).where(Device.is_active.is_(True))))
+            .scalars()
+            .all()
+        )
+
         checks: List[CheckResult] = [
             await self._check_completeness(
-                session, DeviceMetrics, window_start, device_int_id
+                session, DeviceMetrics, window_start, device_int_id, active_pks
             ),
-            await self._check_freshness(session, DeviceMetrics, device_int_id),
+            await self._check_freshness(
+                session, DeviceMetrics, device_int_id, active_pks
+            ),
         ]
         checks.extend(
             await self._check_continuity_and_gaps(
-                session, HealthCheck, window_start, device_int_id
+                session, HealthCheck, window_start, device_int_id, active_pks
             )
         )
         checks.append(
             await self._check_validity(
-                session, DeviceMetrics, window_start, device_int_id
+                session, DeviceMetrics, window_start, device_int_id, active_pks
             )
         )
 
@@ -122,6 +132,7 @@ class DataIntegrityGate(Gate):
         DeviceMetrics: Any,
         window_start: datetime,
         device_int_id: Optional[int],
+        active_pks: list,
     ) -> CheckResult:
         stmt = select(
             func.count(),
@@ -129,7 +140,10 @@ class DataIntegrityGate(Gate):
             func.count(DeviceMetrics.memory_percent),
             func.count(DeviceMetrics.disk_percent),
             func.count(DeviceMetrics.network_latency_ms),
-        ).where(DeviceMetrics.timestamp >= window_start)
+        ).where(
+            DeviceMetrics.timestamp >= window_start,
+            DeviceMetrics.device_id.in_(active_pks),
+        )
         if device_int_id:
             stmt = stmt.where(DeviceMetrics.device_id == device_int_id)
 
@@ -189,9 +203,15 @@ class DataIntegrityGate(Gate):
         )
 
     async def _check_freshness(
-        self, session: Any, DeviceMetrics: Any, device_int_id: Optional[int]
+        self,
+        session: Any,
+        DeviceMetrics: Any,
+        device_int_id: Optional[int],
+        active_pks: list,
     ) -> CheckResult:
-        stmt = select(func.max(DeviceMetrics.timestamp))
+        stmt = select(func.max(DeviceMetrics.timestamp)).where(
+            DeviceMetrics.device_id.in_(active_pks)
+        )
         if device_int_id:
             stmt = stmt.where(DeviceMetrics.device_id == device_int_id)
         last_ts = (await session.execute(stmt)).scalar()
@@ -231,10 +251,14 @@ class DataIntegrityGate(Gate):
         HealthCheck: Any,
         window_start: datetime,
         device_int_id: Optional[int],
+        active_pks: list,
     ) -> List[CheckResult]:
         stmt = (
             select(HealthCheck.timestamp)
-            .where(HealthCheck.timestamp >= window_start)
+            .where(
+                HealthCheck.timestamp >= window_start,
+                HealthCheck.device_id.in_(active_pks),
+            )
             .order_by(HealthCheck.timestamp.asc())
         )
         if device_int_id:
@@ -313,11 +337,15 @@ class DataIntegrityGate(Gate):
         DeviceMetrics: Any,
         window_start: datetime,
         device_int_id: Optional[int],
+        active_pks: list,
     ) -> CheckResult:
         stmt = (
             select(func.count())
             .select_from(DeviceMetrics)
-            .where(DeviceMetrics.timestamp >= window_start)
+            .where(
+                DeviceMetrics.timestamp >= window_start,
+                DeviceMetrics.device_id.in_(active_pks),
+            )
             .where(
                 or_(
                     DeviceMetrics.cpu_percent > 100,

--- a/backend/src/homepot/app/api/API_v1/Endpoints/AIEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/AIEndpoint.py
@@ -12,7 +12,6 @@ from typing import Any, Dict, Optional
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
 from sqlalchemy import case, func, select
-from sqlalchemy.orm import selectinload
 
 # Add project root to path to allow importing 'ai' package
 # Current file: backend/src/homepot/app/api/API_v1/Endpoints/AIEndpoint.py
@@ -106,8 +105,10 @@ async def get_system_anomalies() -> Dict[str, Any]:
 
         db_service = await get_database_service()
         async with db_service.get_session() as session:
-            # 1. Get all devices for mapping (to ensure we can name any device with an alert)
-            all_devices_result = await session.execute(select(Device))
+            # 1. Get active devices for mapping (only live, non-archived devices)
+            all_devices_result = await session.execute(
+                select(Device).where(Device.is_active.is_(True))
+            )
             all_devices = all_devices_result.scalars().all()
             device_map = {d.device_id: d.name for d in all_devices}
 
@@ -388,21 +389,30 @@ async def query_ai(request: AIQueryRequest) -> Dict[str, Any]:
         # 3. Build Real-Time System Context
         db_service = await get_database_service()
         async with db_service.get_session() as session:
-            # Get Sites with Devices
-            result = await session.execute(
-                select(Site)
-                .options(selectinload(Site.devices))
-                .where(Site.is_active.is_(True))
-            )
+            # Get Sites with active Devices only (archived/unpaired/retired
+            # devices must not be visible to the AI).
+            result = await session.execute(select(Site).where(Site.is_active.is_(True)))
             sites = result.scalars().all()
+            site_ids = [s.id for s in sites]
+            devices_by_site: dict = {}
+            if site_ids:
+                dev_result = await session.execute(
+                    select(Device).where(
+                        Device.site_id.in_(site_ids),
+                        Device.is_active.is_(True),
+                    )
+                )
+                for dev in dev_result.scalars().all():
+                    devices_by_site.setdefault(dev.site_id, []).append(dev)
 
             site_context = "[CURRENT SYSTEM STATUS]\n"
             site_context += f"Total Sites: {len(sites)}\n"
             for site in sites:
                 site_context += f"- Site: {site.name} (ID: {site.site_id}), Location: {site.location}\n"
-                if site.devices:
+                site_devices = devices_by_site.get(site.id, [])
+                if site_devices:
                     site_context += "  Devices:\n"
-                    for d in site.devices:
+                    for d in site_devices:
                         site_context += (
                             f"    * Name: {d.name}\n"
                             f"      ID: {d.device_id}\n"
@@ -430,9 +440,17 @@ async def query_ai(request: AIQueryRequest) -> Dict[str, Any]:
             if avg_latency:
                 site_context += f"- Avg Latency: {round(avg_latency, 2)}ms\n"
 
-            # Get Active Alerts for AI Context
+            # Get Active Alerts for AI Context (only for active devices)
+            active_device_ids = select(Device.device_id).where(
+                Device.is_active.is_(True)
+            )
             alerts_result = await session.execute(
-                select(Alert).where(Alert.status == "active").limit(20)
+                select(Alert)
+                .where(
+                    Alert.status == "active",
+                    Alert.device_id.in_(active_device_ids),
+                )
+                .limit(20)
             )
             active_alerts = alerts_result.scalars().all()
 


### PR DESCRIPTION
The AI was mixing archived/unpaired device data with live data, because the context builder and the data-integrity gates queried all devices regardless of lifecycle state. With archive now available, archived devices' retained telemetry could appear alongside live data.

Now every AI-visible data source filters to **active devices** (`is_active=true`, which excludes unpaired/retired/archived devices; purged devices are already gone):

- `query_ai`: site context lists only active devices; active-alert context only includes alerts for active devices
- `get_system_anomalies`: device map + monitored set restricted to active devices
- `context_builder.get_job_context`: failed-jobs context restricted to active devices
- `device_resolver`: only resolves active devices (archived device → not found)
- `gate_b`: completeness/freshness/continuity/validity scope telemetry and health checks to active devices, so archived data cannot skew the trust envelope

Applies uniformly to simulated, emulated, and real devices.

## Verification

- 23 gate + AI service tests pass; 39 with KPI scenario/export tests.
- black / isort / flake8 / mypy clean.