### PR TITLE
feat: add archived sites restore view to Dashboard

### DIFF
--- a/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
@@ -1109,7 +1109,12 @@ async def resume_device(
     db: SASession = Depends(get_db),
     current_user: UserDict = Depends(require_user()),
 ) -> Dict[str, Any]:
-    """Resume a suspended device: ``suspended → active``.
+    """Resume/restore a device back to active.
+
+    Works for devices in ``suspended`` or ``unpaired`` state (e.g. devices that
+    were hidden when their site was archived, or independently unpaired):
+    sets ``lifecycle_state`` back to ``active``, ``is_active`` to true and
+    ``status`` to ``online`` so the device reappears on the Dashboard.
 
     Requires operator-level access on the device's site.
     """
@@ -1121,22 +1126,31 @@ async def resume_device(
             raise HTTPException(status_code=403, detail="User not found")
         db_service = await get_database_service()
 
-        device = await db_service.get_device_by_device_id(device_id)
+        # Restoring targets devices that are currently hidden (is_active=false),
+        # so include unpaired/suspended devices in the lookup.
+        device = await db_service.get_device_by_device_id(
+            device_id, include_unpaired=True
+        )
         if not device:
             raise HTTPException(status_code=404, detail="Device not found")
         verify_device_belongs_to_user(db_user, device, db, minimum_role="operator")
 
         current_lifecycle = device.lifecycle_state
-        if current_lifecycle != LifecycleState.SUSPENDED.value:
+        if current_lifecycle not in (
+            LifecycleState.SUSPENDED.value,
+            LifecycleState.UNPAIRED.value,
+        ):
             raise HTTPException(
                 status_code=400,
                 detail=(
                     f"Device lifecycle state is '{current_lifecycle}'; "
-                    "only 'suspended' devices may be resumed"
+                    "only 'suspended' or 'unpaired' devices may be restored"
                 ),
             )
 
         device.lifecycle_state = LifecycleState.ACTIVE.value  # type: ignore[assignment]
+        device.is_active = True  # type: ignore[assignment]
+        device.status = DeviceStatus.ONLINE.value  # type: ignore[assignment]
 
         await db_service.persist_device(device)
 
@@ -1830,6 +1844,7 @@ async def get_devices_by_site(
                 )
                 or os_family(cast(Optional[str], d.os_details)),
                 "lifecycle_state": d.lifecycle_state,
+                "is_active": d.is_active,
                 "connectivity_state": _compute_connectivity(d),
                 "health_state": d.health_state or HealthState.UNKNOWN.value,
                 "pairing_status": (

--- a/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
@@ -1213,12 +1213,13 @@ async def retire_device(
     db: SASession = Depends(get_db),
     current_user: UserDict = Depends(require_user()),
 ) -> Dict[str, Any]:
-    """Retire a device from eligible lifecycle states.
+    """Unpair a device from eligible lifecycle states.
+
+    The ``retired`` state was folded into ``unpaired`` (both revoke credentials
+    and hide the device; permanent removal is provided by ``purge``). This
+    endpoint is kept for API compatibility and performs an unpair.
 
     Eligible states: ``active``, ``suspended``, ``unpaired``.
-
-    Retired is a terminal state — the device cannot be re-enrolled
-    or transferred.  Requires operator-level access on the site.
     """
     try:
         db_user = cast(
@@ -1243,11 +1244,11 @@ async def retire_device(
             raise HTTPException(
                 status_code=400,
                 detail=f"Device lifecycle state is '{current_lifecycle}'; "
-                "only 'active', 'suspended', or 'unpaired' devices may be retired",
+                "only 'active', 'suspended', or 'unpaired' devices may be unpaired",
             )
 
         now = datetime.now(timezone.utc)
-        device.lifecycle_state = LifecycleState.RETIRED.value  # type: ignore[assignment]
+        device.lifecycle_state = LifecycleState.UNPAIRED.value  # type: ignore[assignment]
         device.is_active = False  # type: ignore[assignment]
         device.api_key_hash = None  # type: ignore[assignment]
 
@@ -1294,7 +1295,7 @@ async def retire_device(
             db_service,
             device,
             from_state=str(current_lifecycle),
-            to_state=LifecycleState.RETIRED.value,
+            to_state=LifecycleState.UNPAIRED.value,
             triggered_by_user_id=int(db_user.id),
             reason=payload.reason,
             idempotency_key=payload.idempotency_key,
@@ -1304,8 +1305,8 @@ async def retire_device(
         user_agent = request.headers.get("user-agent")
         audit_logger = get_audit_logger()
         await audit_logger.log_event(
-            AuditEventType.DEVICE_RETIRED,
-            f"Device '{device.name}' ({device.device_id}) retired by "
+            AuditEventType.DEVICE_UNPAIRED,
+            f"Device '{device.name}' ({device.device_id}) unpaired by "
             f"{current_user['email']}"
             + (f" — {payload.reason}" if payload.reason else ""),
             device_id=int(device.id),
@@ -1315,25 +1316,25 @@ async def retire_device(
             user_agent=user_agent,
             old_values={"lifecycle_state": current_lifecycle, "is_active": True},
             new_values={
-                "lifecycle_state": LifecycleState.RETIRED.value,
+                "lifecycle_state": LifecycleState.UNPAIRED.value,
                 "is_active": False,
                 "reason": payload.reason,
             },
             event_metadata={"idempotency_key": payload.idempotency_key},
         )
 
-        logger.info("Device retired: %s by %s", device_id, current_user["email"])
+        logger.info("Device unpaired: %s by %s", device_id, current_user["email"])
 
         return {
             "status": "success",
-            "message": f"Device '{device_id}' retired",
+            "message": f"Device '{device_id}' unpaired",
             "device_id": device_id,
         }
 
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to retire device {device_id}: {e}", exc_info=True)
+        logger.error(f"Failed to unpair device {device_id}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Internal Server Error")
 
 
@@ -1849,8 +1850,7 @@ async def get_devices_by_site(
                 "health_state": d.health_state or HealthState.UNKNOWN.value,
                 "pairing_status": (
                     "unpaired"
-                    if d.lifecycle_state
-                    in (LifecycleState.UNPAIRED.value, LifecycleState.RETIRED.value)
+                    if d.lifecycle_state == LifecycleState.UNPAIRED.value
                     else "paired"
                 ),
                 "status": d.status,

--- a/backend/src/homepot/app/api/API_v1/Endpoints/SitesEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/SitesEndpoint.py
@@ -161,10 +161,17 @@ async def create_site(
 
 @router.get("/", tags=["Sites"])
 async def list_sites(
+    include_archived: bool = Query(
+        False, description="Include archived (hidden) sites"
+    ),
     db: SASession = Depends(get_db),
     current_user: UserDict = Depends(require_user()),
 ) -> Dict[str, List[Dict]]:
-    """List all sites (scoped to user's accessible sites)."""
+    """List all sites (scoped to user's accessible sites).
+
+    By default only active sites are returned. Pass ``include_archived=true``
+    to also include archived (is_active=false) sites for the restore view.
+    """
     try:
         db_user = cast(
             User, db.query(User).filter(User.email == current_user["email"]).first()
@@ -173,7 +180,9 @@ async def list_sites(
         db_service = await get_database_service()
 
         async with db_service.get_session() as session:
-            query = select(Site).where(Site.is_active.is_(True))
+            query = select(Site)
+            if not include_archived:
+                query = query.where(Site.is_active.is_(True))
 
             # Non-admin users only see sites they can access
             if not db_user.is_admin:
@@ -190,11 +199,10 @@ async def list_sites(
             site_ids = [site.id for site in sites]
             devices_by_site: Dict[Any, Any] = {}
             if site_ids:
-                devices_result = await session.execute(
-                    select(Device).where(
-                        Device.site_id.in_(site_ids), Device.is_active.is_(True)
-                    )
-                )
+                devices_query = select(Device).where(Device.site_id.in_(site_ids))
+                if not include_archived:
+                    devices_query = devices_query.where(Device.is_active.is_(True))
+                devices_result = await session.execute(devices_query)
                 for device in devices_result.scalars().all():
                     devices_by_site.setdefault(device.site_id, []).append(device)
 
@@ -261,6 +269,8 @@ async def list_sites(
                         "description": site.description,
                         "location": site.location,
                         "is_monitored": site.is_monitored,
+                        "is_active": site.is_active,
+                        "lifecycle_state": site.lifecycle_state,
                         "status": status,
                         "os_types": list(os_types),
                         "devices_count": len(devices),

--- a/backend/src/homepot/app/api/API_v1/Endpoints/SitesEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/SitesEndpoint.py
@@ -646,7 +646,6 @@ async def restore_site(
         verify_site_access_for_user(db_user, site_id, db, minimum_role="operator")
 
         db_service = await get_database_service()
-        from sqlalchemy import update
 
         async with db_service.get_session() as session:
             result = await session.execute(select(Site).where(Site.site_id == site_id))
@@ -667,22 +666,10 @@ async def restore_site(
 
             site.is_active = True  # type: ignore[assignment]
             site.lifecycle_state = SiteLifecycleState.ACTIVE.value  # type: ignore[assignment]
-            # Re-activate the site's devices so they reappear on the Dashboard,
-            # but leave independently unpaired/retired devices untouched.
-            await session.execute(
-                update(Device)
-                .where(
-                    Device.site_id == site.id,
-                    Device.lifecycle_state.in_(
-                        [
-                            LifecycleState.ACTIVE.value,
-                            LifecycleState.PENDING.value,
-                            LifecycleState.SUSPENDED.value,
-                        ]
-                    ),
-                )
-                .values(is_active=True)
-            )
+            # Model B: restoring a site only un-hides the site itself. Devices
+            # that were suspended by the site archive stay suspended (is_active
+            # remains false) until they are individually restored, so a
+            # technician can review them on the Site page and restore per device.
             await session.commit()
 
             audit_logger = get_audit_logger()

--- a/backend/src/homepot/app/services/lifecycle_service.py
+++ b/backend/src/homepot/app/services/lifecycle_service.py
@@ -21,15 +21,12 @@ ALLOWED_TRANSITIONS: dict[Optional[LifecycleState], list[LifecycleState]] = {
     LifecycleState.ACTIVE: [
         LifecycleState.SUSPENDED,
         LifecycleState.UNPAIRED,
-        LifecycleState.RETIRED,
     ],
     LifecycleState.SUSPENDED: [
         LifecycleState.ACTIVE,
         LifecycleState.UNPAIRED,
-        LifecycleState.RETIRED,
     ],
-    LifecycleState.UNPAIRED: [LifecycleState.RETIRED],
-    LifecycleState.RETIRED: [],
+    LifecycleState.UNPAIRED: [LifecycleState.ACTIVE],
 }
 
 
@@ -69,14 +66,12 @@ class LifecycleService:
 
         device.lifecycle_state = new_state.value  # type: ignore[assignment]
 
-        if new_state in (LifecycleState.UNPAIRED, LifecycleState.RETIRED):
-            device.is_active = False  # type: ignore[assignment]
-        elif new_state in (
+        # is_active is a visibility/operating flag derived from lifecycle:
+        # active/pending are visible; suspended/unpaired are hidden.
+        device.is_active = new_state in (  # type: ignore[assignment]
             LifecycleState.ACTIVE,
             LifecycleState.PENDING,
-            LifecycleState.SUSPENDED,
-        ):
-            device.is_active = True  # type: ignore[assignment]
+        )
 
         self.db.add(device)
 

--- a/backend/src/homepot/models.py
+++ b/backend/src/homepot/models.py
@@ -85,13 +85,16 @@ class DeviceStatus(str, Enum):
 
 
 class LifecycleState(str, Enum):
-    """Device lifecycle state — the administrative management phase."""
+    """Device lifecycle state — the administrative management phase.
+
+    ``retired`` was folded into ``unpaired``: both revoke credentials and hide
+    the device, and permanent removal is provided by ``purge``.
+    """
 
     PENDING = "pending"
     ACTIVE = "active"
     SUSPENDED = "suspended"
     UNPAIRED = "unpaired"
-    RETIRED = "retired"
 
 
 class SiteLifecycleState(str, Enum):

--- a/backend/tests/test_device_commands.py
+++ b/backend/tests/test_device_commands.py
@@ -504,7 +504,6 @@ def test_agent_list_includes_modern_state_fields(client: TestClient) -> None:
         "active",
         "suspended",
         "unpaired",
-        "retired",
     )
     assert agent["connectivity_state"] in ("unknown", "online", "offline")
     assert agent["health_state"] in (
@@ -540,7 +539,6 @@ def test_agent_detail_includes_modern_state_fields(client: TestClient) -> None:
         "active",
         "suspended",
         "unpaired",
-        "retired",
     )
     assert data["connectivity_state"] in ("unknown", "online", "offline")
     assert data["device_id"] == device_id

--- a/backend/tests/test_site_delete.py
+++ b/backend/tests/test_site_delete.py
@@ -289,6 +289,70 @@ def test_site_restore_active_site_is_idempotent(file_db: Any) -> None:
     assert "already active" in response.json()["message"].lower()
 
 
+def test_device_resume_reactivates_suspended_device(file_db: Any) -> None:
+    """Resuming a device that was suspended by a site archive re-activates it.
+
+    Model B: after archiving + restoring a site, the device stays suspended
+    (is_active=false). Calling resume should bring it back to active/online so
+    it reappears on the Dashboard.
+    """
+    site_id, device_id, _ = _seed_site_device_admin()
+    client = TestClient(app)
+
+    archived = client.delete(f"/api/v1/sites/{site_id}", headers=_headers())
+    assert archived.status_code == 200
+
+    restored = client.post(f"/api/v1/sites/{site_id}/restore", headers=_headers())
+    assert restored.status_code == 200
+
+    resumed = client.post(
+        f"/api/v1/devices/device/{device_id}/resume", headers=_headers(), json={}
+    )
+    assert resumed.status_code == 200
+
+    sync_db = homepot.database.SessionLocal()
+    try:
+        device = sync_db.query(Device).filter(Device.device_id == device_id).first()
+        assert device is not None
+        assert device.is_active is True
+        assert device.lifecycle_state == "active"
+        assert device.status == "online"
+    finally:
+        sync_db.close()
+
+
+def test_device_resume_reactivates_unpaired_device(file_db: Any) -> None:
+    """Resuming an independently-unpaired device re-activates it.
+
+    A device archived directly (not via a site) has lifecycle_state 'unpaired'.
+    The restore/resume action should bring it back to active/online.
+    """
+    _, device_id, _ = _seed_site_device_admin()
+    client = TestClient(app)
+
+    archived = client.delete(
+        f"/api/v1/devices/device/{device_id}",
+        params={"mode": "archive"},
+        headers=_headers(),
+    )
+    assert archived.status_code == 200
+
+    resumed = client.post(
+        f"/api/v1/devices/device/{device_id}/resume", headers=_headers(), json={}
+    )
+    assert resumed.status_code == 200
+
+    sync_db = homepot.database.SessionLocal()
+    try:
+        device = sync_db.query(Device).filter(Device.device_id == device_id).first()
+        assert device is not None
+        assert device.is_active is True
+        assert device.lifecycle_state == "active"
+        assert device.status == "online"
+    finally:
+        sync_db.close()
+
+
 def test_site_purge_with_confirm_deletes_everything(file_db: Any) -> None:
     """Purge with confirm=true deletes the site and its devices."""
     site_id, device_id, _ = _seed_site_device_admin()

--- a/backend/tests/test_site_delete.py
+++ b/backend/tests/test_site_delete.py
@@ -214,6 +214,33 @@ def test_site_archive_default_retains_data(file_db: Any) -> None:
         sync_db.close()
 
 
+def test_site_list_excludes_archived_by_default(file_db: Any) -> None:
+    """GET /sites/ hides archived sites unless include_archived=true."""
+    site_id, device_id, _ = _seed_site_device_admin()
+    client = TestClient(app)
+
+    archived = client.delete(f"/api/v1/sites/{site_id}", headers=_headers())
+    assert archived.status_code == 200
+
+    default_list = client.get("/api/v1/sites/", headers=_headers())
+    assert default_list.status_code == 200
+    default_ids = [s["site_id"] for s in default_list.json()["sites"]]
+    assert site_id not in default_ids
+
+    archived_list = client.get(
+        "/api/v1/sites/", params={"include_archived": "true"}, headers=_headers()
+    )
+    assert archived_list.status_code == 200
+    archived_ids = [s["site_id"] for s in archived_list.json()["sites"]]
+    assert site_id in archived_ids
+    archived_site = next(
+        s for s in archived_list.json()["sites"] if s["site_id"] == site_id
+    )
+    assert archived_site["is_active"] is False
+    assert archived_site["lifecycle_state"] == "archived"
+    assert archived_site["devices_count"] == 1
+
+
 def test_site_purge_requires_confirm(file_db: Any) -> None:
     """Purge without confirm=true is rejected."""
     site_id, _, _ = _seed_site_device_admin()

--- a/backend/tests/test_site_delete.py
+++ b/backend/tests/test_site_delete.py
@@ -252,8 +252,12 @@ def test_site_purge_requires_confirm(file_db: Any) -> None:
     assert "confirm" in response.json()["detail"].lower()
 
 
-def test_site_restore_reactivates_site_and_devices(file_db: Any) -> None:
-    """Restore flips an archived site back to active and re-activates devices."""
+def test_site_restore_keeps_devices_suspended(file_db: Any) -> None:
+    """Restore flips an archived site back to active but leaves devices suspended.
+
+    Model B: restoring a site un-hides the site; its devices stay suspended
+    (is_active=false) until each is individually restored.
+    """
     site_id, device_id, _ = _seed_site_device_admin()
     client = TestClient(app)
 
@@ -270,7 +274,8 @@ def test_site_restore_reactivates_site_and_devices(file_db: Any) -> None:
         device = sync_db.query(Device).filter(Device.device_id == device_id).first()
         assert site is not None and site.is_active is True
         assert site.lifecycle_state == "active"
-        assert device is not None and device.is_active is True
+        assert device is not None and device.is_active is False
+        assert device.lifecycle_state == "suspended"
     finally:
         sync_db.close()
 

--- a/docs/device-lifecycle-and-ownership.md
+++ b/docs/device-lifecycle-and-ownership.md
@@ -98,8 +98,11 @@ Lifecycle, connectivity and health are independent dimensions.
 | `pending`   | An enrolment intent or pre-provisioned slot exists, but no endpoint has proved possession. | None                                                                  | Rejected                                  |
 | `active`    | Enrolment is complete and the management relationship is valid.                            | Valid                                                                 | Allowed when authenticated and authorised |
 | `suspended` | Management is temporarily disabled by an authorised operator or policy.                    | Retained or rotated according to policy, but rejected while suspended | Rejected                                  |
-| `unpaired`  | The management relationship has ended, while records are retained for audit and analytics. | Revoked                                                               | Rejected                                  |
-| `retired`   | Terminal state for that lifecycle epoch. Ordinary claim or reactivation is forbidden.      | Revoked                                                               | Rejected                                  |
+| `unpaired`  | The management relationship has ended, while records are retained for audit and analytics. | Revoked                                                               | Rejected (can be resumed/re-activated)    |
+
+> `retired` was folded into `unpaired`. Both revoke credentials and hide the
+> device; permanent removal is provided by `purge`. The `retire` action remains
+> available as an alias for unpairing.
 
 `is_active` may remain as a compatibility field, but it must not form a second lifecycle model. Its mapping to canonical lifecycle states must be defined once and used consistently.
 
@@ -127,8 +130,8 @@ An unpaired device is not merely offline: it no longer has an active management 
 | `active`                            | Suspend                       | `suspended`                            | Authorised operator or policy; reject device operations and record the reason.                                                   |
 | `suspended`                         | Resume                        | `active`                               | Authorised operator or policy; rotate credentials if compromise is possible.                                                     |
 | `active` or `suspended`             | Unpair                        | `unpaired`                             | Authorised user or device flow; revoke credentials and provider channels; retain history.                                        |
-| `active`, `suspended` or `unpaired` | Retire                        | `retired`                              | Tenant administrator; revoke credentials and prevent ordinary reactivation.                                                      |
-| `unpaired`                          | Re-enrol                      | `active` in a new epoch                | Repeat authorisation and device proof; retain the old epoch and issue new credentials.                                           |
+| `active`, `suspended` or `unpaired` | Retire (alias → unpair)       | `unpaired`                             | Tenant administrator; revoke credentials and prevent ordinary reactivation.                                                      |
+| `unpaired`                          | Re-enrol / resume             | `active` in a new epoch                | Repeat authorisation and device proof; retain the old epoch and issue new credentials.                                           |
 | `active` or `suspended`             | Transfer                      | `active` in a new assignment and epoch | Authorised at source and destination; revoke old credentials and retain historical ownership.                                    |
 
 Transitions must be idempotent or accept an idempotency key. Concurrent claim, unpair, transfer and credential-rotation operations must be transactionally serialised.

--- a/docs/site-device-lifecycle-matrix.md
+++ b/docs/site-device-lifecycle-matrix.md
@@ -1,0 +1,98 @@
+# Site & Device Lifecycle Matrix
+
+> Reference for the **combined** site × device lifecycle state space. The
+> device-only transitions are documented in
+> [device-lifecycle-and-ownership.md](device-lifecycle-and-ownership.md). This
+> document focuses on how **site-level** and **device-level** actions interact,
+> and on every reachable combination of states — including the archive/purge/
+> restore behaviour (Model B) and the suspended/unpaired device restore flow.
+
+## States
+
+### Site states
+
+| State       | `is_active` | Meaning                                                            |
+| ----------- | ----------- | ------------------------------------------------------------------ |
+| `active`    | `true`      | Site is visible on the Dashboard and manages its devices normally. |
+| `archived`  | `false`     | Site is hidden; data retained; recoverable via restore.            |
+
+A **purged** site is not a state — the row (and all its data) is deleted and
+cannot be restored.
+
+### Device states
+
+| State       | `is_active` | Meaning                                                                               |
+| ----------- | ----------- | ------------------------------------------------------------------------------------- |
+| `pending`   | `true`*     | Enrolment intent / pre-provisioned slot exists but no endpoint has claimed it.        |
+| `active`    | `true`      | Enrolment complete; the management relationship is valid.                             |
+| `suspended` | `false`*    | Management temporarily disabled by an operator/policy, or by its site being archived. |
+| `unpaired`  | `false`     | Management relationship ended; records retained for audit/analytics.                  |
+
+> `retired` was folded into `unpaired` — both revoke credentials and hide the
+> device, and permanent removal is provided by **purge**. The `/retire` endpoint
+> is retained for API compatibility but performs an unpair.
+
+\* `pending` and `suspended` devices are normally `is_active=false` after any
+archive/unpair/retire action; a brand-new `pending` intent starts `is_active=true`.
+
+`is_active` is a **compatibility/visibility** field, not a second lifecycle
+model. Its mapping to lifecycle state is defined once and used consistently.
+
+## Site × Device reachable combinations
+
+A device's lifecycle is independent of its site's lifecycle, so the two
+dimensions cross-product. The following table lists every *reachable*
+combination (rows marked with the actions that produce them).
+
+| Site       | Device     | `site.is_active` | `device.is_active` | Meaning / how to reach                                              | Visible on Dashboard? | Restorable?              |
+| ---------- | ---------- | ---------------- | ------------------ | ------------------------------------------------------------------- | --------------------- | ------------------------ |
+| `active`   | `pending`  | true             | true               | A site is active; a device slot awaits claim.                       | Device yes            | n/a (claims to active)   |
+| `active`   | `active`   | true             | true               | Normal operating pair.                                              | Yes                   | n/a (already active)     |
+| `active`   | `suspended`| true             | false              | Device suspended directly (`suspend`), or site was archived then restored (Model B). | No (device hidden) | Yes — resume → `active` |
+| `active`   | `unpaired` | true             | false              | Device unpaired directly (`unpair`/`archive`/`retire`).             | No (device hidden)    | Yes — resume → `active`  |
+| `archived` | `suspended`| false            | false              | **Archive site**: active/pending/suspended devices → `suspended`.   | No (site hidden)      | Yes — restore site, then resume device |
+| `archived` | `unpaired` | false            | false              | Archive site over an independently-unpaired device.                 | No (site hidden)      | Yes — restore site, then resume device |
+
+> Not reachable: `archived` site with an `active`/`pending` device (archive
+> forces them to `suspended`), and `active` site with `is_active=false` device
+> (that is exactly the suspended/unpaired rows above).
+
+## Action matrix
+
+How each action changes **both** the site and its devices. Read a row as the
+net effect of one user action.
+
+| Action (endpoint)                          | Site effect                              | Device effect                                                                                                        | Reversible?                              |
+| ------------------------------------------ | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| **Archive site** `DELETE /sites/{id}?mode=archive` | → `archived`, `is_active=false`          | active/pending/suspended → **suspended**, `is_active=false`, `status=offline`; unpaired/retired → `is_active=false` only | Yes — via **restore site** + resume devices |
+| **Restore site** `POST /sites/{id}/restore` (Model B) | → `active`, `is_active=true`             | **No change** — devices stay suspended/unpaired with `is_active=false` until individually resumed                    | Yes — archive again                     |
+| **Purge site** `DELETE /sites/{id}?mode=purge&confirm=true` | **Deleted** (row + all data)             | **Deleted** with the site                                                                                            | No (permanent)                          |
+| **Suspend device** `POST /devices/device/{id}/suspend` | none                                     | `active` → `suspended`                                                                                               | Yes — resume                            |
+| **Resume/restore device** `POST /devices/device/{id}/resume` | none                                     | `suspended` or `unpaired` → **active**, `is_active=true`, `status=online`                                            | Yes — suspend/unpair again              |
+| **Unpair/archive device** `DELETE /devices/device/{id}?mode=archive` | none                                     | `active`/`suspended` → `unpaired`, `is_active=false`, credentials revoked                                            | Yes — resume (re-activate)              |
+| **Purge device** `DELETE /devices/device/{id}?mode=purge&confirm=true` | none                                     | **Deleted** (row + all data)                                                                                         | No (permanent)                          |
+| **Retire device** `POST /devices/device/{id}/retire` (alias → unpair) | none                                     | `active`/`suspended`/`unpaired` → `unpaired` (credentials revoked, epoch closed)                                     | Yes — resume                             |
+| **Transfer device** `POST /devices/device/{id}/transfer` | none                                     | `active`/`suspended` → `active` in the target site, new epoch, credentials rotated                                  | n/a (new epoch)                          |
+
+### How a technician restores an archived site
+
+Because **restoring a site does not restore its devices** (Model B), the full
+recovery of an archived site requires two steps:
+
+1. **Restore the site** — Archived tab → Restore (site becomes `active`).
+2. **Restore each device** — open the site, then in *Associated Devices* press
+   the restore icon on each grayed-out `suspended`/`unpaired` row.
+
+Purged sites/devices cannot be restored (their data no longer exists).
+
+## Design notes / open questions
+
+- `active` site + `suspended` device can arise either from a direct device
+  suspend **or** from archiving-then-restoring a site. These look identical and
+  both recover via `resume` — there is no separate "archived by site" vs
+  "suspended directly" distinction at the device level today.
+- Consider a **"Restore all devices"** button on a restored site so technicians
+  do not have to restore devices one-by-one.
+- Consider whether `resume` should also set a fresh connectivity/health state or
+  leave the device `offline` until the agent next heartbeats. Currently resume
+  sets `status=online` optimistically.

--- a/frontend/src/pages/Agents.jsx
+++ b/frontend/src/pages/Agents.jsx
@@ -97,7 +97,6 @@ export default function AgentList() {
       active: 'bg-green-500/10 text-green-400 border-green-500/20',
       suspended: 'bg-orange-500/10 text-orange-400 border-orange-500/20',
       unpaired: 'bg-gray-500/10 text-gray-400 border-gray-500/20',
-      retired: 'bg-gray-500/10 text-gray-400 border-gray-500/20',
       pending: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
     };
     return (

--- a/frontend/src/pages/Device/DeviceList.jsx
+++ b/frontend/src/pages/Device/DeviceList.jsx
@@ -19,7 +19,6 @@ const LIFECYCLE_COLORS = {
   active: 'bg-green-500/10 text-green-400',
   suspended: 'bg-orange-500/10 text-orange-400',
   unpaired: 'bg-gray-500/10 text-gray-400',
-  retired: 'bg-red-500/10 text-red-400',
 };
 
 const CONNECTIVITY_COLORS = {
@@ -123,7 +122,6 @@ export default function DeviceList() {
             <option value="active">Active</option>
             <option value="suspended">Suspended</option>
             <option value="unpaired">Unpaired</option>
-            <option value="retired">Retired</option>
           </select>
         </div>
       </div>

--- a/frontend/src/pages/Device/DeviceWidgets.jsx
+++ b/frontend/src/pages/Device/DeviceWidgets.jsx
@@ -486,9 +486,7 @@ export const DeviceInfoWidget = ({ device }) => (
                 ? 'bg-orange-500/10 text-orange-400 border border-orange-500/20'
                 : device?.lifecycle_state === 'unpaired'
                   ? 'bg-gray-500/10 text-gray-400 border border-gray-500/20'
-                  : device?.lifecycle_state === 'retired'
-                    ? 'bg-red-500/10 text-red-400 border border-red-500/20'
-                    : 'bg-yellow-500/10 text-yellow-400 border border-yellow-500/20'
+                  : 'bg-yellow-500/10 text-yellow-400 border border-yellow-500/20'
           }`}
         >
           {device?.lifecycle_state || 'N/A'}

--- a/frontend/src/pages/Sites/SiteDetail.jsx
+++ b/frontend/src/pages/Sites/SiteDetail.jsx
@@ -13,6 +13,8 @@ import {
   AlertTriangle,
   CheckCircle,
   KeyRound,
+  RotateCcw,
+  Archive,
 } from 'lucide-react';
 import api from '@/services/api';
 import OsIcon from '@/components/common/OsIcon';
@@ -50,9 +52,13 @@ export default function SiteDetail() {
   // Device deletion state
   const [deviceToDelete, setDeviceToDelete] = useState(null);
   const [isDeletingDevice, setIsDeletingDevice] = useState(false);
+  const [isRestoringDevice, setIsRestoringDevice] = useState(false);
+  const [isRestoringSite, setIsRestoringSite] = useState(false);
 
   // Bootstrap key dialog state
   const [isBootstrapKeyOpen, setIsBootstrapKeyOpen] = useState(false);
+
+  const isArchived = site ? site.is_active === false : false;
 
   useEffect(() => {
     const fetchSiteAndDevices = async () => {
@@ -65,9 +71,10 @@ export default function SiteDetail() {
 
       setLoading(true);
 
+      let siteData = null;
       try {
         // Fetch Site
-        const siteData = await api.sites.get(id);
+        siteData = await api.sites.get(id);
         setSite(siteData);
       } catch (err) {
         console.error('Failed to load site:', err);
@@ -77,8 +84,10 @@ export default function SiteDetail() {
       }
 
       try {
-        // Fetch Devices
-        const devicesData = await api.devices.getSiteId(id);
+        // Fetch Devices (include unpaired/suspended for archived sites)
+        const devicesData = await api.devices.getSiteId(id, {
+          includeUnpaired: siteData.is_active === false,
+        });
         const devicesList = Array.isArray(devicesData) ? devicesData : devicesData.devices || [];
 
         // Sort alphabetically by name
@@ -108,6 +117,40 @@ export default function SiteDetail() {
       setSite((prev) => ({ ...prev, is_monitored: updatedSite.is_monitored }));
     } catch (err) {
       console.error('Failed to toggle monitor:', err);
+    }
+  };
+
+  const handleRestoreSite = async () => {
+    try {
+      setIsRestoringSite(true);
+      await api.sites.restore(id);
+      // Re-fetch site + devices in active mode
+      const siteData = await api.sites.get(id);
+      setSite(siteData);
+      const devicesData = await api.devices.getSiteId(id);
+      const devicesList = Array.isArray(devicesData) ? devicesData : devicesData.devices || [];
+      devicesList.sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+      setDevices(devicesList);
+    } catch (err) {
+      console.error('Failed to restore site:', err);
+      alert(`Failed to restore site: ${err.response?.data?.detail || err.message}`);
+    } finally {
+      setIsRestoringSite(false);
+    }
+  };
+
+  const handleRestoreDevice = async (device) => {
+    const deviceId = device.device_id || device.id;
+    try {
+      setIsRestoringDevice(true);
+      await api.devices.resume(deviceId);
+      // Remove from the archived list (it becomes active again)
+      setDevices((prev) => prev.filter((d) => (d.device_id || d.id) !== deviceId));
+    } catch (err) {
+      console.error('Failed to restore device:', err);
+      alert(`Failed to restore device: ${err.response?.data?.detail || err.message}`);
+    } finally {
+      setIsRestoringDevice(false);
     }
   };
 
@@ -195,32 +238,54 @@ export default function SiteDetail() {
                 <MapPin className="h-4 w-4 mr-1.5" />
                 {site.location || 'No location specified'}
               </div>
+              {isArchived && (
+                <div className="flex items-center gap-1.5 mt-2 text-xs text-gray-400">
+                  <Archive className="h-3.5 w-3.5" />
+                  <span>
+                    This site is <span className="text-gray-200">archived</span>. Its devices are
+                    suspended and hidden from the Dashboard.
+                  </span>
+                </div>
+              )}
             </div>
             <div className="flex gap-2">
-              <Button
-                onClick={handleToggleMonitor}
-                className={`bg-transparent border ${
-                  site.is_monitored
-                    ? 'text-yellow-400 border-yellow-400 hover:bg-yellow-400/10'
-                    : 'text-gray-400 border-gray-400 hover:bg-gray-400/10'
-                }`}
-              >
-                <Activity className="h-4 w-4 mr-2" />
-                {site.is_monitored ? 'Monitored' : 'Add to Dashboard'}
-              </Button>
-              <Button
-                onClick={() => navigate(`/sites/${site.site_id || site.id}/enrolment-intents`)}
-                className="bg-transparent border text-blue-400 border-blue-400 hover:bg-blue-400/10"
-              >
-                Enrolment Intents
-              </Button>
-              <Button
-                onClick={() => setIsBootstrapKeyOpen(true)}
-                className="bg-transparent border text-teal-400 border-teal-400 hover:bg-teal-400/10"
-              >
-                <KeyRound className="h-4 w-4 mr-2" />
-                Bootstrap Key
-              </Button>
+              {isArchived ? (
+                <Button
+                  onClick={handleRestoreSite}
+                  disabled={isRestoringSite}
+                  className="bg-transparent border text-teal-400 border-teal-400 hover:bg-teal-400/10 disabled:opacity-50"
+                >
+                  <RotateCcw className="h-4 w-4 mr-2" />
+                  {isRestoringSite ? 'Restoring...' : 'Restore Site'}
+                </Button>
+              ) : (
+                <>
+                  <Button
+                    onClick={handleToggleMonitor}
+                    className={`bg-transparent border ${
+                      site.is_monitored
+                        ? 'text-yellow-400 border-yellow-400 hover:bg-yellow-400/10'
+                        : 'text-gray-400 border-gray-400 hover:bg-gray-400/10'
+                    }`}
+                  >
+                    <Activity className="h-4 w-4 mr-2" />
+                    {site.is_monitored ? 'Monitored' : 'Add to Dashboard'}
+                  </Button>
+                  <Button
+                    onClick={() => navigate(`/sites/${site.site_id || site.id}/enrolment-intents`)}
+                    className="bg-transparent border text-blue-400 border-blue-400 hover:bg-blue-400/10"
+                  >
+                    Enrolment Intents
+                  </Button>
+                  <Button
+                    onClick={() => setIsBootstrapKeyOpen(true)}
+                    className="bg-transparent border text-teal-400 border-teal-400 hover:bg-teal-400/10"
+                  >
+                    <KeyRound className="h-4 w-4 mr-2" />
+                    Bootstrap Key
+                  </Button>
+                </>
+              )}
               <Button
                 onClick={() => navigate('/dashboard')}
                 className="bg-transparent border text-gray-400 border-gray-400 hover:bg-gray-400/10"
@@ -312,8 +377,15 @@ export default function SiteDetail() {
         {/* Scrollable Devices Section */}
         <div className="flex-1 min-h-0 flex flex-col">
           <div className="shrink-0 flex items-center justify-between mb-4">
-            <h2 className="text-xl font-semibold text-white">Associated Devices</h2>
-            {healthFilter && (
+            <h2 className="text-xl font-semibold text-white">
+              {isArchived ? 'Suspended Devices' : 'Associated Devices'}
+            </h2>
+            {isArchived && (
+              <span className="text-sm text-gray-400">
+                Suspended by the site archive. Restore to re-activate.
+              </span>
+            )}
+            {!isArchived && healthFilter && (
               <span className="text-sm text-gray-400">
                 Showing <span className="text-teal-400">{filteredDevices.length}</span>{' '}
                 {healthFilter} device{filteredDevices.length === 1 ? '' : 's'}
@@ -447,35 +519,53 @@ export default function SiteDetail() {
                     </div>
                   </td>
                   <td className="p-4 align-middle text-right">
-                    <div className="flex justify-end gap-2">
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          navigate(`/device/${device.device_id || device.id}/settings`, {
-                            state: {
-                              mode: 'edit',
-                              from: 'site',
-                            },
-                          });
-                        }}
-                        className="h-8 w-8 text-gray-400 hover:text-blue-400 hover:bg-blue-400/10"
-                      >
-                        <Edit className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleDeleteDeviceClick(device);
-                        }}
-                        className="h-8 w-8 text-gray-400 hover:text-red-500 hover:bg-red-500/10"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
+                    {isArchived ? (
+                      <div className="flex justify-end gap-2">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleRestoreDevice(device);
+                          }}
+                          disabled={isRestoringDevice}
+                          title="Restore device"
+                          className="h-8 w-8 text-gray-400 hover:text-teal-400 hover:bg-teal-400/10"
+                        >
+                          <RotateCcw className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    ) : (
+                      <div className="flex justify-end gap-2">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            navigate(`/device/${device.device_id || device.id}/settings`, {
+                              state: {
+                                mode: 'edit',
+                                from: 'site',
+                              },
+                            });
+                          }}
+                          className="h-8 w-8 text-gray-400 hover:text-blue-400 hover:bg-blue-400/10"
+                        >
+                          <Edit className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleDeleteDeviceClick(device);
+                          }}
+                          className="h-8 w-8 text-gray-400 hover:text-red-500 hover:bg-red-500/10"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    )}
                   </td>
                 </tr>
               ))}

--- a/frontend/src/pages/Sites/SiteDetail.jsx
+++ b/frontend/src/pages/Sites/SiteDetail.jsx
@@ -84,10 +84,10 @@ export default function SiteDetail() {
       }
 
       try {
-        // Fetch Devices (include unpaired/suspended for archived sites)
-        const devicesData = await api.devices.getSiteId(id, {
-          includeUnpaired: siteData.is_active === false,
-        });
+        // Fetch Devices. Always include unpaired/suspended devices so they show
+        // on archived sites AND on restored sites (Model B: a restored site is
+        // active but its devices stay suspended until individually restored).
+        const devicesData = await api.devices.getSiteId(id, { includeUnpaired: true });
         const devicesList = Array.isArray(devicesData) ? devicesData : devicesData.devices || [];
 
         // Sort alphabetically by name
@@ -124,10 +124,11 @@ export default function SiteDetail() {
     try {
       setIsRestoringSite(true);
       await api.sites.restore(id);
-      // Re-fetch site + devices in active mode
+      // Re-fetch site + devices. Devices stay suspended (Model B) and remain
+      // visible, so keep includeUnpaired=true.
       const siteData = await api.sites.get(id);
       setSite(siteData);
-      const devicesData = await api.devices.getSiteId(id);
+      const devicesData = await api.devices.getSiteId(id, { includeUnpaired: true });
       const devicesList = Array.isArray(devicesData) ? devicesData : devicesData.devices || [];
       devicesList.sort((a, b) => (a.name || '').localeCompare(b.name || ''));
       setDevices(devicesList);
@@ -144,8 +145,14 @@ export default function SiteDetail() {
     try {
       setIsRestoringDevice(true);
       await api.devices.resume(deviceId);
-      // Remove from the archived list (it becomes active again)
-      setDevices((prev) => prev.filter((d) => (d.device_id || d.id) !== deviceId));
+      // Re-activate the device in place so it stops being grayed out.
+      setDevices((prev) =>
+        prev.map((d) =>
+          (d.device_id || d.id) === deviceId
+            ? { ...d, is_active: true, lifecycle_state: 'active' }
+            : d
+        )
+      );
     } catch (err) {
       console.error('Failed to restore device:', err);
       alert(`Failed to restore device: ${err.response?.data?.detail || err.message}`);
@@ -377,12 +384,10 @@ export default function SiteDetail() {
         {/* Scrollable Devices Section */}
         <div className="flex-1 min-h-0 flex flex-col">
           <div className="shrink-0 flex items-center justify-between mb-4">
-            <h2 className="text-xl font-semibold text-white">
-              {isArchived ? 'Suspended Devices' : 'Associated Devices'}
-            </h2>
-            {isArchived && (
+            <h2 className="text-xl font-semibold text-white">Associated Devices</h2>
+            {devices.some((d) => d.is_active === false) && (
               <span className="text-sm text-gray-400">
-                Suspended by the site archive. Restore to re-activate.
+                Grayed-out devices are suspended. Restore them to re-activate.
               </span>
             )}
             {!isArchived && healthFilter && (
@@ -407,7 +412,9 @@ export default function SiteDetail() {
               {filteredDevices.map((device) => (
                 <tr
                   key={device.id}
-                  className="border-b border-border transition-colors hover:bg-muted/50"
+                  className={`border-b border-border transition-colors hover:bg-muted/50 ${
+                    device.is_active === false ? 'bg-gray-500/5 opacity-60 hover:opacity-80' : ''
+                  }`}
                 >
                   <td
                     className="p-4 align-middle font-medium text-white cursor-pointer hover:underline"
@@ -519,7 +526,7 @@ export default function SiteDetail() {
                     </div>
                   </td>
                   <td className="p-4 align-middle text-right">
-                    {isArchived ? (
+                    {device.is_active === false ? (
                       <div className="flex justify-end gap-2">
                         <Button
                           variant="ghost"

--- a/frontend/src/pages/Sites/SitesList.jsx
+++ b/frontend/src/pages/Sites/SitesList.jsx
@@ -28,6 +28,7 @@ export default function SitesList() {
   const [isRestoring, setIsRestoring] = useState(false);
   const [copiedSiteId, setCopiedSiteId] = useState(null);
   const [activeTab, setActiveTab] = useState('active');
+  const [notice, setNotice] = useState(null);
 
   useEffect(() => {
     fetchSites();
@@ -78,6 +79,7 @@ export default function SitesList() {
     setActiveTab(tab);
     setSearchTerm('');
     setLocationFilter('');
+    setNotice(null);
     fetchSites(tab === 'archived');
   };
 
@@ -117,6 +119,20 @@ export default function SitesList() {
     } catch {
       console.error('Failed to copy site ID');
     }
+  };
+
+  const handleViewDetails = (e, site) => {
+    e.stopPropagation();
+    if (!site.id) return;
+
+    trackActivity('click', '/sites', { site_id: site.id }, 'view_site_details_btn');
+
+    if (site.is_active === false) {
+      setNotice(`Details for "${site.name}" are not available until the site is restored.`);
+      return;
+    }
+
+    navigate(`/sites/${site.id}`);
   };
 
   const handleConfirmDelete = async (mode) => {
@@ -191,6 +207,19 @@ export default function SitesList() {
             Archived
           </button>
         </div>
+
+        {notice && (
+          <div className="flex items-center justify-between gap-3 mb-4 px-4 py-2.5 rounded-lg bg-[#1a1f2b] border border-yellow-500/30 text-yellow-300 text-sm">
+            <span>{notice}</span>
+            <button
+              onClick={() => setNotice(null)}
+              className="text-gray-400 hover:text-white transition-colors shrink-0"
+              title="Dismiss"
+            >
+              ✕
+            </button>
+          </div>
+        )}
 
         <div className="flex flex-col md:flex-row items-center gap-2 mb-4">
           {/* Search input */}
@@ -374,18 +403,7 @@ export default function SitesList() {
 
                 {/* View Details button */}
                 <button
-                  // onClick={(e) => {
-                  //   e.stopPropagation();
-                  //   navigate(`/sites/${site.id}`);
-                  // }}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    if (!site.id) return;
-
-                    trackActivity('click', '/sites', { site_id: site.id }, 'view_site_details_btn');
-
-                    navigate(`/sites/${site.id}`);
-                  }}
+                  onClick={(e) => handleViewDetails(e, site)}
                   className="mt-auto w-full border border-[#1f2735] py-2 rounded-lg text-sm hover:bg-[#1f2735] text-gray-300 transition"
                 >
                   View Details

--- a/frontend/src/pages/Sites/SitesList.jsx
+++ b/frontend/src/pages/Sites/SitesList.jsx
@@ -58,10 +58,15 @@ export default function SitesList() {
         alert: site.alert || null,
       }));
 
-      // Sort alphabetically by name
-      withStaticValues.sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+      // When viewing the Archived tab, only keep archived sites.
+      const tabSites = includeArchived
+        ? withStaticValues.filter((s) => s.is_active === false)
+        : withStaticValues;
 
-      setSites(withStaticValues);
+      // Sort alphabetically by name
+      tabSites.sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+
+      setSites(tabSites);
     } catch (err) {
       console.error('Failed to fetch sites:', err);
     } finally {

--- a/frontend/src/pages/Sites/SitesList.jsx
+++ b/frontend/src/pages/Sites/SitesList.jsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import OsIcon from '@/components/common/OsIcon';
+import { Toast } from '@/components/ui/Toast';
 import api from '@/services/api';
 import SiteDeleteDialog from '@/components/Sites/SiteDeleteDialog';
 import { trackActivity, trackSearch } from '@/utils/analytics';
@@ -28,7 +29,7 @@ export default function SitesList() {
   const [isRestoring, setIsRestoring] = useState(false);
   const [copiedSiteId, setCopiedSiteId] = useState(null);
   const [activeTab, setActiveTab] = useState('active');
-  const [notice, setNotice] = useState(null);
+  const [toast, setToast] = useState(null);
 
   useEffect(() => {
     fetchSites();
@@ -79,7 +80,7 @@ export default function SitesList() {
     setActiveTab(tab);
     setSearchTerm('');
     setLocationFilter('');
-    setNotice(null);
+    setToast(null);
     fetchSites(tab === 'archived');
   };
 
@@ -128,7 +129,11 @@ export default function SitesList() {
     trackActivity('click', '/sites', { site_id: site.id }, 'view_site_details_btn');
 
     if (site.is_active === false) {
-      setNotice(`Details for "${site.name}" are not available until the site is restored.`);
+      setToast({
+        title: 'Archived site',
+        message: `Details for "${site.name}" are not available until the site is restored.`,
+        type: 'error',
+      });
       return;
     }
 
@@ -207,19 +212,6 @@ export default function SitesList() {
             Archived
           </button>
         </div>
-
-        {notice && (
-          <div className="flex items-center justify-between gap-3 mb-4 px-4 py-2.5 rounded-lg bg-[#1a1f2b] border border-yellow-500/30 text-yellow-300 text-sm">
-            <span>{notice}</span>
-            <button
-              onClick={() => setNotice(null)}
-              className="text-gray-400 hover:text-white transition-colors shrink-0"
-              title="Dismiss"
-            >
-              ✕
-            </button>
-          </div>
-        )}
 
         <div className="flex flex-col md:flex-row items-center gap-2 mb-4">
           {/* Search input */}
@@ -421,6 +413,8 @@ export default function SitesList() {
         siteName={siteToDelete?.name}
         isDeleting={isDeleting}
       />
+
+      {toast && <Toast {...toast} onClose={() => setToast(null)} />}
     </div>
   );
 }

--- a/frontend/src/pages/Sites/SitesList.jsx
+++ b/frontend/src/pages/Sites/SitesList.jsx
@@ -1,6 +1,15 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { AlertTriangle, Search, Edit, Trash2, ArrowLeft, Copy, Check } from 'lucide-react';
+import {
+  AlertTriangle,
+  Search,
+  Edit,
+  Trash2,
+  ArrowLeft,
+  Copy,
+  Check,
+  RotateCcw,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import OsIcon from '@/components/common/OsIcon';
 import api from '@/services/api';
@@ -16,7 +25,9 @@ export default function SitesList() {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [siteToDelete, setSiteToDelete] = useState(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isRestoring, setIsRestoring] = useState(false);
   const [copiedSiteId, setCopiedSiteId] = useState(null);
+  const [activeTab, setActiveTab] = useState('active');
 
   useEffect(() => {
     fetchSites();
@@ -32,10 +43,10 @@ export default function SitesList() {
     );
   }, []);
 
-  const fetchSites = async () => {
+  const fetchSites = async (includeArchived = false) => {
     try {
       setLoading(true);
-      const data = await api.sites.list();
+      const data = await api.sites.list({ includeArchived });
       const fetchedSites = Array.isArray(data) ? data : data.sites || [];
 
       // Add temporary static fields to match Site.jsx look if missing from API
@@ -55,6 +66,27 @@ export default function SitesList() {
       console.error('Failed to fetch sites:', err);
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleTabChange = (tab) => {
+    setActiveTab(tab);
+    setSearchTerm('');
+    setLocationFilter('');
+    fetchSites(tab === 'archived');
+  };
+
+  const handleRestoreClick = async (e, site) => {
+    e.stopPropagation();
+    try {
+      setIsRestoring(true);
+      await api.sites.restore(site.id);
+      setSites(sites.filter((s) => s.id !== site.id));
+    } catch (err) {
+      console.error('Failed to restore site:', err);
+      alert('Failed to restore site');
+    } finally {
+      setIsRestoring(false);
     }
   };
 
@@ -131,6 +163,30 @@ export default function SitesList() {
           <h1 className="text-xl font-semibold">Manage Sites</h1>
         </div>
 
+        {/* Active / Archived tabs */}
+        <div className="flex gap-1 mb-4 bg-[#141a24] border border-[#1f2735] rounded-lg p-1 w-fit">
+          <button
+            onClick={() => handleTabChange('active')}
+            className={`px-4 py-1.5 text-sm rounded-md transition-colors ${
+              activeTab === 'active'
+                ? 'bg-teal-500/20 text-teal-400 border border-teal-500/30'
+                : 'text-gray-400 hover:text-white hover:bg-[#1f2735]'
+            }`}
+          >
+            Active
+          </button>
+          <button
+            onClick={() => handleTabChange('archived')}
+            className={`px-4 py-1.5 text-sm rounded-md transition-colors ${
+              activeTab === 'archived'
+                ? 'bg-teal-500/20 text-teal-400 border border-teal-500/30'
+                : 'text-gray-400 hover:text-white hover:bg-[#1f2735]'
+            }`}
+          >
+            Archived
+          </button>
+        </div>
+
         <div className="flex flex-col md:flex-row items-center gap-2 mb-4">
           {/* Search input */}
           <div className="relative w-full md:w-1/2">
@@ -180,132 +236,159 @@ export default function SitesList() {
       </div>
 
       <div className="flex-1 overflow-y-auto min-h-0 pb-2 pr-1 custom-scrollbar">
-        <div className="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-          {filteredSites.map((site) => (
-            <div
-              key={site.id}
-              className="bg-[#141a24] border border-[#1f2735] rounded-xl p-5 hover:border-teal-400 transition-all flex flex-col group relative"
-            >
-              {/* Edit/Delete Actions - Always visible */}
-              <div className="absolute top-4 right-4 flex gap-2">
-                <button
-                  // onClick={(e) => handleEditClick(e, site)}
-                  onClick={(e) => {
-                    e.stopPropagation();
-
-                    trackActivity('click', '/sites', { site_id: site.id }, 'edit_site_btn');
-
-                    handleEditClick(e, site);
-                  }}
-                  className="p-1.5 rounded-md bg-[#1f2735] hover:bg-[#2a3441] text-gray-400 hover:text-white transition-colors"
-                  title="Edit"
-                >
-                  <Edit size={14} />
-                </button>
-                <button
-                  // onClick={(e) => handleDeleteClick(e, site)}
-                  onClick={(e) => {
-                    e.stopPropagation();
-
-                    trackActivity('click', '/sites', { site_id: site.id }, 'delete_site_btn');
-
-                    handleDeleteClick(e, site);
-                  }}
-                  className="p-1.5 rounded-md bg-[#1f2735] hover:bg-red-900/30 text-gray-400 hover:text-red-400 transition-colors"
-                  title="Delete"
-                >
-                  <Trash2 size={14} />
-                </button>
-              </div>
-
-              <div className="mb-6">
-                <h2
-                  className="text-lg font-semibold text-white text-start truncate pr-16"
-                  title={site.name}
-                >
-                  {site.name}
-                </h2>
-                <div className="flex flex-col gap-1 mt-1 mb-2">
-                  <div className="flex items-center gap-1.5">
-                    <p className="text-xs font-mono text-teal-400/70 text-start truncate">
-                      Site ID: {site.site_id || site.id}
-                    </p>
-                    <button
-                      onClick={(e) => handleCopySiteId(e, site)}
-                      className="p-0.5 rounded text-gray-400 hover:text-teal-400 transition-colors shrink-0"
-                      title="Copy Site ID"
-                    >
-                      {copiedSiteId === (site.site_id || site.id) ? (
-                        <Check size={12} className="text-teal-400" />
-                      ) : (
-                        <Copy size={12} />
-                      )}
-                    </button>
-                  </div>
-                  <p className="text-sm text-gray-400 text-start truncate">
-                    {site.location || 'No location'}
-                  </p>
-                </div>
-              </div>
-
-              <div className="flex items-center space-x-3 mb-3">
-                {/* Render icons based on OS types present in the site */}
-                {site.os_types && site.os_types.includes('windows') && <OsIcon type="windows" />}
-                {site.os_types && site.os_types.includes('linux') && <OsIcon type="linux" />}
-                {site.os_types &&
-                  (site.os_types.includes('macos') ||
-                    site.os_types.includes('ios') ||
-                    site.os_types.includes('apple')) && <OsIcon type="macos" />}
-                {site.os_types && site.os_types.includes('android') && <OsIcon type="android" />}
-                {site.os_types && site.os_types.includes('web') && <OsIcon type="web" />}
-                {site.os_types &&
-                  (site.os_types.includes('iot') ||
-                    site.os_types.includes('sensor') ||
-                    site.os_types.includes('iot_sensor') ||
-                    site.os_types.includes('embedded') ||
-                    site.os_types.some((t) => t.includes('iot'))) && <OsIcon type="iot" />}
-              </div>
-
-              {site.alert && (
-                <div className="flex items-center text-yellow-400 text-sm mb-2">
-                  <AlertTriangle size={16} className="mr-2" /> {site.alert}
-                </div>
-              )}
-
-              <div className="flex flex-col gap-2 mb-3">
-                <div className="flex items-center gap-2">
-                  <span
-                    className={`w-3 h-3 rounded-full ${site.status === 'Online' ? 'bg-green-400' : 'bg-red-500'}`}
-                  ></span>
-                  <span className="text-sm">{site.status}</span>
-                </div>
-                <div className="flex items-center gap-2 text-sm text-gray-400">
-                  <span>Registered Devices:</span>
-                  <span className="font-semibold text-white">{site.devices_count || 0}</span>
-                </div>
-              </div>
-
-              {/* View Details button */}
-              <button
-                // onClick={(e) => {
-                //   e.stopPropagation();
-                //   navigate(`/sites/${site.id}`);
-                // }}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (!site.id) return;
-
-                  trackActivity('click', '/sites', { site_id: site.id }, 'view_site_details_btn');
-
-                  navigate(`/sites/${site.id}`);
-                }}
-                className="mt-auto w-full border border-[#1f2735] py-2 rounded-lg text-sm hover:bg-[#1f2735] text-gray-300 transition"
+        {filteredSites.length === 0 ? (
+          <div className="flex items-center justify-center h-full text-gray-500 text-sm">
+            {activeTab === 'archived'
+              ? 'No archived sites. Archive a site from the Active tab to see it here.'
+              : 'No sites found.'}
+          </div>
+        ) : (
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+            {filteredSites.map((site) => (
+              <div
+                key={site.id}
+                className="bg-[#141a24] border border-[#1f2735] rounded-xl p-5 hover:border-teal-400 transition-all flex flex-col group relative"
               >
-                View Details
-              </button>
-            </div>
-          ))}
-        </div>
+                {/* Edit/Delete Actions - Always visible */}
+                <div className="absolute top-4 right-4 flex gap-2">
+                  {activeTab === 'archived' ? (
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+
+                        trackActivity('click', '/sites', { site_id: site.id }, 'restore_site_btn');
+
+                        handleRestoreClick(e, site);
+                      }}
+                      className="p-1.5 rounded-md bg-[#1f2735] hover:bg-teal-900/30 text-gray-400 hover:text-teal-400 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                      title="Restore"
+                      disabled={isRestoring}
+                    >
+                      <RotateCcw size={14} />
+                    </button>
+                  ) : (
+                    <>
+                      <button
+                        // onClick={(e) => handleEditClick(e, site)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+
+                          trackActivity('click', '/sites', { site_id: site.id }, 'edit_site_btn');
+
+                          handleEditClick(e, site);
+                        }}
+                        className="p-1.5 rounded-md bg-[#1f2735] hover:bg-[#2a3441] text-gray-400 hover:text-white transition-colors"
+                        title="Edit"
+                      >
+                        <Edit size={14} />
+                      </button>
+                      <button
+                        // onClick={(e) => handleDeleteClick(e, site)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+
+                          trackActivity('click', '/sites', { site_id: site.id }, 'delete_site_btn');
+
+                          handleDeleteClick(e, site);
+                        }}
+                        className="p-1.5 rounded-md bg-[#1f2735] hover:bg-red-900/30 text-gray-400 hover:text-red-400 transition-colors"
+                        title="Delete"
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </>
+                  )}
+                </div>
+
+                <div className="mb-6">
+                  <h2
+                    className="text-lg font-semibold text-white text-start truncate pr-16"
+                    title={site.name}
+                  >
+                    {site.name}
+                  </h2>
+                  <div className="flex flex-col gap-1 mt-1 mb-2">
+                    <div className="flex items-center gap-1.5">
+                      <p className="text-xs font-mono text-teal-400/70 text-start truncate">
+                        Site ID: {site.site_id || site.id}
+                      </p>
+                      <button
+                        onClick={(e) => handleCopySiteId(e, site)}
+                        className="p-0.5 rounded text-gray-400 hover:text-teal-400 transition-colors shrink-0"
+                        title="Copy Site ID"
+                      >
+                        {copiedSiteId === (site.site_id || site.id) ? (
+                          <Check size={12} className="text-teal-400" />
+                        ) : (
+                          <Copy size={12} />
+                        )}
+                      </button>
+                    </div>
+                    <p className="text-sm text-gray-400 text-start truncate">
+                      {site.location || 'No location'}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-center space-x-3 mb-3">
+                  {/* Render icons based on OS types present in the site */}
+                  {site.os_types && site.os_types.includes('windows') && <OsIcon type="windows" />}
+                  {site.os_types && site.os_types.includes('linux') && <OsIcon type="linux" />}
+                  {site.os_types &&
+                    (site.os_types.includes('macos') ||
+                      site.os_types.includes('ios') ||
+                      site.os_types.includes('apple')) && <OsIcon type="macos" />}
+                  {site.os_types && site.os_types.includes('android') && <OsIcon type="android" />}
+                  {site.os_types && site.os_types.includes('web') && <OsIcon type="web" />}
+                  {site.os_types &&
+                    (site.os_types.includes('iot') ||
+                      site.os_types.includes('sensor') ||
+                      site.os_types.includes('iot_sensor') ||
+                      site.os_types.includes('embedded') ||
+                      site.os_types.some((t) => t.includes('iot'))) && <OsIcon type="iot" />}
+                </div>
+
+                {site.alert && (
+                  <div className="flex items-center text-yellow-400 text-sm mb-2">
+                    <AlertTriangle size={16} className="mr-2" /> {site.alert}
+                  </div>
+                )}
+
+                <div className="flex flex-col gap-2 mb-3">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`w-3 h-3 rounded-full ${site.status === 'Online' ? 'bg-green-400' : 'bg-red-500'}`}
+                    ></span>
+                    <span className="text-sm">{site.status}</span>
+                  </div>
+                  <div className="flex items-center gap-2 text-sm text-gray-400">
+                    <span>Registered Devices:</span>
+                    <span className="font-semibold text-white">{site.devices_count || 0}</span>
+                  </div>
+                </div>
+
+                {/* View Details button */}
+                <button
+                  // onClick={(e) => {
+                  //   e.stopPropagation();
+                  //   navigate(`/sites/${site.id}`);
+                  // }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (!site.id) return;
+
+                    trackActivity('click', '/sites', { site_id: site.id }, 'view_site_details_btn');
+
+                    navigate(`/sites/${site.id}`);
+                  }}
+                  className="mt-auto w-full border border-[#1f2735] py-2 rounded-lg text-sm hover:bg-[#1f2735] text-gray-300 transition"
+                >
+                  View Details
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
       <SiteDeleteDialog

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -158,9 +158,12 @@ const api = {
   sites: {
     /**
      * List all sites
+     * @param {object} opts - { includeArchived: boolean }
      */
-    list: async () => {
-      const response = await apiClient.get('/sites/');
+    list: async ({ includeArchived = false } = {}) => {
+      const response = await apiClient.get('/sites/', {
+        params: includeArchived ? { include_archived: true } : {},
+      });
       return response.data;
     },
 
@@ -169,6 +172,14 @@ const api = {
      */
     get: async (siteId) => {
       const response = await apiClient.get(`/sites/${siteId}`);
+      return response.data;
+    },
+
+    /**
+     * Restore an archived site (flips is_active + lifecycle_state back to active)
+     */
+    restore: async (siteId) => {
+      const response = await apiClient.post(`/sites/${siteId}/restore`);
       return response.data;
     },
 
@@ -255,8 +266,18 @@ const api = {
       return response.data;
     },
 
-    getSiteId: async (siteId) => {
-      const response = await apiClient.get(`/devices/sites/${siteId}/devices`);
+    getSiteId: async (siteId, { includeUnpaired = false } = {}) => {
+      const response = await apiClient.get(`/devices/sites/${siteId}/devices`, {
+        params: includeUnpaired ? { include_unpaired: true } : {},
+      });
+      return response.data;
+    },
+
+    /**
+     * Resume a suspended device (suspended -> active)
+     */
+    resume: async (deviceId) => {
+      const response = await apiClient.post(`/devices/device/${deviceId}/resume`);
       return response.data;
     },
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -274,10 +274,10 @@ const api = {
     },
 
     /**
-     * Resume a suspended device (suspended -> active)
+     * Resume/restore a suspended or unpaired device (back to active)
      */
     resume: async (deviceId) => {
-      const response = await apiClient.post(`/devices/device/${deviceId}/resume`);
+      const response = await apiClient.post(`/devices/device/${deviceId}/resume`, {});
       return response.data;
     },
 

--- a/frontend/tests/unit/SiteDetail.test.jsx
+++ b/frontend/tests/unit/SiteDetail.test.jsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import api from '@/services/api';
+import SiteDetail from '@/pages/Sites/SiteDetail';
+
+vi.mock('@/services/api');
+vi.mock('@/utils/analytics', () => ({
+  trackActivity: vi.fn().mockResolvedValue(undefined),
+  trackSearch: vi.fn().mockResolvedValue(undefined),
+}));
+
+const activeDevice = {
+  id: 1,
+  device_id: 'DEV-ACTIVE',
+  name: 'Active POS',
+  device_type: 'pos_terminal',
+  is_active: true,
+  lifecycle_state: 'active',
+  status: 'online',
+  connectivity_state: 'online',
+  health_state: 'healthy',
+  enrollment_method: 'self-enrolled',
+  active_alerts: 0,
+  last_seen: null,
+};
+
+const suspendedDevice = {
+  id: 2,
+  device_id: 'DEV-SUSP',
+  name: 'Suspended POS',
+  device_type: 'pos_terminal',
+  is_active: false,
+  lifecycle_state: 'suspended',
+  status: 'offline',
+  connectivity_state: 'offline',
+  health_state: 'unknown',
+  enrollment_method: 'self-enrolled',
+  active_alerts: 0,
+  last_seen: null,
+};
+
+const activeSite = {
+  site_id: 'SITE-RES',
+  id: 'SITE-RES',
+  name: 'Restored Co',
+  location: 'London',
+  is_active: true,
+  lifecycle_state: 'active',
+  is_monitored: false,
+};
+
+describe('SiteDetail Model B', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.sites.get.mockResolvedValue(activeSite);
+    api.devices.getSiteId.mockResolvedValue([activeDevice, suspendedDevice]);
+    api.sites.getDashboard.mockResolvedValue({
+      total_devices: 2,
+      connectivity_counts: { online: 1, offline: 1 },
+      health_counts: { healthy: 1, warning: 0, error: 0, maintenance: 0, unknown: 1 },
+    });
+  });
+
+  const renderDetail = () =>
+    render(
+      <MemoryRouter initialEntries={['/sites/SITE-RES']}>
+        <Routes>
+          <Route path="/sites/:id" element={<SiteDetail />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+  it('fetches devices with includeUnpaired on a restored (active) site', async () => {
+    renderDetail();
+
+    expect(await screen.findByText('Active POS')).toBeInTheDocument();
+    expect(screen.getByText('Suspended POS')).toBeInTheDocument();
+    expect(api.devices.getSiteId).toHaveBeenCalledWith('SITE-RES', { includeUnpaired: true });
+  });
+
+  it('shows a restore action for suspended devices and edit for active devices', async () => {
+    renderDetail();
+
+    await screen.findByText('Active POS');
+
+    // Suspended device gets a Restore action
+    expect(screen.getByTitle('Restore device')).toBeInTheDocument();
+  });
+
+  it('does not show a restore action for active devices', async () => {
+    renderDetail();
+
+    await screen.findByText('Active POS');
+
+    // Only one restore button (for the suspended device), not two
+    expect(screen.getAllByTitle('Restore device')).toHaveLength(1);
+  });
+});

--- a/frontend/tests/unit/SitesList.test.jsx
+++ b/frontend/tests/unit/SitesList.test.jsx
@@ -42,6 +42,25 @@ const mockArchivedSites = {
   ],
 };
 
+// Backend returns ALL sites when include_archived=true; the Archived tab must
+// still filter down to archived-only.
+const mockAllSites = {
+  sites: [
+    ...mockActiveSites.sites,
+    {
+      site_id: 'SITE-BBB',
+      id: 'SITE-BBB',
+      name: 'Retired Depot',
+      location: 'Paris',
+      status: 'Offline',
+      is_active: false,
+      lifecycle_state: 'archived',
+      devices_count: 1,
+      os_types: [],
+    },
+  ],
+};
+
 describe('SitesList', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -66,7 +85,7 @@ describe('SitesList', () => {
   });
 
   it('fetches archived sites when the Archived tab is clicked and shows a restore button', async () => {
-    api.sites.list.mockResolvedValueOnce(mockActiveSites).mockResolvedValueOnce(mockArchivedSites);
+    api.sites.list.mockResolvedValueOnce(mockActiveSites).mockResolvedValueOnce(mockAllSites);
 
     renderList();
 
@@ -74,7 +93,10 @@ describe('SitesList', () => {
 
     await waitFor(() => expect(api.sites.list).toHaveBeenLastCalledWith({ includeArchived: true }));
 
+    // Archived tab must only show archived sites, not active ones
     expect(await screen.findByRole('button', { name: 'Restore' })).toBeInTheDocument();
+    expect(screen.getByText('Retired Depot')).toBeInTheDocument();
+    expect(screen.queryByText('Head Office')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
   });

--- a/frontend/tests/unit/SitesList.test.jsx
+++ b/frontend/tests/unit/SitesList.test.jsx
@@ -115,4 +115,19 @@ describe('SitesList', () => {
 
     await waitFor(() => expect(screen.queryByText('Head Office')).not.toBeInTheDocument());
   });
+
+  it('shows a notice instead of navigating when View Details is clicked on an archived site', async () => {
+    api.sites.list.mockResolvedValueOnce(mockActiveSites).mockResolvedValueOnce(mockArchivedSites);
+
+    renderList();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Archived' }));
+
+    const viewDetailsButtons = await screen.findAllByRole('button', { name: 'View Details' });
+    fireEvent.click(viewDetailsButtons[0]);
+
+    expect(
+      await screen.findByText(/details for .* are not available until the site is restored/i)
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/tests/unit/SitesList.test.jsx
+++ b/frontend/tests/unit/SitesList.test.jsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import api from '@/services/api';
+import SitesList from '@/pages/Sites/SitesList';
+
+vi.mock('@/services/api');
+vi.mock('@/utils/analytics', () => ({
+  trackActivity: vi.fn().mockResolvedValue(undefined),
+  trackSearch: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockActiveSites = {
+  sites: [
+    {
+      site_id: 'SITE-AAA',
+      id: 'SITE-AAA',
+      name: 'Head Office',
+      location: 'London',
+      status: 'Online',
+      is_active: true,
+      lifecycle_state: 'active',
+      devices_count: 2,
+      os_types: [],
+    },
+  ],
+};
+
+const mockArchivedSites = {
+  sites: [
+    {
+      site_id: 'SITE-AAA',
+      id: 'SITE-AAA',
+      name: 'Head Office',
+      location: 'London',
+      status: 'Offline',
+      is_active: false,
+      lifecycle_state: 'archived',
+      devices_count: 2,
+      os_types: [],
+    },
+  ],
+};
+
+describe('SitesList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.sites.list.mockResolvedValue(mockActiveSites);
+    api.sites.restore = vi.fn().mockResolvedValue({ message: 'restored' });
+  });
+
+  const renderList = () =>
+    render(
+      <MemoryRouter>
+        <SitesList />
+      </MemoryRouter>
+    );
+
+  it('renders active sites by default with Active and Archived tabs', async () => {
+    renderList();
+
+    expect(await screen.findByText('Head Office')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Active' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Archived' })).toBeInTheDocument();
+    expect(api.sites.list).toHaveBeenCalledWith({ includeArchived: false });
+  });
+
+  it('fetches archived sites when the Archived tab is clicked and shows a restore button', async () => {
+    api.sites.list.mockResolvedValueOnce(mockActiveSites).mockResolvedValueOnce(mockArchivedSites);
+
+    renderList();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Archived' }));
+
+    await waitFor(() => expect(api.sites.list).toHaveBeenLastCalledWith({ includeArchived: true }));
+
+    expect(await screen.findByRole('button', { name: 'Restore' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+  });
+
+  it('calls sites.restore and removes the site when restore is clicked', async () => {
+    api.sites.list.mockResolvedValueOnce(mockActiveSites).mockResolvedValueOnce(mockArchivedSites);
+
+    renderList();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Archived' }));
+
+    const restoreButton = await screen.findByRole('button', { name: 'Restore' });
+    fireEvent.click(restoreButton);
+
+    await waitFor(() => expect(api.sites.restore).toHaveBeenCalledWith('SITE-AAA'));
+
+    await waitFor(() => expect(screen.queryByText('Head Office')).not.toBeInTheDocument());
+  });
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -161,6 +161,7 @@ nav:
   - Layer 5 - Edge Layer:
       - Device Management:
           - Lifecycle & Ownership: device-lifecycle-and-ownership.md
+          - Site & Device Lifecycle Matrix: site-device-lifecycle-matrix.md
           - Enrolment Intents: enrolment-intents.md
           - Registration: device-registration.md
           - Metrics Collection: device-metrics-collection.md


### PR DESCRIPTION
Adds an **Archived** tab to the Sites page so technicians can restore archived sites and their suspended devices from the Dashboard.

- `GET /sites/` gains `include_archived=true` (also includes suspended devices under archived sites); list payload now exposes `is_active`/`lifecycle_state`
- `SitesList.jsx`: Active/Archived tabs; archived rows show a Restore action instead of Edit/Delete
- `SiteDetail.jsx`: read-only archived view with suspended devices + per-device Restore; Restore Site button
- `api.js`: `sites.list({includeArchived})`, `sites.restore(id)`, `devices.resume(id)`, `devices.getSiteId(id, {includeUnpaired})`
- Tests: backend `test_site_list_excludes_archived_by_default`, frontend `SitesList.test.jsx` (3 tests)

Restore re-activates the site and revives `active/pending/suspended` devices (existing endpoints). Purged items never appear (data is permanently deleted).