### PR TITLE
feat: retain a purge tombstone and surface archived/purged devices

### DIFF
--- a/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
@@ -42,6 +42,7 @@ from homepot.models import (
     DeviceCommand,
     DeviceCredential,
     DeviceLifecycleEvent,
+    DeviceStatus,
     HealthState,
     Job,
     LifecycleEpoch,
@@ -860,6 +861,7 @@ async def unpair_device(
         device.lifecycle_state = LifecycleState.UNPAIRED.value  # type: ignore[assignment]
         device.is_active = False  # type: ignore[assignment]
         device.api_key_hash = None  # type: ignore[assignment]
+        device.status = DeviceStatus.OFFLINE.value  # type: ignore[assignment]
         # The device was loaded via get_device_by_device_id, whose session is
         # already closed; merge the changes back into a fresh session so the
         # state transition actually persists.

--- a/backend/src/homepot/database.py
+++ b/backend/src/homepot/database.py
@@ -594,6 +594,27 @@ class DatabaseService:
                 )
             )
 
+            # Record a tombstone audit event BEFORE deleting the device row so
+            # we can still capture its identity. device_id is left None because
+            # the row is deleted immediately after (an FK would otherwise break);
+            # the purged identity is preserved in old_values. This is the only
+            # retained trace of a purge -- the data itself is gone.
+            device_name = device.name
+            device_site_id = device.site_id
+            session.add(
+                AuditLog(
+                    event_type="device_deleted",
+                    description=f"Device '{device_name}' ({device_id}) purged with all associated data",
+                    site_id=device_site_id,
+                    old_values={
+                        "device_id": device_id,
+                        "name": device_name,
+                        "site_id": device_site_id,
+                        "cleanup_policy": "purge",
+                    },
+                )
+            )
+
             # Finally the device row itself
             await session.delete(device)
             await session.commit()

--- a/backend/src/homepot/database.py
+++ b/backend/src/homepot/database.py
@@ -507,6 +507,7 @@ class DatabaseService:
             device.lifecycle_state = LifecycleState.UNPAIRED.value  # type: ignore[assignment]
             device.is_active = False  # type: ignore[assignment]
             device.api_key_hash = None  # type: ignore[assignment]
+            device.status = DeviceStatus.OFFLINE.value  # type: ignore[assignment]
 
             # Revoke all active credentials
             cred_result = await session.execute(

--- a/backend/tests/test_site_delete.py
+++ b/backend/tests/test_site_delete.py
@@ -172,6 +172,9 @@ def test_device_archive_default_retains_data(file_db: Any) -> None:
     try:
         device = sync_db.query(Device).filter(Device.device_id == device_id).first()
         assert device is not None and device.is_active is False
+        # archived device is no longer reachable, so connectivity status is offline
+        assert device.status == "offline"
+        assert device.lifecycle_state == "unpaired"
     finally:
         sync_db.close()
 

--- a/backend/tests/test_site_delete.py
+++ b/backend/tests/test_site_delete.py
@@ -20,7 +20,7 @@ from homepot.app.auth_utils import create_access_token, hash_password
 from homepot.app.main import app
 from homepot.config import reload_settings
 import homepot.database
-from homepot.models import Base, Device, DeviceStatus, Site, User
+from homepot.models import AuditLog, Base, Device, DeviceStatus, Site, User
 
 
 @pytest.fixture
@@ -205,5 +205,36 @@ def test_device_purge_with_confirm_deletes(file_db: Any) -> None:
     try:
         device = sync_db.query(Device).filter(Device.device_id == device_id).first()
         assert device is None
+    finally:
+        sync_db.close()
+
+
+def test_device_purge_creates_audit_tombstone(file_db: Any) -> None:
+    """Purging a device leaves a 'device_deleted' audit tombstone."""
+    _, device_id, site_pk = _seed_site_device_admin()
+    client = TestClient(app)
+    response = client.delete(
+        f"/api/v1/devices/device/{device_id}",
+        params={"mode": "purge", "confirm": "true"},
+        headers=_headers(),
+    )
+    assert response.status_code == 200
+
+    sync_db = homepot.database.SessionLocal()
+    try:
+        tombstone = (
+            sync_db.query(AuditLog)
+            .filter(
+                AuditLog.event_type == "device_deleted",
+                AuditLog.description.like(f"%{device_id}%"),
+            )
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert tombstone is not None
+        # device_id FK is null (device row is gone); identity preserved in data
+        assert tombstone.device_id is None
+        assert tombstone.old_values.get("device_id") == device_id
+        assert tombstone.old_values.get("cleanup_policy") == "purge"
     finally:
         sync_db.close()

--- a/scripts/query-db.sh
+++ b/scripts/query-db.sh
@@ -31,6 +31,7 @@ if [ $# -eq 0 ]; then
     echo "  where                      - Show where PostgreSQL stores data"
     echo "  site_devices [site_id]     - Show all devices for a specific site"
     echo "  device_details [device_id] - Show full details and recent metrics for a device"
+    echo "  archived_purged            - Show archived (data retained) and purged (tombstone) devices"
     echo "  sql 'query'                - Run custom SQL query"
     echo ""
     echo "Examples:"
@@ -71,10 +72,33 @@ EOF
         ;;
     devices)
         psql -h localhost -p 5432 -U homepot_user -d homepot_db <<EOF
-SELECT d.id, d.device_id, d.name, d.device_type, s.site_id, d.status 
+SELECT d.id, d.device_id, d.name, d.device_type, s.site_id, d.lifecycle_state, d.is_active, d.status
 FROM devices d
 JOIN sites s ON d.site_id = s.id
+ORDER BY d.id
 LIMIT 10;
+EOF
+        ;;
+    archived_purged)
+        echo "=== Archived / Purged Devices ==="
+        echo ""
+        echo "--- Archived devices (unpaired/retired, data retained) ---"
+        psql -h localhost -p 5432 -U homepot_user -d homepot_db <<EOF
+SELECT d.device_id, d.name, d.lifecycle_state, s.site_id
+FROM devices d
+JOIN sites s ON d.site_id = s.id
+WHERE d.is_active = false OR d.lifecycle_state IN ('unpaired','retired')
+ORDER BY d.id;
+EOF
+        echo ""
+        echo "--- Purged devices (data deleted; tombstone from audit_logs) ---"
+        psql -h localhost -p 5432 -U homepot_user -d homepot_db <<EOF
+SELECT al.created_at AS purged_at,
+       (al.old_values->>'device_id') AS device_id,
+       (al.old_values->>'name') AS name
+FROM audit_logs al
+WHERE al.event_type = 'device_deleted'
+ORDER BY al.created_at DESC;
 EOF
         ;;
     jobs)


### PR DESCRIPTION
## Problem

Purging a device deleted every trace, so there was no record that the purge happened. Also,  showed only a stale `status` column, so archived (unpaired/retired) devices looked identical to active ones.

## Changes

**Audit-log tombstone on purge** (`database.py purge_device`):
- Records a `device_deleted` audit event before deleting the device row.
- `device_id` FK is set to `NULL` (the row is deleted immediately after, so an FK would break); the purged identity is preserved in `old_values` (`device_id`, `name`, `site_id`, `cleanup_policy=purge`). `created_at` records when the purge happened.

**`query-db.sh` visibility**:
- `devices` now shows `lifecycle_state` + `is_active`, so archived/unpaired devices are no longer hidden behind a stale `status`.
- New `archived_purged` command lists:
  - **Archived** devices (from `devices` where `is_active=false` or lifecycle `unpaired`/`retired`) — data retained.
  - **Purged** devices (tombstones from `audit_logs` where `event_type='device_deleted'`) — data deleted, tombstone retained with purge timestamp.

## Verification

- New test `test_device_purge_creates_audit_tombstone` verifies the tombstone row is created (event `device_deleted`, `device_id` NULL, identity in `old_values`).
- `archived_purged` + `devices` commands verified against the live DB.
- 15 tests pass (site_delete, device_unpair, lifecycle); black / isort / flake8 / mypy clean.