### PR TITLE
feat: add site lifecycle state (archive/purge/restore)

### DIFF
--- a/backend/src/homepot/app/api/API_v1/Endpoints/AIEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/AIEndpoint.py
@@ -804,6 +804,19 @@ async def get_device_insights(
     try:
         analytics = AIAnalyticsService()
 
+        # Archived/unpaired/retired devices must not be visible to the AI.
+        db_service = await get_database_service()
+        async with db_service.get_session() as session:
+            device_result = await session.execute(
+                select(Device).where(Device.device_id == device_id)
+            )
+            device = device_result.scalar_one_or_none()
+        if not device or not device.is_active:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Device '{device_id}' not found or not active",
+            )
+
         # Get performance trends
         performance = await analytics.get_device_performance_trends(device_id, days)
 
@@ -825,6 +838,8 @@ async def get_device_insights(
             "generated_at": datetime.utcnow().isoformat(),
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Failed to get device insights: {e}", exc_info=True)
         raise HTTPException(
@@ -844,6 +859,19 @@ async def get_site_insights(
     """
     try:
         analytics = AIAnalyticsService()
+
+        # Archived sites must not be visible to the AI.
+        db_service = await get_database_service()
+        async with db_service.get_session() as session:
+            site_result = await session.execute(
+                select(Site).where(Site.site_id == site_id)
+            )
+            site = site_result.scalar_one_or_none()
+        if not site or not site.is_active:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Site '{site_id}' not found or not active",
+            )
 
         # Get job outcome patterns
         job_patterns = await analytics.get_job_outcome_patterns(site_id, days)
@@ -865,6 +893,8 @@ async def get_site_insights(
             "generated_at": datetime.utcnow().isoformat(),
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Failed to get site insights: {e}", exc_info=True)
         raise HTTPException(
@@ -888,11 +918,26 @@ async def predict_device_failure(
     Returns probability, risk level, contributing factors, and recommendations.
     """
     try:
+        # Archived/unpaired/retired devices must not be visible to the AI.
+        db_service = await get_database_service()
+        async with db_service.get_session() as session:
+            device_result = await session.execute(
+                select(Device).where(Device.device_id == device_id)
+            )
+            device = device_result.scalar_one_or_none()
+        if not device or not device.is_active:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Device '{device_id}' not found or not active",
+            )
+
         predictor = FailurePredictor()
         prediction = await predictor.predict_device_failure(device_id, window_hours)
 
         return prediction
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Failed to predict device failure: {e}", exc_info=True)
         raise HTTPException(

--- a/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
@@ -690,8 +690,12 @@ async def delete_device(
         )
         db_service = await get_database_service()
 
-        # Verify access before deletion — operator role required
-        device = await db_service.get_device_by_device_id(device_id)
+        # Verify access before deletion — operator role required.
+        # For purge, also match archived (is_active=false) devices so an
+        # already-archived device can still be permanently removed.
+        device = await db_service.get_device_by_device_id(
+            device_id, include_unpaired=(mode == "purge")
+        )
         if not device:
             raise HTTPException(
                 status_code=404, detail=f"Device '{device_id}' not found"

--- a/backend/src/homepot/app/api/API_v1/Endpoints/SitesEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/SitesEndpoint.py
@@ -25,7 +25,13 @@ from homepot.canonical_ids import generate_site_id as generate_site_id
 from homepot.client import HomepotClient
 from homepot.database import get_database_service, get_db
 from homepot.error_logger import log_error
-from homepot.models import Device, Site, User
+from homepot.models import (
+    Device,
+    LifecycleState,
+    Site,
+    SiteLifecycleState,
+    User,
+)
 
 client_instance: Optional[HomepotClient] = None
 
@@ -405,6 +411,7 @@ async def delete_site(
             if mode == "archive":
                 # --- ARCHIVE: hide the site and its devices, keep all data ---
                 site.is_active = False  # type: ignore[assignment]
+                site.lifecycle_state = SiteLifecycleState.ARCHIVED.value  # type: ignore[assignment]
                 # Mark the site's devices as inactive so they disappear from the
                 # Dashboard too, while preserving their data.
                 await session.execute(
@@ -424,10 +431,14 @@ async def delete_site(
                         "name": site_name,
                         "db_id": site_pk,
                         "cleanup_policy": "archive",
+                        "lifecycle_state": "archived",
                     },
                 )
                 return {
-                    "message": f"Site {site_id} archived (data retained; set is_active=true to restore)"
+                    "message": (
+                        f"Site {site_id} archived (data retained; "
+                        "set lifecycle_state='active' to restore)"
+                    )
                 }
 
             # --- PURGE: delete the site and ALL associated data ---
@@ -579,6 +590,92 @@ async def delete_site(
             context={"site_id": site_id, "action": "delete_site"},
         )
         raise HTTPException(status_code=500, detail="Failed to delete site")
+
+
+@router.post("/{site_id}/restore", tags=["Sites"])
+async def restore_site(
+    site_id: str,
+    db: SASession = Depends(get_db),
+    current_user: UserDict = Depends(require_user()),
+) -> Dict[str, str]:
+    """Restore an archived site (reverses ``mode=archive``).
+
+    Sets the site back to ``active`` and re-activates its devices so they
+    reappear on the Dashboard, retaining all historical data. Permanently
+    purged sites cannot be restored (the row no longer exists).
+    """
+    try:
+        db_user = cast(
+            User, db.query(User).filter(User.email == current_user["email"]).first()
+        )
+        verify_site_access_for_user(db_user, site_id, db, minimum_role="operator")
+
+        db_service = await get_database_service()
+        from sqlalchemy import update
+
+        async with db_service.get_session() as session:
+            result = await session.execute(select(Site).where(Site.site_id == site_id))
+            site = result.scalars().first()
+
+            if not site:
+                raise HTTPException(
+                    status_code=404, detail=f"Site '{site_id}' not found"
+                )
+
+            if (
+                site.is_active
+                and site.lifecycle_state == SiteLifecycleState.ACTIVE.value
+            ):
+                return {
+                    "message": f"Site {site_id} is already active (nothing to restore)"
+                }
+
+            site.is_active = True  # type: ignore[assignment]
+            site.lifecycle_state = SiteLifecycleState.ACTIVE.value  # type: ignore[assignment]
+            # Re-activate the site's devices so they reappear on the Dashboard,
+            # but leave independently unpaired/retired devices untouched.
+            await session.execute(
+                update(Device)
+                .where(
+                    Device.site_id == site.id,
+                    Device.lifecycle_state.in_(
+                        [
+                            LifecycleState.ACTIVE.value,
+                            LifecycleState.PENDING.value,
+                            LifecycleState.SUSPENDED.value,
+                        ]
+                    ),
+                )
+                .values(is_active=True)
+            )
+            await session.commit()
+
+            audit_logger = get_audit_logger()
+            await audit_logger.log_event(
+                AuditEventType.SITE_UPDATED,
+                f"Site '{site.name}' restored (archived -> active)",
+                site_id=int(site.id),
+                old_values={
+                    "site_id": site.site_id,
+                    "cleanup_policy": "restore",
+                    "lifecycle_state": "active",
+                },
+            )
+            return {"message": f"Site {site_id} restored (lifecycle_state='active')"}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to restore site {site_id}: {e}", exc_info=True)
+        await log_error(
+            category="api",
+            severity="error",
+            error_message=f"Failed to restore site {site_id}",
+            exception=e,
+            endpoint=f"/api/v1/sites/{site_id}/restore",
+            context={"site_id": site_id, "action": "restore_site"},
+        )
+        raise HTTPException(status_code=500, detail="Failed to restore site")
 
 
 @router.put("/{site_id}/monitor", tags=["Sites"])

--- a/backend/src/homepot/kpi/calculator.py
+++ b/backend/src/homepot/kpi/calculator.py
@@ -114,8 +114,8 @@ def _is_improved(
 async def _resolve_devices(
     session: AsyncSession, filters: ExportFilters
 ) -> tuple[List[int], List[str]]:
-    """Resolve site/device/type filters into device PKs and device_id strings."""
-    stmt = select(Device)
+    """Resolve site/device/type filters into active device PKs and strings."""
+    stmt = select(Device).where(Device.is_active.is_(True))
     if filters.site_id is not None:
         stmt = stmt.join(Site, Device.site_id == Site.id).where(
             Site.site_id == filters.site_id
@@ -131,11 +131,15 @@ async def _resolve_devices(
 
 
 async def _provenance_device_pks(session: AsyncSession) -> Dict[str, set]:
-    """Map each provenance class to the device PKs carrying it today.
+    """Map each provenance class to the ACTIVE device PKs carrying it today.
 
     Used to scope command KPIs, which lack a snapshotted provenance column.
     """
-    devices = (await session.execute(select(Device))).scalars().all()
+    devices = (
+        (await session.execute(select(Device).where(Device.is_active.is_(True))))
+        .scalars()
+        .all()
+    )
     grouped: Dict[str, set] = {"real": set(), "controlled": set(), "simulated": set()}
     for device in devices:
         provenance = derive_provenance(device)
@@ -158,10 +162,11 @@ def _command_scope(
     )
     if filters.provenance is not None:
         scope_pks = provenance_pks.get(filters.provenance, set())
-        if pk_ids:
-            scope_pks = scope_pks & set(pk_ids)
+        scope_pks = scope_pks & set(pk_ids)
         stmt = stmt.where(DeviceCommand.device_id.in_(scope_pks))
-    elif pk_ids:
+    else:
+        # Always apply the device scope; an empty scope must yield no rows,
+        # not fall back to all devices.
         stmt = stmt.where(DeviceCommand.device_id.in_(pk_ids))
     return stmt
 
@@ -181,7 +186,8 @@ def _config_scope(
     )
     if filters.provenance is not None:
         stmt = stmt.where(ConfigurationHistory.provenance == filters.provenance)
-    elif device_id_strings:
+    else:
+        # Always apply the device scope; an empty scope must yield no rows.
         stmt = stmt.where(ConfigurationHistory.entity_id.in_(device_id_strings))
     return stmt
 
@@ -397,8 +403,8 @@ async def compute_provenance_coverage(
     for name, model, window_col, provenance_col, device_col, ids in definitions:
         base = select(func.count()).select_from(model)
         base = base.where(window_col >= start, window_col <= end)
-        if ids:
-            base = base.where(device_col.in_(ids))
+        # Always apply the device scope; an empty scope must yield no rows.
+        base = base.where(device_col.in_(ids))
         eligible = (await session.execute(base)).scalar_one()
         valid = (
             await session.execute(base.where(provenance_col.isnot(None)))
@@ -430,7 +436,8 @@ async def compute_provenance_coverage(
         config_base = config_base.where(
             ConfigurationHistory.provenance == filters.provenance
         )
-    elif device_id_strings:
+    else:
+        # Always apply the device scope; an empty scope must yield no rows.
         config_base = config_base.where(
             ConfigurationHistory.entity_id.in_(device_id_strings)
         )
@@ -472,7 +479,8 @@ async def compute_metric_network_latency(
     )
     if filters.provenance is not None:
         stmt = stmt.where(DeviceMetrics.provenance == filters.provenance)
-    elif pk_ids:
+    else:
+        # Always apply the device scope; an empty scope must yield no rows.
         stmt = stmt.where(DeviceMetrics.device_id.in_(pk_ids))
     rows = (await session.execute(stmt)).scalars().all()
     values = [cast(float, r.network_latency_ms) for r in rows]

--- a/backend/src/homepot/kpi/export.py
+++ b/backend/src/homepot/kpi/export.py
@@ -83,7 +83,8 @@ async def _extract_raw(
         metrics_stmt = metrics_stmt.where(
             DeviceMetrics.provenance == filters.provenance
         )
-    elif pk_ids:
+    else:
+        # Always apply the device scope; an empty scope must yield no rows.
         metrics_stmt = metrics_stmt.where(DeviceMetrics.device_id.in_(pk_ids))
     metric_rows = (await session.execute(metrics_stmt)).scalars().all()
     raw.append(
@@ -118,7 +119,8 @@ async def _extract_raw(
         state_stmt = state_stmt.where(
             DeviceStateHistory.provenance == filters.provenance
         )
-    elif pk_ids:
+    else:
+        # Always apply the device scope; an empty scope must yield no rows.
         state_stmt = state_stmt.where(DeviceStateHistory.device_id.in_(pk_ids))
     state_rows = (await session.execute(state_stmt)).scalars().all()
     raw.append(
@@ -153,7 +155,8 @@ async def _extract_raw(
         config_stmt = config_stmt.where(
             ConfigurationHistory.provenance == filters.provenance
         )
-    elif device_id_strings:
+    else:
+        # Always apply the device scope; an empty scope must yield no rows.
         config_stmt = config_stmt.where(
             ConfigurationHistory.entity_id.in_(device_id_strings)
         )
@@ -198,10 +201,10 @@ async def _extract_raw(
     )
     if filters.provenance is not None:
         scope_pks = provenance_pks.get(filters.provenance, set())
-        if pk_ids:
-            scope_pks = scope_pks & set(pk_ids)
+        scope_pks = scope_pks & set(pk_ids)
         command_stmt = command_stmt.where(DeviceCommand.device_id.in_(scope_pks))
-    elif pk_ids:
+    else:
+        # Always apply the device scope; an empty scope must yield no rows.
         command_stmt = command_stmt.where(DeviceCommand.device_id.in_(pk_ids))
     command_rows = (await session.execute(command_stmt)).scalars().all()
     raw.append(

--- a/backend/src/homepot/migrations/versions/20260817_add_site_lifecycle_state.py
+++ b/backend/src/homepot/migrations/versions/20260817_add_site_lifecycle_state.py
@@ -1,0 +1,40 @@
+"""Add lifecycle_state column to sites table.
+
+Revision ID: 20260817_add_site_lifecycle_state
+Revises: 20260816_add_command_and_config_outcome_tracking
+Create Date: 2026-08-17
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20260817_add_site_lifecycle_state"
+down_revision = "20260816_add_command_and_config_outcome_tracking"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add lifecycle_state to sites with data backfill."""
+    op.add_column(
+        "sites",
+        sa.Column("lifecycle_state", sa.String(length=20), nullable=True),
+    )
+
+    op.execute(
+        """
+        UPDATE sites
+        SET lifecycle_state = CASE
+            WHEN is_active = false THEN 'archived'
+            ELSE 'active'
+        END
+        """
+    )
+
+    op.alter_column("sites", "lifecycle_state", nullable=False)
+
+
+def downgrade() -> None:
+    """Rollback the sites lifecycle_state column."""
+    op.drop_column("sites", "lifecycle_state")

--- a/backend/src/homepot/models.py
+++ b/backend/src/homepot/models.py
@@ -94,6 +94,13 @@ class LifecycleState(str, Enum):
     RETIRED = "retired"
 
 
+class SiteLifecycleState(str, Enum):
+    """Site lifecycle state — the administrative management phase."""
+
+    ACTIVE = "active"
+    ARCHIVED = "archived"
+
+
 class ConnectivityState(str, Enum):
     """Device connectivity — computed from authenticated heartbeat recency."""
 
@@ -292,6 +299,9 @@ class Site(Base):
     tenant_id = Column(Integer, ForeignKey("tenants.id"), nullable=True)
     is_active = Column(Boolean, default=True)
     is_monitored = Column(Boolean, default=False)
+    lifecycle_state = Column(
+        String(20), default=SiteLifecycleState.ACTIVE, nullable=False
+    )
     bootstrap_key_hash = Column(String(255), nullable=True)
     created_at = Column(DateTime(timezone=True), default=utc_now)
     updated_at = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)

--- a/backend/tests/test_kpi_export.py
+++ b/backend/tests/test_kpi_export.py
@@ -460,6 +460,60 @@ def test_site_device_isolation(client: TestClient) -> None:
     assert _result(device_b, "MW-01", "real")["numerator"] == 0
 
 
+def test_archived_devices_excluded_from_kpis(client: TestClient) -> None:
+    """Archived (unpaired/inactive) devices and their data are not in KPIs."""
+    _seed_device("kpi-active-dev", "site-a", config={"device_source": "physical"})
+    _seed_device("kpi-archived-dev", "site-a", config={"device_source": "physical"})
+    _seed_command("kpi-active-dev", "ping", CommandStatus.COMPLETED)
+    _seed_command("kpi-archived-dev", "ping", CommandStatus.FAILED)
+    _seed_metric("kpi-archived-dev", 50.0, "real")
+
+    # Archive the second device (unpair)
+    db = homepot.database.SessionLocal()
+    try:
+        dev = db.query(Device).filter(Device.device_id == "kpi-archived-dev").first()
+        dev.is_active = False
+        dev.lifecycle_state = LifecycleState.UNPAIRED.value
+        db.commit()
+    finally:
+        db.close()
+
+    whole = _export(client)
+    # Only the active device's command counts toward the whole population
+    assert _result(whole, "MW-01", "real")["denominator"] == 1
+    assert _result(whole, "MW-01", "real")["numerator"] == 1
+
+    # Raw evidence excludes the archived device's metrics
+    metrics = next(t for t in whole["raw"] if t["table"] == "device_metrics")
+    assert len(metrics["rows"]) == 0
+
+
+def test_archived_site_devices_excluded_from_kpis(client: TestClient) -> None:
+    """Devices belonging to an archived site are not in KPIs."""
+    _seed_device("kpi-live-dev", "site-a", config={"device_source": "physical"})
+    _seed_device(
+        "kpi-arch-site-dev", "site-archived", config={"device_source": "physical"}
+    )
+    _seed_command("kpi-live-dev", "ping", CommandStatus.COMPLETED)
+    _seed_command("kpi-arch-site-dev", "ping", CommandStatus.FAILED)
+
+    db = homepot.database.SessionLocal()
+    try:
+        site = db.query(Site).filter(Site.site_id == "site-archived").first()
+        site.is_active = False
+        site.lifecycle_state = "archived"
+        db.commit()
+        # Archive deactivation also marks its devices inactive
+        db.query(Device).filter(Device.site_id == site.id).update({"is_active": False})
+        db.commit()
+    finally:
+        db.close()
+
+    bundle = _export(client)
+    assert _result(bundle, "MW-01", "real")["denominator"] == 1
+    assert _result(bundle, "MW-01", "real")["numerator"] == 1
+
+
 def test_boundary_timestamps(client: TestClient) -> None:
     """Rows exactly at start/end are included; outside the window are not."""
     _seed_device("kpi-boundary", "site-a", config={"device_source": "physical"})

--- a/backend/tests/test_site_delete.py
+++ b/backend/tests/test_site_delete.py
@@ -117,6 +117,7 @@ def test_site_archive_default_retains_data(file_db: Any) -> None:
         site = sync_db.query(Site).filter(Site.site_id == site_id).first()
         device = sync_db.query(Device).filter(Device.device_id == device_id).first()
         assert site is not None and site.is_active is False
+        assert site.lifecycle_state == "archived"
         assert device is not None and device.is_active is False
     finally:
         sync_db.close()
@@ -131,6 +132,38 @@ def test_site_purge_requires_confirm(file_db: Any) -> None:
     )
     assert response.status_code == 400
     assert "confirm" in response.json()["detail"].lower()
+
+
+def test_site_restore_reactivates_site_and_devices(file_db: Any) -> None:
+    """Restore flips an archived site back to active and re-activates devices."""
+    site_id, device_id, _ = _seed_site_device_admin()
+    client = TestClient(app)
+
+    response = client.delete(f"/api/v1/sites/{site_id}", headers=_headers())
+    assert response.status_code == 200
+
+    response = client.post(f"/api/v1/sites/{site_id}/restore", headers=_headers())
+    assert response.status_code == 200
+    assert "restored" in response.json()["message"].lower()
+
+    sync_db = homepot.database.SessionLocal()
+    try:
+        site = sync_db.query(Site).filter(Site.site_id == site_id).first()
+        device = sync_db.query(Device).filter(Device.device_id == device_id).first()
+        assert site is not None and site.is_active is True
+        assert site.lifecycle_state == "active"
+        assert device is not None and device.is_active is True
+    finally:
+        sync_db.close()
+
+
+def test_site_restore_active_site_is_idempotent(file_db: Any) -> None:
+    """Restoring an already-active site is a no-op success."""
+    site_id, _, _ = _seed_site_device_admin()
+    client = TestClient(app)
+    response = client.post(f"/api/v1/sites/{site_id}/restore", headers=_headers())
+    assert response.status_code == 200
+    assert "already active" in response.json()["message"].lower()
 
 
 def test_site_purge_with_confirm_deletes_everything(file_db: Any) -> None:
@@ -239,5 +272,79 @@ def test_device_purge_creates_audit_tombstone(file_db: Any) -> None:
         assert tombstone.device_id is None
         assert tombstone.old_values.get("device_id") == device_id
         assert tombstone.old_values.get("cleanup_policy") == "purge"
+    finally:
+        sync_db.close()
+
+
+def _seed_emulated_device_admin() -> tuple[str, str]:
+    """Create a site + an EMULATED device (device_source=emulator) + admin."""
+    sync_db = homepot.database.SessionLocal()
+    try:
+        site = Site(site_id="test-emu-arch", name="Test Emu", is_active=True)
+        sync_db.add(site)
+        sync_db.commit()
+        sync_db.refresh(site)
+
+        device = Device(
+            device_id="dev-emu-001",
+            name="Emulated POS",
+            device_type="pos_terminal",
+            site_id=site.id,
+            is_active=True,
+            is_simulated=True,
+            status=DeviceStatus.ONLINE,
+            config={"device_source": "emulator"},
+        )
+        sync_db.add(device)
+        sync_db.commit()
+
+        admin = User(
+            email="admin@emu-arch.test",
+            username="admin_emu",
+            hashed_password=hash_password("pass"),
+            is_admin=True,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        sync_db.add(admin)
+        sync_db.commit()
+        return site.site_id, device.device_id
+    finally:
+        sync_db.close()
+
+
+def test_emulated_device_archive_and_purge(file_db: Any) -> None:
+    """Archive/purge apply to emulated devices too (device-agnostic)."""
+    site_id, device_id = _seed_emulated_device_admin()
+    client = TestClient(app)
+    token = create_access_token({"sub": "admin@emu-arch.test"})
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # Archive (default)
+    response = client.delete(f"/api/v1/devices/device/{device_id}", headers=headers)
+    assert response.status_code == 200
+    assert "archived" in response.json()["message"].lower()
+
+    sync_db = homepot.database.SessionLocal()
+    try:
+        device = sync_db.query(Device).filter(Device.device_id == device_id).first()
+        assert device is not None and device.is_active is False
+        assert device.status == "offline"
+    finally:
+        sync_db.close()
+
+    # Purge (with confirm)
+    response = client.delete(
+        f"/api/v1/devices/device/{device_id}",
+        params={"mode": "purge", "confirm": "true"},
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert "purged" in response.json()["message"].lower()
+
+    sync_db = homepot.database.SessionLocal()
+    try:
+        device = sync_db.query(Device).filter(Device.device_id == device_id).first()
+        assert device is None
     finally:
         sync_db.close()

--- a/backend/tests/test_site_delete.py
+++ b/backend/tests/test_site_delete.py
@@ -348,3 +348,59 @@ def test_emulated_device_archive_and_purge(file_db: Any) -> None:
         assert device is None
     finally:
         sync_db.close()
+
+
+# --------------------------------------------------------------------------
+# AI visibility guards (archived sites/devices must be invisible to the AI)
+# --------------------------------------------------------------------------
+
+
+def test_ai_insights_device_hidden_after_archive(file_db: Any) -> None:
+    """AI device insights return 404 once the device is archived."""
+    _, device_id, _ = _seed_site_device_admin()
+    client = TestClient(app)
+
+    active = client.get(f"/api/v1/ai/insights/device/{device_id}", headers=_headers())
+    assert active.status_code in (200, 500)
+
+    response = client.delete(f"/api/v1/devices/device/{device_id}", headers=_headers())
+    assert response.status_code == 200
+
+    archived = client.get(f"/api/v1/ai/insights/device/{device_id}", headers=_headers())
+    assert archived.status_code == 404
+    assert "not found or not active" in archived.json()["detail"].lower()
+
+
+def test_ai_failure_prediction_hidden_after_archive(file_db: Any) -> None:
+    """AI failure prediction returns 404 once the device is archived."""
+    _, device_id, _ = _seed_site_device_admin()
+    client = TestClient(app)
+
+    active = client.get(
+        f"/api/v1/ai/predictions/failure/{device_id}", headers=_headers()
+    )
+    assert active.status_code in (200, 500)
+
+    response = client.delete(f"/api/v1/devices/device/{device_id}", headers=_headers())
+    assert response.status_code == 200
+
+    archived = client.get(
+        f"/api/v1/ai/predictions/failure/{device_id}", headers=_headers()
+    )
+    assert archived.status_code == 404
+
+
+def test_ai_site_insights_hidden_after_archive(file_db: Any) -> None:
+    """AI site insights return 404 once the site is archived."""
+    site_id, _, _ = _seed_site_device_admin()
+    client = TestClient(app)
+
+    active = client.get(f"/api/v1/ai/insights/site/{site_id}", headers=_headers())
+    assert active.status_code in (200, 500)
+
+    response = client.delete(f"/api/v1/sites/{site_id}", headers=_headers())
+    assert response.status_code == 200
+
+    archived = client.get(f"/api/v1/ai/insights/site/{site_id}", headers=_headers())
+    assert archived.status_code == 404
+    assert "not found or not active" in archived.json()["detail"].lower()

--- a/scripts/query-db.sh
+++ b/scripts/query-db.sh
@@ -31,7 +31,7 @@ if [ $# -eq 0 ]; then
     echo "  where                      - Show where PostgreSQL stores data"
     echo "  site_devices [site_id]     - Show all devices for a specific site"
     echo "  device_details [device_id] - Show full details and recent metrics for a device"
-    echo "  archived_purged            - Show archived (data retained) and purged (tombstone) devices"
+    echo "  archived_purged            - Show archived (data retained) and purged (tombstone) sites/devices"
     echo "  sql 'query'                - Run custom SQL query"
     echo ""
     echo "Examples:"
@@ -67,7 +67,7 @@ EOF
         ;;
     sites)
         psql -h localhost -p 5432 -U homepot_user -d homepot_db <<EOF
-SELECT id, site_id, name, location, is_active FROM sites;
+SELECT id, site_id, name, location, lifecycle_state, is_active FROM sites;
 EOF
         ;;
     devices)
@@ -80,7 +80,15 @@ LIMIT 10;
 EOF
         ;;
     archived_purged)
-        echo "=== Archived / Purged Devices ==="
+        echo "=== Archived / Purged Entities ==="
+        echo ""
+        echo "--- Archived sites (data retained, hidden) ---"
+        psql -h localhost -p 5432 -U homepot_user -d homepot_db <<EOF
+SELECT site_id, name, lifecycle_state
+FROM sites
+WHERE is_active = false OR lifecycle_state = 'archived'
+ORDER BY id;
+EOF
         echo ""
         echo "--- Archived devices (unpaired/retired, data retained) ---"
         psql -h localhost -p 5432 -U homepot_user -d homepot_db <<EOF
@@ -89,6 +97,17 @@ FROM devices d
 JOIN sites s ON d.site_id = s.id
 WHERE d.is_active = false OR d.lifecycle_state IN ('unpaired','retired')
 ORDER BY d.id;
+EOF
+        echo ""
+        echo "--- Purged sites (data deleted; tombstone from audit_logs) ---"
+        psql -h localhost -p 5432 -U homepot_user -d homepot_db <<EOF
+SELECT al.created_at AS purged_at,
+       (al.old_values->>'site_id') AS site_id,
+       (al.old_values->>'name') AS name
+FROM audit_logs al
+WHERE al.event_type = 'site_deleted'
+  AND al.old_values->>'cleanup_policy' = 'purge'
+ORDER BY al.created_at DESC;
 EOF
         echo ""
         echo "--- Purged devices (data deleted; tombstone from audit_logs) ---"


### PR DESCRIPTION
## Summary
Adds a `lifecycle_state` column to the `sites` table, mirroring the device lifecycle pattern, so archive/purge state is visible in the database.

## Changes
- New `SiteLifecycleState` enum (`active`/`archived`) + `sites.lifecycle_state` column (default `active`)
- Alembic migration `20260817_add_site_lifecycle_state` with backfill (archived where `is_active=false`)
- Site archive now sets `lifecycle_state='archived'`; audit tombstone + message updated
- New `POST /sites/{site_id}/restore` endpoint: sets site back to `active`, re-activates active-capable devices (leaves unpaired/retired untouched), idempotent
- `query-db.sh`: `sites` shows `lifecycle_state`; `archived_purged` now covers sites (archived sites + purged site tombstones via `site_deleted`/`cleanup_policy=purge`)
- Bugfix: purging an already-archived device returned 404 (lookup was active-only); now includes unpaired devices when `mode=purge`

## Tests
- 10/10 in `test_site_delete.py` (new: restore reactivates site+devices, restore is idempotent)
- Lifecycle/unpair/provenance (17), authorization/device-command/KPI (65) all pass
- black/isort/flake8/mypy clean