### PR TITLE
docs: refresh AI docs to match current implementation

### DIFF
--- a/ai/README.md
+++ b/ai/README.md
@@ -8,7 +8,9 @@ This directory contains the AI and Machine Learning services for the HOMEPOT Cli
 
 ## Context Builder
 
-The **Context Builder** (`ai/context_builder.py`) aggregates data from all **25 database tables** to provide "situational awareness" to the LLM:
+The **Context Builder** (`ai/context_builder.py`) exposes many context sources for "situational awareness" to the LLM. Note that this README describes the standalone/legacy architecture; the **live integrated** AI surface (`/api/v1/ai/query` in `AIEndpoint.py`) injects a focused, real-time subset (current site/device status, push stats, active alerts, recent jobs) rather than every table on every request — see [AI Implementation & Architecture](../docs/ai-implementation.md) and the [API Reference](../docs/ai-api-reference.md).
+
+Available context sources include:
 
 *   **Tenants:** Multi-tenancy organisations and their active status.
 *   **Tenant Memberships:** User-role assignments within tenants.

--- a/docs/ai-api-reference.md
+++ b/docs/ai-api-reference.md
@@ -1,139 +1,178 @@
 # AI Service API Reference
 
-> **Version:** 1.0  
-> **Status:** Experimental  
-> **Base URL:** `/api/ai`
+> **Status:** Experimental
+> **Base URL:** `/api/v1/ai`
 
-The AI Service provides intelligent analysis and natural language querying capabilities for the HOMEPOT Client. It leverages a local LLM (Ollama) and Vector Memory (ChromaDB) to ensure data privacy.
+The AI Service provides intelligent analysis and natural-language querying for the HOMEPOT Client. It uses a local LLM (Ollama) with Vector Memory (ChromaDB) for data privacy, and wraps every chat answer in a [trust & validation-gate envelope](ai-validation-gates.md) so confidence is always surfaced.
 
 ---
 
-## 1. Analyze Device Metrics
+## 1. Natural Language Query
 
-Analyze a set of device metrics to detect anomalies and receive actionable recommendations. This endpoint uses a **Hybrid Approach**:
-1.  **Rule-Based Detection:** Instantly flags known issues (e.g., CPU > 90%).
-2.  **LLM Analysis:** Provides context, explanation, and troubleshooting steps based on the rule-based findings.
+Ask questions about the system, specific devices, or historical incidents. The system uses **RAG** and **Context Injection**, and returns the answer together with a **trust envelope** describing how much confidence to place in it.
 
 ### Endpoint
-`POST /analyze`
+`POST /api/v1/ai/query`
 
 ### Request Body
 ```json
 {
-  "device_id": "pos-terminal-01",
-  "metrics": {
-    "cpu_percent": 92.5,
-    "memory_percent": 60.0,
-    "disk_percent": 45.0,
-    "error_rate": 0.05,
-    "network_latency_ms": 120
-  }
-}
-```
-
-### Response
-```json
-{
-  "device_id": "pos-terminal-01",
-  "anomaly_score": 0.4,
-  "is_anomaly": false,
-  "analysis": "The CPU usage is high (92.5%), which exceeds the 90% threshold. However, memory and disk usage are within normal limits. This suggests a compute-intensive process is running. Recommendation: Check for stuck background jobs or recent software updates.",
-  "status": "processed"
-}
-```
-
----
-
-## 2. Set Analysis Mode
-
-Switch the AI's "persona" to tailor the analysis output for different audiences.
-
-### Endpoint
-`POST /mode`
-
-### Request Body
-```json
-{
-  "mode": "executive"
-}
-```
-
-**Available Modes:**
-- `maintenance` (Default): Technical focus, root cause analysis, fix recommendations.
-- `predictive`: Trend analysis, failure prediction, risk assessment.
-- `executive`: High-level summaries, business impact, KPIs.
-
-### Response
-```json
-{
-  "status": "success",
-  "mode": "executive"
-}
-```
-
----
-
-## 3. Natural Language Query
-
-Ask questions about the system, specific devices, or historical incidents. The system uses **RAG (Retrieval-Augmented Generation)** and **Context Injection** to provide accurate answers based on:
-
-1.  **Real-Time Context:** Current device status, health checks, and push notification stats.
-2.  **System Knowledge:** Awareness of the codebase structure and project documentation.
-3.  **Long-Term Memory:** Historical logs and similar past incidents stored in ChromaDB.
-4.  **Short-Term Memory:** The recent conversation history (last 5 messages).
-
-### Endpoint
-`POST /query`
-
-### Request Body
-```json
-{
-  "query": "Why is device pos-terminal-01 failing?",
-  "device_id": "pos-terminal-01",
+  "query": "Why is device DEVICE-8TKX-MVVG-U4EH failing?",
+  "device_id": "DEVICE-8TKX-MVVG-U4EH",
+  "role": "Admin",
   "history": [
-    {
-      "role": "user",
-      "content": "Is the system healthy?"
-    },
-    {
-      "role": "assistant",
-      "content": "Yes, most devices are online, but pos-terminal-01 is reporting errors."
-    }
+    { "role": "user", "content": "Is the system healthy?" },
+    { "role": "assistant", "content": "Most devices are online, but one is reporting errors." }
   ]
 }
 ```
 
 **Parameters:**
-*   `query` (string, required): The question to ask.
-*   `device_id` (string, optional): If provided, fetches specific context for this device.
-*   `history` (list, optional): A list of previous messages to maintain conversation context.
+* `query` (string, required): the question to ask.
+* `context` (string, optional): extra context appended verbatim to the prompt.
+* `device_id` (string, optional): if provided, fetches device-specific context and runs the per-device gates (D, E).
+* `role` (string, optional): the requester's role, injected into the prompt.
+* `history` (list, optional): prior `{role, content}` messages for short-term memory.
 
 ### Response
 ```json
 {
-  "response": "Based on recent logs, pos-terminal-01 is experiencing high CPU usage (92.5%) and intermittent network latency. This pattern matches a known issue with the 'v2.4.1' firmware update. I recommend rolling back to v2.4.0.",
-  "context_used": {
-    "long_term_memories": 3,
-    "short_term_messages": 2
+  "response": "Based on recent logs, DEVICE-8TKX-MVVG-U4EH is experiencing high CPU usage (92.5%) and intermittent network latency. This pattern matches a known issue with the v2.4.1 firmware update. I recommend rolling back to v2.4.0.",
+  "timestamp": "2026-07-17T15:13:16.418238",
+  "trust": {
+    "trust_mode": "grounded",
+    "trust_mode_label": "Grounded LLM Interface",
+    "trust_score": 1.0,
+    "actionable": true,
+    "passed_gates": ["A", "B", "C", "D", "E", "C"],
+    "failed_gate": null,
+    "summary": "Passed all gates (A, B, C, D, E, C) — Grounded LLM Interface",
+    "gates": [
+      {
+        "gate_id": "A",
+        "name": "Contract and Infrastructure",
+        "status": "pass",
+        "score": 1.0,
+        "checks": [ { "check_id": "A.db_readiness", "passed": true, "message": "...", "evidence": [] } ]
+      }
+    ]
+  }
+}
+```
+
+The `trust` object is the `EnvelopeResult` from `ai/gates/envelope.py`. See [Trust & Validation Gates](ai-validation-gates.md) for the mode reference and how trust is surfaced in the Dashboard.
+
+---
+
+## 2. Anomaly Scan
+
+Return the current rule-based anomaly scan across active devices.
+
+### Endpoint
+`GET /api/v1/ai/anomalies`
+
+### Response
+```json
+{
+  "anomalies": [
+    {
+      "device_id": "DEVICE-8TKX-MVVG-U4EH",
+      "device_name": "Web Dashboard 1-4",
+      "score": 0.82,
+      "severity": "high",
+      "reason": "CPU 92.5% and memory 85% sustained"
+    }
+  ],
+  "status": "success"
+}
+```
+
+---
+
+## 3. Insights
+
+Per-scope analytics summaries.
+
+### Endpoint
+`GET /api/v1/ai/insights/device/{device_id}`
+`GET /api/v1/ai/insights/site/{site_id}`
+`GET /api/v1/ai/insights/push-notifications`
+
+### Example (site)
+`GET /api/v1/ai/insights/site/SITE-6725-FUJH`
+
+```json
+{
+  "site_id": "SITE-6725-FUJH",
+  "insights": {
+    "performance_trend": "...",
+    "configuration_impact": "...",
+    "job_outcomes": "..."
   }
 }
 ```
 
 ---
 
-## 4. Health Check
+## 4. Predictions
 
-Verify that the AI Service and LLM are operational.
+Failure-risk assessments for devices.
 
-### Endpoint
-`GET /health`
+### Endpoints
+`GET /api/v1/ai/predictions/failure/{device_id}`
+`GET /api/v1/ai/predictions/at-risk-devices`
 
-### Response
+### Example
+`GET /api/v1/ai/predictions/failure/DEVICE-8TKX-MVVG-U4EH`
+
 ```json
 {
-  "status": "healthy",
-  "llm_connected": true,
-  "version": "1.0.0",
-  "mode": "maintenance"
+  "device_id": "DEVICE-8TKX-MVVG-U4EH",
+  "risk_score": 0.4,
+  "risk_level": "medium",
+  "factors": { "resource_trend": 0.35, "error_trend": 0.3 },
+  "prediction_window_hours": 24,
+  "recommendation": "..."
 }
 ```
+
+---
+
+## 5. Recommendations
+
+Job-scheduling recommendations.
+
+### Endpoints
+`POST /api/v1/ai/recommendations/schedule-job`
+`POST /api/v1/ai/recommendations/success-probability`
+`GET /api/v1/ai/recommendations/optimal-windows/{site_id}`
+
+### Example
+`POST /api/v1/ai/recommendations/schedule-job`
+
+```json
+{ "site_id": "SITE-6725-FUJH", "job_priority": "medium", "earliest_start": "2026-07-17T20:00:00Z" }
+```
+
+---
+
+## 6. Health Forecast
+
+`GET /api/v1/ai/health-forecast`
+
+Aggregate operational-health forecast across all active devices.
+
+---
+
+## 7. Status
+
+`GET /api/v1/ai/status`
+
+Static capability/status report for the AI service.
+
+---
+
+## Authentication
+
+!!! warning
+    As of the current implementation, the `/api/v1/ai/*` endpoints do **not** enforce authentication or per-site/tenant authorization. They are intended to be reached from within the Dashboard, which is itself unauthenticated at the API layer. Adding `Depends(require_user())` and site/tenant scoping to these routes is a tracked improvement.

--- a/docs/ai-implementation.md
+++ b/docs/ai-implementation.md
@@ -39,13 +39,15 @@ As of January 2026, the AI has been upgraded with a **Dual-Memory System** and *
 
 ## Key Components
 
-The implementation consists of core modules:
+The live AI surface is exposed through the main backend at `/api/v1/ai/*`, implemented in `backend/src/homepot/app/api/API_v1/Endpoints/AIEndpoint.py` and the `ai/` package:
 
-*   **`api.py` (The Brain)**: A FastAPI application serving as the entry point.
-    *   `POST /api/ai/analyze`: Analyzes metrics, scores anomalies, and generates LLM explanations.
-    *   `POST /api/ai/query`: Answers natural language questions using RAG (Retrieval-Augmented Generation).
-    *   `POST /api/ai/mode`: Switches the AI's analysis persona (Maintenance, Predictive, Executive).
-    *   `GET /api/ai/anomalies`: Returns a list of currently detected anomalies. See [Anomaly Detection](anomaly-detection.md) for details.
+*   **`AIEndpoint.py` (The API Surface)**: The FastAPI router mounted at `/api/v1/ai`.
+    *   `POST /api/v1/ai/query`: Answers natural-language questions using RAG, wrapped in the [validation-gate trust envelope](ai-validation-gates.md). Returns `{response, timestamp, trust}`.
+    *   `GET /api/v1/ai/anomalies`: Returns the current rule-based anomaly scan. See [Anomaly Detection](anomaly-detection.md).
+    *   `GET /api/v1/ai/insights/...` and `/api/v1/ai/predictions/...`: Per-device/site insights and failure predictions.
+    *   `POST /api/v1/ai/recommendations/...`: Job-scheduling recommendations and success-probability estimates.
+*   **`context_builder.py` (The Context)**: Assembles the real-time, historical, and system context handed to the LLM (sites, devices, alerts, jobs, memories).
+*   **`gates/` (The Validation Envelope)**: Gates A-E bound the trust of every answer (see [Trust & Validation Gates](ai-validation-gates.md)).
 *   **`system_knowledge.py` (The Self-Awareness)**:
     *   Scans the project directory structure.
     *   Reads the root `README.md` to understand the project's purpose.
@@ -56,8 +58,10 @@ The implementation consists of core modules:
     *   See [Anomaly Detection Documentation](anomaly-detection.md) for scoring logic.
 *   **`llm.py` (The Voice)**: A wrapper for **Ollama** that manages the connection to local models (Llama/Mistral) and constructs context-aware prompts.
 *   **`device_memory.py` (The Long-Term Memory)**: Manages **ChromaDB** interactions for storing and retrieving semantic vector embeddings of device logs.
-*   **`event_store.py` (The Short-Term Device Memory)**: Caches recent device events in-memory and persists them to the **PostgreSQL** `device_metrics` table to provide immediate context for analysis.
-*   **`analysis_modes.py` (The Persona)**: Manages different system prompts to tailor the AI's output style and focus (e.g., technical vs. executive).
+*   **`failure_predictor.py` / `job_scheduler.py` / `analytics_service.py`**: Predictive-maintenance risk scoring, job scheduling recommendations, and analytics aggregations.
+
+!!! note "Legacy standalone service"
+    An older, standalone FastAPI app in `ai/api.py` (routes like `POST /api/ai/analyze`, `POST /api/ai/query`, `POST /api/ai/mode`, `GET /predict/{device_id}`) predates the integrated `/api/v1/ai` surface. It is **not** the live service, is not started by any launch script, and does **not** run the validation gates. It remains in the repository and is still exercised by some backend tests. Prefer the integrated `/api/v1/ai/*` endpoints for all new work.
 
 ## Predictive Maintenance
 
@@ -66,11 +70,11 @@ We have introduced a **Predictive Maintenance** module (`failure_predictor.py`) 
 ### Features
 *   **Risk Scoring**: Calculates a risk score (0.0 - 1.0) based on CPU, Memory, and Disk usage trends.
 *   **Trend Analysis**: Detects increasing resource usage over time.
-*   **API Endpoint**: `GET /predict/{device_id}` returns the current risk assessment.
+*   **API Endpoint**: `GET /api/v1/ai/predictions/failure/{device_id}` returns the current risk assessment.
 
 ## NLP Context Injection
 
-The AI Query endpoint (`/api/ai/query`) has been enhanced to bridge the gap between historical knowledge and real-time status.
+The AI Query endpoint (`POST /api/v1/ai/query`) has been enhanced to bridge the gap between historical knowledge and real-time status.
 
 ### How it Works
 When a user asks a question about a specific device (e.g., "Is the kitchen camera failing?"), the system:
@@ -114,13 +118,13 @@ We prioritize **normal execution cycles** (running directly in a local environme
     pip install -r backend/requirements.txt
     ```
 
-3.  **Run the Service**:
+3.  **Run the Service**: The AI endpoints are part of the main backend, so start the normal backend app rather than a separate AI process:
     ```bash
-    python ai/api.py
+    python -m uvicorn homepot.app.main:app --host 0.0.0.0 --port 8000 --reload
     ```
-    The API will be available at `http://localhost:8000`.
+    The AI API is available at `http://localhost:8000/api/v1/ai/*`. The legacy standalone `ai/api.py` service can still be run on port 8001 for debugging legacy paths, but it is not the live service.
 
 4.  **Run Tests**:
     ```bash
-    pytest backend/tests/test_ai_service.py
+    pytest backend/tests/test_ai_service.py backend/tests/test_ai_nlp_integration.py backend/tests/test_validation_gates.py
     ```

--- a/docs/ai-roadmap.md
+++ b/docs/ai-roadmap.md
@@ -102,7 +102,7 @@ app/
 | AI Infrastructure (FastAPI + Ollama + ChromaDB) | ✅ | `ai/api.py`, `ai/llm.py`, `ai/device_memory.py` |
 | Context Builder (12 data sources) | ✅ | `ai/context_builder.py` — parallel async DB queries |
 | Anomaly Detection (rule-based) | ✅ | `ai/anomaly_detection.py` — 6-factor scoring |
-| Validation Gates (A, B, C) | ✅ | `ai/gates/` — contract, integrity, context readiness |
+| Validation Gates (A, B, C, D, E) | ✅ | `ai/gates/` — contract, integrity, context readiness, permissions/capabilities, lifecycle integrity |
 | Analysis Modes (3 personas) | ✅ | `ai/analysis_modes.py` — maintenance, predictive, executive |
 | AI Query Endpoint (`/api/v1/ai/query`) | ✅ | `AIEndpoint.py` with trust envelope |
 | Device Memory (ChromaDB RAG) | ✅ | `ai/device_memory.py` — semantic vector storage |

--- a/docs/ai-validation-gates.md
+++ b/docs/ai-validation-gates.md
@@ -3,7 +3,7 @@
 > **Status:** Implemented (July 2026)
 > **Related:** [AI Implementation & Architecture](ai-implementation.md) &middot; [Context Builder](ai-context-builder.md) &middot; [Anomaly Detection](anomaly-detection.md)
 
-The **System Diagnostics AI** does not treat every LLM answer as equally trustworthy. Before a question reaches the model, the underlying telemetry passes through a sequential chain of **validation gates** (Gate A &rarr; Gate B &rarr; Gate C &rarr; &hellip;). Each gate either passes or fails; a failure short-circuits the chain into a named, capped-trust **mode** instead of silently allowing an unqualified narrative. This is the implementation of the *validation-first* architecture described in the HOMEPOT ICCS2026 paper (Fig. 2).
+The **System Diagnostics AI** does not treat every LLM answer as equally trustworthy. Before a question reaches the model, the underlying telemetry passes through a sequential chain of **validation gates** (Gate A &rarr; Gate B &rarr; Gate C &rarr; Gate D &rarr; Gate E). Each gate either passes or fails; a failure short-circuits the chain into a named, capped-trust **mode** instead of silently allowing an unqualified narrative. This is the implementation of the *validation-first* architecture described in the HOMEPOT ICCS2026 paper (Fig. 2).
 
 The goal is simple: **a technician should never see a recommendation without also seeing how much confidence to place in it.**
 
@@ -13,7 +13,7 @@ An LLM will happily produce a fluent, confident-sounding answer even when the da
 
 * Each gate inspects a specific quality dimension of the data the LLM is about to be given.
 * A failing gate doesn't necessarily block the chat turn -- the LLM still responds -- but the response is explicitly labeled as non-actionable/advisory, and the reported trust score is capped accordingly.
-* The chain is **extensible**: new gates (e.g. a future cybersecurity/provenance Gate D) can be appended without modifying Gate A/B/C.
+* The chain is **extensible**: new gates can be appended without modifying Gate A/B/C/D/E.
 
 ## The gate chain
 
@@ -21,10 +21,14 @@ An LLM will happily produce a fluent, confident-sounding answer even when the da
 flowchart LR
     A[Gate A<br/>Contract & Infrastructure] -->|pass| B[Gate B<br/>Data Integrity]
     B -->|pass| C[Gate C<br/>Context Readiness]
-    C -->|pass| G[Grounded LLM Interface<br/>trust = 1.0, actionable]
+    C -->|pass| D[Gate D<br/>Permissions & Capabilities]
+    D -->|pass| E[Gate E<br/>Lifecycle Integrity]
+    E -->|pass| G[Grounded LLM Interface<br/>trust = 1.0, actionable]
     A -->|fail| M1[Mode 1: Status-only<br/>trust ceiling 0.0]
     B -->|fail| M2[Mode 2: Best-effort analytics<br/>trust ceiling 0.5]
     C -->|fail| M3[Mode 3: Cautionary summaries<br/>trust ceiling 0.75]
+    D -->|fail| M4[Mode 4: Permission Gap<br/>trust ceiling 0.75]
+    E -->|fail| M5[Mode 5: Lifecycle Halt<br/>trust ceiling 0.5]
 ```
 
 ### Gate A -- Contract and Infrastructure
@@ -66,6 +70,30 @@ Failing Gate C falls back to **Mode 3: Cautionary summaries** -- only uncertaint
 
 Gate C is deliberately **re-evaluated twice** per query: once against the base context, and again after the AI Insights block (anomaly/failure-prediction signals, see below) is appended -- since that append can push the context past the size threshold or otherwise disturb readiness. If the post-insight check fails, the trust mode is downgraded to Mode 3 even if the first pass was fully actionable.
 
+### Gate D -- Permissions and Capabilities
+
+Implemented in `ai/gates/gate_d.py`. Validates that a device's requested permissions are bounded by its capabilities, so the AI never recommends an action the device is not permitted or able to perform:
+
+| Check | What it verifies |
+|---|---|
+| `D.capabilities_defined` | The device has a defined capability set. |
+| `D.permissions_defined` | The device has a defined permission set. |
+| `D.permissions_within_capabilities` | Every requested permission is a subset of the device's capabilities. |
+
+Failing Gate D falls back to **Mode 4: Permission Gap** (trust ceiling `0.75`) -- the AI cannot safely recommend device actions when permissions and capabilities are inconsistent or undefined. Gate D only applies when a specific device is the subject of the query; it passes trivially when no device is identified.
+
+### Gate E -- Lifecycle Integrity
+
+Implemented in `ai/gates/gate_e.py`. Confirms the device is in a valid, healthy, manageable state before the AI can recommend actionable changes:
+
+| Check | What it verifies |
+|---|---|
+| `E.lifecycle_active` | `lifecycle_state == "active"` (suspended/unpaired/archived devices are not actionable). |
+| `E.health_ok` | Device health state is not `error`. |
+| `E.credentials_ok` | At least one active, non-revoked credential exists. |
+
+Failing Gate E falls back to **Mode 5: Lifecycle Halt** (trust ceiling `0.50`) -- the AI may still provide analytic summaries, but it cannot make actionable recommendations for a device that is suspended, in error, or has compromised credentials. This is the gate that prevents the AI from recommending actions on devices hidden by a site archive or device suspension (see the [Site & Device Lifecycle Matrix](site-device-lifecycle-matrix.md)).
+
 ### Grounded LLM Interface
 
 If every gate in the chain passes, the envelope reports the **`grounded`** mode: full, actionable AI inference and recommendations, trust score up to `1.0`.
@@ -77,6 +105,8 @@ If every gate in the chain passes, the envelope reports the **`grounded`** mode:
 | Mode 1: Status-only | `mode_1` | No | `0.0` | Raw status may be reported; no LLM narrative permitted. |
 | Mode 2: Best-effort analytics | `mode_2` | No | `0.5` | LLM analysis permitted but explicitly limited-trust. |
 | Mode 3: Cautionary summaries | `mode_3` | No | `0.75` | Only non-actionable, uncertainty-qualified summaries. |
+| Mode 4: Permission Gap | `mode_4` | No | `0.75` | Permissions/capabilities inconsistent; no device-action recommendations. |
+| Mode 5: Lifecycle Halt | `mode_5` | No | `0.5` | Device not active/healthy/credentialed; no actionable recommendations. |
 | Grounded LLM Interface | `grounded` | Yes | `1.0` | All gates passed -- full grounded inference. |
 
 !!! note "Tunable, not yet calibrated"
@@ -99,9 +129,9 @@ The chat response also surfaces the same anomaly-detection and failure-predictio
     "trust_mode_label": "Grounded LLM Interface",
     "trust_score": 1.0,
     "actionable": true,
-    "passed_gates": ["A", "B", "C", "C"],
+    "passed_gates": ["A", "B", "C", "D", "E", "C"],
     "failed_gate": null,
-    "summary": "Passed all gates (A, B, C, C) \u2014 Grounded LLM Interface",
+    "summary": "Passed all gates (A, B, C, D, E, C) \u2014 Grounded LLM Interface",
     "gates": [
       {
         "gate_id": "A",
@@ -110,7 +140,7 @@ The chat response also surfaces the same anomaly-detection and failure-predictio
         "score": 1.0,
         "checks": [ { "check_id": "A.db_readiness", "passed": true, "message": "...", "evidence": [ /* traceable table/row refs */ ] } ]
       }
-      // ...B, C (pre-insight), C (post-insight)
+      // ...B, C (pre-insight), D, E, C (post-insight)
     ]
   }
 }
@@ -123,7 +153,7 @@ Every check carries `evidence` entries (table, field, record ID, observed value,
 The **System Diagnostics AI** widget (`frontend/src/components/Dashboard/AskAIWidget.jsx`) renders a **trust banner** above every recommendation, so the gate outcome is never hidden behind the answer text:
 
 * A color-coded icon + label for the resulting trust mode (green for `grounded`, amber/orange/red for the degraded modes).
-* De-duplicated gate chips (`A`, `B`, `C`) -- green if that gate passed, red if it's the one that failed.
+* De-duplicated gate chips (`A`, `B`, `C`, `D`, `E`) -- green if that gate passed, red if it's the one that failed.
 * An overall **Trust %** score.
 * A click-to-expand detail view listing every gate's individual check messages (row counts, freshness, completeness, etc.), including both the pre- and post-insight Gate C re-validation.
 
@@ -131,13 +161,13 @@ The **System Diagnostics AI** widget (`frontend/src/components/Dashboard/AskAIWi
 
 ## Extending the chain
 
-New gates can be appended to the envelope without touching Gate A/B/C:
+New gates can be appended to the envelope without touching Gate A/B/C/D/E:
 
 ```python
 from ai.gates.envelope import build_default_envelope
 
 envelope = build_default_envelope()
-envelope.add_gate(MyCybersecurityGate())  # e.g. a future Gate D
+envelope.add_gate(MyCybersecurityGate())  # e.g. a future Gate F
 ```
 
 Each gate defines its own `failure_mode` (a `Mode` instance), so a new gate can introduce its own fallback trust mode independently of the existing ones.

--- a/docs/anomaly-detection.md
+++ b/docs/anomaly-detection.md
@@ -47,34 +47,18 @@ Currently, the system uses a **Rule-Based Heuristic Engine**, not a black-box ma
 There is a distinction in how alerts are displayed across the application:
 
 1.  **Dashboard (Real-Time + Persistent)**:
-    *   Shows anomalies detected **right now** in memory (e.g., a sudden 5-second CPU spike).
+    *   Shows anomalies detected **right now** in memory (e.g., a sudden 5-second CPU spike) via the `ActiveAlertsTicker`.
     *   Shows persistent alerts stored in the database.
     *   *Purpose*: Immediate operational awareness.
 
-2.  **Device Detail Page (Persistent Only)**:
-    *   Under the "Alerts" tab, this view shows **only** alerts that have been formally logged to the database.
-    *   Transient anomalies (like a momentary spike) may appear on the Dashboard but not here unless they persist long enough to be committed to the database.
-    *   *Purpose*: Historical audit trail and case management.
+2.  **Device Detail Page (Merged DB + AI Anomalies)**:
+    *   Under the "Alerts" tab, this view merges formally logged database alerts with the live AI anomaly scan (`GET /api/v1/ai/anomalies`), tagging AI-sourced rows with an **AI Analysis** source badge and de-duplicating against the DB alerts by reason.
+    *   The anomaly list is fetched on load and re-polled every few seconds so it stays live.
+    *   *Purpose*: A single, current view of both committed and detected issues for that device.
 
-## Configuration
-Thresholds are defined in `ai/config.yaml` under the `anomaly_detection` section.
+## Triggering a scan
 
-```yaml
-anomaly_detection:
-  sensitivity: 0.8
-  thresholds:
-    max_latency_ms: 500
-    max_error_rate: 0.05
-    max_flapping_count: 5
-    consecutive_failures: 3
-```
-
-## API Usage & Frequency
-The anomaly detection is **Pull-Based** (On-Demand), meaning the calculation runs whenever the API is called.
-
-*   **Trigger**: The Dashboard automatically calls this API every **30 seconds**.
-*   **Effect**: This provides "Near Real-Time" monitoring for any user viewing the dashboard.
-*   **Endpoint**: `GET /api/v1/ai/anomalies`
+`GET /api/v1/ai/anomalies` is **pull-based**: it runs the rule-based scan on demand across active devices, and the Dashboard calls it on a polling cycle for near-real-time visibility. Note that calling it also syncs each device's `online`/`offline` status based on consecutive health-check failures.
 
 **Response**:
 ```json
@@ -82,17 +66,40 @@ The anomaly detection is **Pull-Based** (On-Demand), meaning the calculation run
   "count": 1,
   "anomalies": [
     {
-      "device_id": "dev-123",
-      "device_name": "POS Terminal 1",
+      "device_id": "DEVICE-8TKX-MVVG-U4EH",
+      "device_name": "Web Dashboard 1-4",
       "score": 1.0,
+      "reasons": ["High CPU: 92.5%", "High Memory: 88.0%"],
       "severity": "critical",
       "metrics": {
         "flapping_count": 12,
         "consecutive_failures": 5,
-        "cpu_percent": 45.0
+        "cpu_percent": 92.5,
+        "memory_percent": 88.0
       },
-      "timestamp": "2025-12-30T10:00:00Z"
+      "timestamp": "2026-07-17T10:00:00Z"
     }
   ]
 }
 ```
+
+The response is limited to the top 5 anomalies by score.
+
+## Configuration
+Thresholds are defined in `ai/config.yaml` under the `anomaly_detection` section.
+
+```yaml
+anomaly_detection:
+  sensitivity: 0.8
+  window_size: 50
+  thresholds:
+    network_latency_ms: 200          # ms; above this flags "High Latency"
+    cpu_percent: 90.0                # %; above this flags "High CPU"
+    memory_percent: 90.0             # %; above this flags "High Memory"
+    disk_percent: 90.0               # %; above this flags "High Disk Usage"
+    error_rate: 0.05                 # ratio (5%); above this flags "High Error Rate"
+    max_flapping_count: 5            # state changes per hour; above this flags "High Instability"
+    consecutive_failures: 3          # health-check failures in a row; at/above this flags "System Failure"
+```
+
+`sensitivity` scales the final anomaly score (`score * sensitivity`, capped at `1.0`); it changes the reported score but not which thresholds fire. `window_size` is reserved and not currently applied.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,9 +141,11 @@ nav:
       - AI & Cognitive Engine:
           - Roadmap: ai-roadmap.md
           - Implementation: ai-implementation.md
+          - API Reference: ai-api-reference.md
           - Context Builder: ai-context-builder.md
           - Trust & Validation Gates: ai-validation-gates.md
           - Anomaly Detection: anomaly-detection.md
+          - Infrastructure: ai-infrastructure.md
           - Memory Inspection: ai-memory-inspection.md
       - Audit System: audit-compliance.md
       - Background Analytics: backend-analytics.md


### PR DESCRIPTION
Refreshes the AI documentation to match the current implementation, following a code review of the AI feature.

**Changes:**

- **`docs/ai-validation-gates.md`** — Gates D (Permissions & Capabilities) and E (Lifecycle Integrity) are implemented, not "future". Updated the gate-chain diagram, added Gate D/E sections, expanded the trust-modes reference table (mode_4, mode_5), and corrected the "extending the chain" example and the `/query` trust-envelope response example.

- **`docs/ai-implementation.md`** — Now documents the **live** `/api/v1/ai/*` surface (in `AIEndpoint.py`), marks the legacy standalone `ai/api.py` as non-live/not gated, and corrects the endpoint references and "running locally" instructions.

- **`docs/ai-api-reference.md`** — Rewritten from the legacy standalone-service endpoints to the **live** `/api/v1/ai/*` routes, with accurate request/response shapes including the trust envelope; added an explicit note that AI endpoints are not yet authenticated.

- **`docs/anomaly-detection.md`** — Corrected the config keys to the real `ai/config.yaml` values, the anomaly response shape, and the device-page behavior (now merges DB alerts with live AI anomalies).

- **`docs/ai-roadmap.md`** — Validation Gates row updated to A–E.

- **`ai/README.md`** — Replaced the misleading "all 25 database tables" claim with an accurate description and cross-references to the live path.

- **`mkdocs.yml`** — Added the previously orphaned `ai-api-reference.md` and `ai-infrastructure.md` to the AI & Cognitive Engine nav.

Verified with `mkdocs build --strict`.