### PR TITLE
feat: archive/purge options in site & device delete dialogs

### DIFF
--- a/backend/src/homepot/database.py
+++ b/backend/src/homepot/database.py
@@ -539,7 +539,7 @@ class DatabaseService:
         configuration history, audit logs, and the device row itself.
         Irreversible -- only call after an explicit ``confirm``.
         """
-        from sqlalchemy import delete
+        from sqlalchemy import delete, update
 
         from homepot.models import DeviceAssignment, DeviceLifecycleEvent
 
@@ -577,6 +577,14 @@ class DatabaseService:
                     delete(AuditLog).where(AuditLog.job_id.in_(job_ids))
                 )
             await session.execute(delete(Job).where(Job.device_id == pk))
+
+            # The device row itself carries a nullable FK to its current
+            # lifecycle epoch (Device.lifecycle_epoch_id); null it before
+            # deleting the epochs or the delete violates
+            # devices_lifecycle_epoch_id_fkey.
+            await session.execute(
+                update(Device).where(Device.id == pk).values(lifecycle_epoch_id=None)
+            )
 
             # Lifecycle epochs for this device (after lifecycle events above)
             await session.execute(

--- a/backend/tests/test_site_delete.py
+++ b/backend/tests/test_site_delete.py
@@ -20,7 +20,15 @@ from homepot.app.auth_utils import create_access_token, hash_password
 from homepot.app.main import app
 from homepot.config import reload_settings
 import homepot.database
-from homepot.models import AuditLog, Base, Device, DeviceStatus, Site, User
+from homepot.models import (
+    AuditLog,
+    Base,
+    Device,
+    DeviceStatus,
+    LifecycleEpoch,
+    Site,
+    User,
+)
 
 
 @pytest.fixture
@@ -43,11 +51,40 @@ def file_db(monkeypatch: Any) -> Generator[None, None, None]:
     new_engine = create_engine(
         db_url, connect_args={"check_same_thread": False}, pool_pre_ping=True
     )
+
+    from sqlalchemy import event
+
+    @event.listens_for(new_engine, "connect")
+    def _set_sqlite_pragma(dbapi_connection, connection_record):  # type: ignore[no-untyped-def]
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
     Base.metadata.create_all(bind=new_engine)
     new_session_local = sessionmaker(bind=new_engine, autocommit=False, autoflush=False)
 
     monkeypatch.setattr(homepot.database, "sync_engine", new_engine)
     monkeypatch.setattr(homepot.database, "SessionLocal", new_session_local)
+
+    # The async engine used by the API is created lazily; construct it now,
+    # attach FK enforcement before any connection is opened, then initialize so
+    # the tests exercise the same FK constraints as PostgreSQL.
+    import homepot.database as db_mod
+
+    async def _init_async() -> None:
+        service = db_mod.DatabaseService()
+        from sqlalchemy import event as sa_event
+
+        @sa_event.listens_for(service.engine.sync_engine, "connect")
+        def _async_sqlite_pragma(dbapi_connection, connection_record):  # type: ignore[no-untyped-def]
+            cursor = dbapi_connection.cursor()
+            cursor.execute("PRAGMA foreign_keys=ON")
+            cursor.close()
+
+        await service.initialize()
+        db_mod._db_service = service
+
+    asyncio.run(_init_async())
 
     yield
 
@@ -78,6 +115,7 @@ def _seed_site_device_admin() -> tuple[str, str, int]:
         )
         sync_db.add(device)
         sync_db.commit()
+        sync_db.refresh(device)
 
         admin = User(
             email="admin@arch-purge.test",
@@ -90,6 +128,57 @@ def _seed_site_device_admin() -> tuple[str, str, int]:
         sync_db.add(admin)
         sync_db.commit()
         return site.site_id, device.device_id, site.id
+    finally:
+        sync_db.close()
+
+
+def _seed_device_with_epoch(device_id: str = "dev-epoch-001") -> None:
+    """Create a site, device, and a linked lifecycle epoch (as after claiming)."""
+    import uuid
+
+    sync_db = homepot.database.SessionLocal()
+    try:
+        site = Site(site_id="site-epoch", name="Epoch Co", is_active=True)
+        sync_db.add(site)
+        sync_db.commit()
+        sync_db.refresh(site)
+
+        device = Device(
+            device_id=device_id,
+            name="Epoch POS",
+            device_type="pos_terminal",
+            site_id=site.id,
+            is_active=True,
+            status=DeviceStatus.ONLINE,
+        )
+        sync_db.add(device)
+        sync_db.commit()
+        sync_db.refresh(device)
+
+        epoch = LifecycleEpoch(
+            epoch_id=str(uuid.uuid4()),
+            device_id=device.id,
+            site_id=site.id,
+            claimed_at=datetime.now(timezone.utc),
+            enrolment_method="pre-provisioned",
+        )
+        sync_db.add(epoch)
+        sync_db.commit()
+        sync_db.refresh(epoch)
+
+        admin = User(
+            email="admin@arch-purge.test",
+            username="admin_ap",
+            hashed_password=hash_password("pass"),
+            is_admin=True,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        if not sync_db.query(User).filter(User.email == admin.email).first():
+            sync_db.add(admin)
+
+        device.lifecycle_epoch_id = epoch.id  # type: ignore[assignment]
+        sync_db.commit()
     finally:
         sync_db.close()
 
@@ -342,10 +431,33 @@ def test_emulated_device_archive_and_purge(file_db: Any) -> None:
     assert response.status_code == 200
     assert "purged" in response.json()["message"].lower()
 
+
+def test_device_purge_with_lifecycle_epoch_deletes(file_db: Any) -> None:
+    """Purging a device whose current epoch is linked via lifecycle_epoch_id works.
+
+    Regression: deleting the lifecycle epochs before the device row used to
+    violate devices_lifecycle_epoch_id_fkey on PostgreSQL (device still
+    referenced the epoch), returning an Internal Server Error.
+    """
+    device_id = "dev-epoch-001"
+    _seed_device_with_epoch(device_id)
+    client = TestClient(app)
+    response = client.delete(
+        f"/api/v1/devices/device/{device_id}",
+        params={"mode": "purge", "confirm": "true"},
+        headers=_headers(),
+    )
+    assert response.status_code == 200
+    assert "purged" in response.json()["message"].lower()
+
     sync_db = homepot.database.SessionLocal()
     try:
         device = sync_db.query(Device).filter(Device.device_id == device_id).first()
         assert device is None
+        epoch = sync_db.query(LifecycleEpoch).filter(
+            LifecycleEpoch.device_id.isnot(None)
+        )
+        assert epoch.count() == 0
     finally:
         sync_db.close()
 

--- a/frontend/src/components/Devices/DeviceDeleteDialog.jsx
+++ b/frontend/src/components/Devices/DeviceDeleteDialog.jsx
@@ -1,12 +1,17 @@
-import React, { useEffect } from 'react';
-import { X, AlertTriangle } from 'lucide-react';
+import React, { useEffect, useState } from 'react';
+import { X, AlertTriangle, Archive, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 // import { trackActivity } from '@/utils/analytics'; // Uncomment if analytics is needed
 
 export default function DeviceDeleteDialog({ isOpen, onClose, onConfirm, deviceName, isDeleting }) {
+  const [mode, setMode] = useState('archive');
+  const [purgeConfirmText, setPurgeConfirmText] = useState('');
+
   // Track when the dialog opens
   useEffect(() => {
     if (isOpen) {
+      setMode('archive');
+      setPurgeConfirmText('');
       // trackActivity('modal_open', '/devices/delete', {
       //   modal: 'delete_device_dialog',
       //   device: deviceName,
@@ -30,12 +35,15 @@ export default function DeviceDeleteDialog({ isOpen, onClose, onConfirm, deviceN
     //   device: deviceName,
     // });
 
-    await onConfirm();
+    await onConfirm(mode);
 
     // trackActivity('device_deleted', '/devices/delete', {
     //   device: deviceName,
     // });
   };
+
+  const isPurge = mode === 'purge';
+  const canConfirm = !isPurge || purgeConfirmText === deviceName;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm">
@@ -43,7 +51,7 @@ export default function DeviceDeleteDialog({ isOpen, onClose, onConfirm, deviceN
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-2 text-destructive">
             <AlertTriangle className="h-5 w-5" />
-            <h3 className="text-lg font-semibold">Delete Device</h3>
+            <h3 className="text-lg font-semibold">{isPurge ? 'Purge Device' : 'Archive Device'}</h3>
           </div>
           <button
             onClick={handleClose}
@@ -53,16 +61,66 @@ export default function DeviceDeleteDialog({ isOpen, onClose, onConfirm, deviceN
           </button>
         </div>
 
-        <div className="mb-6">
-          <p className="text-gray-300 mb-2">
-            Are you sure you want to delete{' '}
-            <span className="font-semibold text-white">{deviceName}</span>?
-          </p>
-          <p className="text-sm text-gray-400">
-            This action cannot be undone. All data associated with this device will be permanently
-            removed.
-          </p>
+        <p className="text-gray-300 mb-5">
+          Choose how you want to remove{' '}
+          <span className="font-semibold text-white">{deviceName}</span>.
+        </p>
+
+        <div className="space-y-3 mb-4">
+          <button
+            type="button"
+            onClick={() => setMode('archive')}
+            className={`w-full flex items-start gap-3 p-4 rounded-lg border text-left transition-colors ${
+              !isPurge
+                ? 'border-teal-500 bg-teal-500/10'
+                : 'border-gray-700 bg-transparent hover:bg-gray-800'
+            }`}
+          >
+            <Archive className={`h-5 w-5 mt-0.5 ${!isPurge ? 'text-teal-400' : 'text-gray-400'}`} />
+            <div>
+              <p className={`font-medium ${!isPurge ? 'text-teal-400' : 'text-white'}`}>Archive</p>
+              <p className="text-sm text-gray-400 mt-0.5">
+                Unpair the device and retain its historical data. The device can be re-paired or
+                restored later.
+              </p>
+            </div>
+          </button>
+
+          <button
+            type="button"
+            onClick={() => setMode('purge')}
+            className={`w-full flex items-start gap-3 p-4 rounded-lg border text-left transition-colors ${
+              isPurge
+                ? 'border-red-500 bg-red-500/10'
+                : 'border-gray-700 bg-transparent hover:bg-gray-800'
+            }`}
+          >
+            <Trash2 className={`h-5 w-5 mt-0.5 ${isPurge ? 'text-red-400' : 'text-gray-400'}`} />
+            <div>
+              <p className={`font-medium ${isPurge ? 'text-red-400' : 'text-white'}`}>Purge</p>
+              <p className="text-sm text-gray-400 mt-0.5">
+                Permanently delete the device and ALL associated data (telemetry, commands,
+                history). This action cannot be undone.
+              </p>
+            </div>
+          </button>
         </div>
+
+        {isPurge && (
+          <div className="mb-5">
+            <p className="text-sm text-red-400 mb-2">
+              Type <span className="font-medium text-white">"{deviceName}"</span> to confirm
+              permanent deletion.
+            </p>
+            <input
+              type="text"
+              value={purgeConfirmText}
+              onChange={(e) => setPurgeConfirmText(e.target.value)}
+              placeholder={deviceName}
+              className="w-full h-9 rounded-md border border-red-500/50 bg-transparent px-3 py-1 text-sm text-white placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-red-500"
+            />
+          </div>
+        )}
 
         <div className="flex justify-end gap-3">
           <Button
@@ -76,10 +134,20 @@ export default function DeviceDeleteDialog({ isOpen, onClose, onConfirm, deviceN
           <Button
             variant="destructive"
             onClick={handleConfirm}
-            disabled={isDeleting}
-            className="bg-red-600 hover:bg-red-700 text-white"
+            disabled={isDeleting || !canConfirm}
+            className={
+              isPurge
+                ? 'bg-red-600 hover:bg-red-700 text-white'
+                : 'bg-transparent text-teal-400 border border-teal-500 hover:bg-teal-500/10'
+            }
           >
-            {isDeleting ? 'Deleting...' : 'Delete Device'}
+            {isDeleting
+              ? isPurge
+                ? 'Purging...'
+                : 'Archiving...'
+              : isPurge
+                ? 'Purge Device'
+                : 'Archive Device'}
           </Button>
         </div>
       </div>

--- a/frontend/src/components/Sites/SiteDeleteDialog.jsx
+++ b/frontend/src/components/Sites/SiteDeleteDialog.jsx
@@ -1,12 +1,16 @@
-import React, { useEffect } from 'react';
-import { X, AlertTriangle } from 'lucide-react';
+import React, { useEffect, useState } from 'react';
+import { X, AlertTriangle, Archive, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { trackActivity } from '@/utils/analytics';
 
 export default function SiteDeleteDialog({ isOpen, onClose, onConfirm, siteName, isDeleting }) {
-  // Track when the dialog opens
+  const [mode, setMode] = useState('archive');
+  const [purgeConfirmText, setPurgeConfirmText] = useState('');
+
   useEffect(() => {
     if (isOpen) {
+      setMode('archive');
+      setPurgeConfirmText('');
       trackActivity('modal_open', '/sites/delete', {
         modal: 'delete_site_dialog',
         site: siteName,
@@ -28,17 +32,20 @@ export default function SiteDeleteDialog({ isOpen, onClose, onConfirm, siteName,
   const handleConfirm = async () => {
     trackActivity('delete_confirm_click', '/sites/delete', {
       site: siteName,
+      mode,
     });
 
     try {
-      await onConfirm();
+      await onConfirm(mode);
 
       trackActivity('site_deleted', '/sites/delete', {
         site: siteName,
+        mode,
       });
     } catch (err) {
       trackActivity('delete_failed', '/sites/delete', {
         site: siteName,
+        mode,
         error: err?.message || 'Delete failed',
       });
 
@@ -46,13 +53,16 @@ export default function SiteDeleteDialog({ isOpen, onClose, onConfirm, siteName,
     }
   };
 
+  const isPurge = mode === 'purge';
+  const canConfirm = !isPurge || purgeConfirmText === siteName;
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm">
       <div className="w-full max-w-md rounded-lg bg-[#141a24] p-6 shadow-lg border border-[#1f2735] animate-in fade-in zoom-in-95 duration-200">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-lg font-semibold text-white flex items-center gap-2">
             <AlertTriangle className="h-5 w-5 text-red-500" />
-            Delete Site
+            {isPurge ? 'Purge Site' : 'Archive Site'}
           </h2>
           <button
             onClick={handleClose}
@@ -62,11 +72,66 @@ export default function SiteDeleteDialog({ isOpen, onClose, onConfirm, siteName,
           </button>
         </div>
 
-        <p className="text-gray-300 mb-6">
-          Are you sure you want to delete{' '}
-          <span className="font-medium text-white">"{siteName}"</span>? This action cannot be undone
-          and will remove all associated devices and data.
+        <p className="text-gray-300 mb-5">
+          Choose how you want to remove <span className="font-medium text-white">"{siteName}"</span>
+          .
         </p>
+
+        <div className="space-y-3 mb-4">
+          <button
+            type="button"
+            onClick={() => setMode('archive')}
+            className={`w-full flex items-start gap-3 p-4 rounded-lg border text-left transition-colors ${
+              !isPurge
+                ? 'border-teal-500 bg-teal-500/10'
+                : 'border-[#1f2735] bg-transparent hover:bg-[#1f2735]'
+            }`}
+          >
+            <Archive className={`h-5 w-5 mt-0.5 ${!isPurge ? 'text-teal-400' : 'text-gray-400'}`} />
+            <div>
+              <p className={`font-medium ${!isPurge ? 'text-teal-400' : 'text-white'}`}>Archive</p>
+              <p className="text-sm text-gray-400 mt-0.5">
+                Hide the site and its devices from the Dashboard. All historical data is retained
+                and the site can be restored later.
+              </p>
+            </div>
+          </button>
+
+          <button
+            type="button"
+            onClick={() => setMode('purge')}
+            className={`w-full flex items-start gap-3 p-4 rounded-lg border text-left transition-colors ${
+              isPurge
+                ? 'border-red-500 bg-red-500/10'
+                : 'border-[#1f2735] bg-transparent hover:bg-[#1f2735]'
+            }`}
+          >
+            <Trash2 className={`h-5 w-5 mt-0.5 ${isPurge ? 'text-red-400' : 'text-gray-400'}`} />
+            <div>
+              <p className={`font-medium ${isPurge ? 'text-red-400' : 'text-white'}`}>Purge</p>
+              <p className="text-sm text-gray-400 mt-0.5">
+                Permanently delete the site and ALL associated data (devices, metrics, commands,
+                history). This action cannot be undone.
+              </p>
+            </div>
+          </button>
+        </div>
+
+        {isPurge && (
+          <div className="mb-5">
+            <p className="text-sm text-red-400 mb-2">
+              Type <span className="font-medium text-white">"{siteName}"</span> to confirm permanent
+              deletion.
+            </p>
+            <input
+              type="text"
+              value={purgeConfirmText}
+              onChange={(e) => setPurgeConfirmText(e.target.value)}
+              placeholder={siteName}
+              className="w-full h-9 rounded-md border border-red-500/50 bg-transparent px-3 py-1 text-sm text-white placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-red-500"
+            />
+          </div>
+        )}
 
         <div className="flex justify-end gap-3">
           <Button
@@ -80,10 +145,20 @@ export default function SiteDeleteDialog({ isOpen, onClose, onConfirm, siteName,
           <Button
             variant="destructive"
             onClick={handleConfirm}
-            disabled={isDeleting}
-            className="bg-transparent text-red-500 border border-red-500 hover:bg-red-500/10"
+            disabled={isDeleting || !canConfirm}
+            className={
+              isPurge
+                ? 'bg-red-600 hover:bg-red-700 text-white'
+                : 'bg-transparent text-teal-400 border border-teal-500 hover:bg-teal-500/10'
+            }
           >
-            {isDeleting ? 'Deleting...' : 'Delete Site'}
+            {isDeleting
+              ? isPurge
+                ? 'Purging...'
+                : 'Archiving...'
+              : isPurge
+                ? 'Purge Site'
+                : 'Archive Site'}
           </Button>
         </div>
       </div>

--- a/frontend/src/pages/Sites/SiteDetail.jsx
+++ b/frontend/src/pages/Sites/SiteDetail.jsx
@@ -115,7 +115,7 @@ export default function SiteDetail() {
     setDeviceToDelete(device);
   };
 
-  const handleConfirmDeleteDevice = async () => {
+  const handleConfirmDeleteDevice = async (mode) => {
     if (!deviceToDelete) return;
 
     try {
@@ -123,7 +123,7 @@ export default function SiteDetail() {
       // Use device_id (string) if available, otherwise fallback to id (int) but convert to string if needed
       // The backend expects the string ID (e.g. "device-123")
       const idToDelete = deviceToDelete.device_id || deviceToDelete.id;
-      await api.devices.delete(idToDelete);
+      await api.devices.delete(idToDelete, mode);
 
       // Remove from list
       setDevices((prev) => prev.filter((d) => (d.device_id || d.id) !== idToDelete));

--- a/frontend/src/pages/Sites/SitesList.jsx
+++ b/frontend/src/pages/Sites/SitesList.jsx
@@ -82,12 +82,12 @@ export default function SitesList() {
     }
   };
 
-  const handleConfirmDelete = async () => {
+  const handleConfirmDelete = async (mode) => {
     if (!siteToDelete) return;
 
     try {
       setIsDeleting(true);
-      await api.sites.delete(siteToDelete.id);
+      await api.sites.delete(siteToDelete.id, mode);
       setSites(sites.filter((s) => s.id !== siteToDelete.id));
       setDeleteDialogOpen(false);
       setSiteToDelete(null);

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -202,10 +202,14 @@ const api = {
     },
 
     /**
-     * Delete site
+     * Delete site.
+     * `mode` is 'archive' (default, reversible) or 'purge' (permanent).
+     * Purge requires `confirm=true` on the backend, so it is always sent.
      */
-    delete: async (siteId) => {
-      const response = await apiClient.delete(`/sites/${siteId}`);
+    delete: async (siteId, mode = 'archive') => {
+      const response = await apiClient.delete(`/sites/${siteId}`, {
+        params: { mode, confirm: true },
+      });
       return response.data;
     },
 
@@ -295,10 +299,14 @@ const api = {
     },
 
     /**
-     * Delete device
+     * Delete device.
+     * `mode` is 'archive' (default, reversible) or 'purge' (permanent).
+     * Purge requires `confirm=true` on the backend, so it is always sent.
      */
-    delete: async (deviceId) => {
-      const response = await apiClient.delete(`/devices/device/${deviceId}`);
+    delete: async (deviceId, mode = 'archive') => {
+      const response = await apiClient.delete(`/devices/device/${deviceId}`, {
+        params: { mode, confirm: true },
+      });
       return response.data;
     },
 

--- a/frontend/tests/unit/DeviceDeleteDialog.test.jsx
+++ b/frontend/tests/unit/DeviceDeleteDialog.test.jsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import DeviceDeleteDialog from '../../src/components/Devices/DeviceDeleteDialog';
+
+describe('DeviceDeleteDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const props = {
+    isOpen: true,
+    onClose: vi.fn(),
+    onConfirm: vi.fn().mockResolvedValue(undefined),
+    deviceName: 'pos-001',
+    isDeleting: false,
+  };
+
+  it('renders archive mode by default with Archive Device confirm', () => {
+    render(<DeviceDeleteDialog {...props} />);
+
+    expect(screen.getByRole('button', { name: 'Archive Device' })).toBeInTheDocument();
+  });
+
+  it('calls onConfirm with archive when Archive Device is clicked', async () => {
+    render(<DeviceDeleteDialog {...props} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Archive Device' }));
+
+    expect(props.onConfirm).toHaveBeenCalledWith('archive');
+  });
+
+  it('switches to purge mode and requires the device name to confirm', () => {
+    render(<DeviceDeleteDialog {...props} />);
+
+    fireEvent.click(screen.getByText('Purge'));
+
+    const confirmButton = screen.getByRole('button', { name: 'Purge Device' });
+    expect(confirmButton).toBeInTheDocument();
+    expect(confirmButton).toBeDisabled();
+
+    const input = screen.getByPlaceholderText('pos-001');
+    fireEvent.change(input, { target: { value: 'pos-999' } });
+    expect(confirmButton).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: 'pos-001' } });
+    expect(confirmButton).toBeEnabled();
+  });
+
+  it('calls onConfirm with purge once the name matches', async () => {
+    render(<DeviceDeleteDialog {...props} />);
+
+    fireEvent.click(screen.getByText('Purge'));
+    fireEvent.change(screen.getByPlaceholderText('pos-001'), {
+      target: { value: 'pos-001' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Purge Device' }));
+
+    expect(props.onConfirm).toHaveBeenCalledWith('purge');
+  });
+});

--- a/frontend/tests/unit/SiteDeleteDialog.test.jsx
+++ b/frontend/tests/unit/SiteDeleteDialog.test.jsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SiteDeleteDialog from '../../src/components/Sites/SiteDeleteDialog';
+
+vi.mock('../../src/utils/analytics', () => ({
+  trackActivity: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('SiteDeleteDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const props = {
+    isOpen: true,
+    onClose: vi.fn(),
+    onConfirm: vi.fn().mockResolvedValue(undefined),
+    siteName: 'Head Office',
+    isDeleting: false,
+  };
+
+  it('renders archive mode by default with Archive Site confirm', () => {
+    render(<SiteDeleteDialog {...props} />);
+
+    expect(screen.getByRole('button', { name: 'Archive Site' })).toBeInTheDocument();
+  });
+
+  it('calls onConfirm with archive when Archive Site is clicked', async () => {
+    render(<SiteDeleteDialog {...props} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Archive Site' }));
+
+    expect(props.onConfirm).toHaveBeenCalledWith('archive');
+  });
+
+  it('switches to purge mode and requires the site name to confirm', () => {
+    render(<SiteDeleteDialog {...props} />);
+
+    fireEvent.click(screen.getByText('Purge'));
+
+    const confirmButton = screen.getByRole('button', { name: 'Purge Site' });
+    expect(confirmButton).toBeInTheDocument();
+    expect(confirmButton).toBeDisabled();
+
+    const input = screen.getByPlaceholderText('Head Office');
+    fireEvent.change(input, { target: { value: 'wrong name' } });
+    expect(confirmButton).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: 'Head Office' } });
+    expect(confirmButton).toBeEnabled();
+  });
+
+  it('calls onConfirm with purge once the name matches', async () => {
+    render(<SiteDeleteDialog {...props} />);
+
+    fireEvent.click(screen.getByText('Purge'));
+    fireEvent.change(screen.getByPlaceholderText('Head Office'), {
+      target: { value: 'Head Office' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Purge Site' }));
+
+    expect(props.onConfirm).toHaveBeenCalledWith('purge');
+  });
+
+  it('resets mode and confirmation text when reopened', () => {
+    const { rerender } = render(<SiteDeleteDialog {...props} />);
+
+    fireEvent.click(screen.getByText('Purge'));
+    fireEvent.change(screen.getByPlaceholderText('Head Office'), {
+      target: { value: 'Head Office' },
+    });
+
+    rerender(<SiteDeleteDialog {...props} isOpen={false} />);
+    rerender(<SiteDeleteDialog {...props} isOpen={true} />);
+
+    expect(screen.getByRole('button', { name: 'Archive Site' })).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Head Office')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Reworks the existing delete dialogs for sites and devices into a choice between **Archive** and **Purge**, exposing the backend's `mode=archive|purge` contract.

- **SiteDeleteDialog** and **DeviceDeleteDialog**: two option cards (Archive / Purge).
  - *Archive* (default): reversible — hides the site/device and its devices from the Dashboard while retaining all historical data. Devices are unpaired.
  - *Purge*: permanent — deletes the entity and ALL associated data. Requires typing the exact site/device name to enable the confirm button (guards against accidental destructive action).
- **api.js**: `sites.delete` / `devices.delete` now accept a `mode` parameter and always send `confirm=true` (required by the backend for purge).
- Callers updated: `SitesList` and `SiteDetail` pass the selected mode through.
- Unit tests for both dialogs (default archive, mode switch, purge name-confirmation gating, reset on reopen).

Backend endpoints consumed:
- `DELETE /sites/{site_id}?mode=archive|purge&confirm=true`
- `DELETE /devices/device/{device_id}?mode=archive|purge&confirm=true`

## Verification
- `npm test`: 30/30 pass (incl. 9 new dialog tests)
- `npm run lint`: clean
- `npm run build`: succeeds
- Prettier formatted