### PR TITLE
feat: suspend a site's devices when the site is archived

### DIFF
--- a/backend/src/homepot/app/api/API_v1/Endpoints/SitesEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/SitesEndpoint.py
@@ -27,6 +27,7 @@ from homepot.database import get_database_service, get_db
 from homepot.error_logger import log_error
 from homepot.models import (
     Device,
+    DeviceStatus,
     LifecycleState,
     Site,
     SiteLifecycleState,
@@ -412,8 +413,31 @@ async def delete_site(
                 # --- ARCHIVE: hide the site and its devices, keep all data ---
                 site.is_active = False  # type: ignore[assignment]
                 site.lifecycle_state = SiteLifecycleState.ARCHIVED.value  # type: ignore[assignment]
-                # Mark the site's devices as inactive so they disappear from the
-                # Dashboard too, while preserving their data.
+                # Suspend the site's devices so they read as clearly inactive
+                # (offline) on the Dashboard, while preserving their data.
+                # They remain recoverable: restore re-activates devices whose
+                # lifecycle_state is active/pending/suspended, so suspended
+                # devices are revived when the site is restored.
+                await session.execute(
+                    update(Device)
+                    .where(
+                        Device.site_id == site.id,
+                        Device.lifecycle_state.in_(
+                            [
+                                LifecycleState.ACTIVE.value,
+                                LifecycleState.PENDING.value,
+                                LifecycleState.SUSPENDED.value,
+                            ]
+                        ),
+                    )
+                    .values(
+                        is_active=False,
+                        lifecycle_state=LifecycleState.SUSPENDED.value,
+                        status=DeviceStatus.OFFLINE.value,
+                    )
+                )
+                # Also hide any independently unpaired/retired devices under the
+                # site so nothing under an archived site remains visible.
                 await session.execute(
                     update(Device)
                     .where(Device.site_id == site.id)
@@ -432,6 +456,7 @@ async def delete_site(
                         "db_id": site_pk,
                         "cleanup_policy": "archive",
                         "lifecycle_state": "archived",
+                        "devices": "suspended",
                     },
                 )
                 return {

--- a/backend/tests/test_site_delete.py
+++ b/backend/tests/test_site_delete.py
@@ -208,6 +208,8 @@ def test_site_archive_default_retains_data(file_db: Any) -> None:
         assert site is not None and site.is_active is False
         assert site.lifecycle_state == "archived"
         assert device is not None and device.is_active is False
+        assert device.lifecycle_state == "suspended"
+        assert device.status == "offline"
     finally:
         sync_db.close()
 


### PR DESCRIPTION
Follow-up to #313. When a site is archived, suspend its active/pending/suspended devices (`lifecycle_state='suspended'`, `status='offline'`, `is_active=False`) so they read as clearly inactive while remaining recoverable on restore (restore already whitelists `suspended`).