### PR TITLE
fix: auto-start agent manager on API startup

### DIFF
--- a/backend/src/homepot/app/main.py
+++ b/backend/src/homepot/app/main.py
@@ -95,6 +95,32 @@ async def initialize_database() -> None:
 
 
 @app.on_event("startup")
+async def start_agent_manager() -> None:
+    """Auto-start the device agent simulator when the API starts.
+
+    Previously the agent manager only started lazily when an endpoint (e.g.
+    ``/health/system-pulse``) first called ``get_agent_manager()``, so after a
+    backend restart no simulated data collection ran until something pinged it.
+    Starting it here makes simulated/emulated device data collection resume
+    automatically on startup (respecting ``enable_agent_simulation``).
+    """
+    if not get_settings().enable_agent_simulation:
+        logging.getLogger(__name__).info(
+            "Agent simulation disabled — skipping agent manager startup"
+        )
+        return
+    try:
+        from homepot.agents import get_agent_manager
+
+        await get_agent_manager()
+        logging.getLogger(__name__).info("Agent manager started on API startup")
+    except Exception as e:
+        logging.getLogger(__name__).warning(
+            f"Failed to start agent manager on startup: {e}"
+        )
+
+
+@app.on_event("startup")
 async def initialize_client() -> None:
     """Connect the HOMEPOT client and wire it into the endpoints that need it.
 


### PR DESCRIPTION
Auto-start the device agent simulator when the API starts.

**Problem:** The agent manager only started lazily, when an endpoint such as `/health/system-pulse` or an agent endpoint first called `get_agent_manager()`. After a backend restart, no simulated/emulated device data collection ran until something pinged the agent manager — so `ENABLE_AGENT_SIMULATION` data collection did not resume on its own.

**Fix:** Add an API startup hook (`homepot/app/main.py`) that calls `get_agent_manager()` on startup (respecting `enable_agent_simulation`). Now the simulated agent fleet starts automatically when the API boots, and data collection resumes without manual intervention.

Verified live: on backend reload, the log shows
`Agent Manager started` followed by `Agent manager started on API startup`, and the agent fleet immediately begins collecting.

Tests are unaffected — the API startup hook only fires when the API app runs as a context-managed ASGI app in production; the test suite's context-managed clients use the separate client app (`homepot.main`), which already started the manager.