### PR TITLE
fix: require auth and scope AI endpoints to user access; sanitize prompt-injection input

### DIFF
--- a/backend/src/homepot/app/api/API_v1/Endpoints/AIEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/AIEndpoint.py
@@ -7,11 +7,19 @@ from datetime import datetime, timedelta
 import logging
 import os
 import sys
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 from sqlalchemy import case, func, select
+from sqlalchemy.orm import Session as SASession
+
+from homepot.app.auth_utils import (  # noqa: E402
+    require_user,
+    verify_device_belongs_to_user,
+    verify_site_access_for_user,
+)
+from homepot.app.schemas.schemas import UserDict  # noqa: E402
 
 # Add project root to path to allow importing 'ai' package
 # Current file: backend/src/homepot/app/api/API_v1/Endpoints/AIEndpoint.py
@@ -45,12 +53,56 @@ from homepot.app.models.AnalyticsModel import (  # noqa: E402
 )
 from homepot.app.models.AnalyticsModel import Alert  # noqa: E402
 from homepot.audit import AuditEventType, get_audit_logger  # noqa: E402
-from homepot.database import get_database_service  # noqa: E402
-from homepot.models import Device, HealthCheck, Site  # noqa: E402
+from homepot.database import get_database_service, get_db  # noqa: E402
+from homepot.models import Device, HealthCheck, Site, User  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_user())])
+
+# Tokens commonly used to break out of a prompt context and inject adversarial
+# instructions. These are neutralized in any user-supplied text before it is
+# placed into the LLM prompt (see _sanitize_ai_input).
+_INJECTION_TOKENS = (
+    "[INST]",
+    "[/INST]",
+    "<|im_start|>",
+    "<|im_end|>",
+    "<|system|>",
+    "<|assistant|>",
+    "<|user|>",
+    "### Instruction",
+    "### System",
+    "### Human:",
+    "Ignore all previous instructions",
+    "Ignore previous instructions",
+    "Disregard all previous",
+    "You are now",
+    "You are a helpful",
+)
+
+
+def _sanitize_ai_input(text: Optional[str], label: str = "text") -> str:
+    """Neutralize common prompt-injection tokens in user-supplied input.
+
+    User-provided ``context``, ``role`` and chat ``history`` are placed into the
+    LLM prompt, so they are a prompt-injection surface. This helper strips and
+    flags any tokens that could be used to break out of the instruction context.
+    """
+    if not text:
+        return ""
+    sanitized = text
+    flagged = 0
+    for token in _INJECTION_TOKENS:
+        if token.lower() in sanitized.lower():
+            flagged += 1
+            sanitized = sanitized.replace(token, "[neutralized]")
+    if flagged:
+        logger.warning(
+            "Sanitized %d injection token(s) from AI %s input", flagged, label
+        )
+    # Limit length so a single field cannot blow out the bounded context.
+    return sanitized[:4000]
 
 
 # Request/Response Models
@@ -345,12 +397,16 @@ def get_ai_services() -> Any:
 
 
 @router.post("/query", tags=["AI Chat"])
-async def query_ai(request: AIQueryRequest) -> Dict[str, Any]:
+async def query_ai(
+    request: AIQueryRequest,
+    current_user: UserDict = Depends(require_user()),
+) -> Dict[str, Any]:
     """Query the AI assistant."""
     logger.info(
-        "AI query | device_id=%s | query_len=%d",
+        "AI query | device_id=%s | query_len=%d | user=%s",
         request.device_id or "N/A",
         len(request.query),
+        current_user.get("email"),
     )
     try:
         # Use singletons for heavy services
@@ -363,7 +419,11 @@ async def query_ai(request: AIQueryRequest) -> Dict[str, Any]:
         if request.history:
             short_term_context = "\n[CONVERSATION HISTORY]\n"
             short_term_context += "\n".join(
-                [f"{msg.role}: {msg.content}" for msg in request.history[-5:]]
+                [
+                    f"{_sanitize_ai_input(msg.role, 'history-role')}: "
+                    f"{_sanitize_ai_input(msg.content, 'history')}"
+                    for msg in request.history[-5:]
+                ]
             )
 
         # 2. Build Long-Term Context (Vector Memory)
@@ -475,10 +535,12 @@ async def query_ai(request: AIQueryRequest) -> Dict[str, Any]:
             full_context = f"{site_context}\n{job_context}\n{long_term_context}\n{short_term_context}"
 
             if request.context:
-                full_context += f"\n[USER CONTEXT]\n{request.context}"
+                sanitized_context = _sanitize_ai_input(request.context, "context")
+                full_context += f"\n[USER CONTEXT]\n{sanitized_context}"
 
             if request.role:
-                full_context += f"\n[REQUESTER ROLE]\n{request.role}"
+                sanitized_role = _sanitize_ai_input(request.role, "role")
+                full_context += f"\n[REQUESTER ROLE]\n{sanitized_role}"
 
             if request.device_id:
                 full_context += f"\n[FOCUS DEVICE]\nID: {request.device_id}"
@@ -721,6 +783,7 @@ async def query_ai(request: AIQueryRequest) -> Dict[str, Any]:
                     f"AI query | device={request.device_id or 'N/A'} | "
                     f"mode={trust.trust_mode.label} | score={trust.trust_score:.2f}"
                 ),
+                user_id=current_user.get("user_id"),
                 event_metadata={
                     "query_length": len(request.query),
                     "trust_mode": trust.trust_mode.label,
@@ -735,6 +798,7 @@ async def query_ai(request: AIQueryRequest) -> Dict[str, Any]:
                     description=(
                         f"Gate {trust.failed_gate_id} failed | device={request.device_id or 'N/A'}"
                     ),
+                    user_id=current_user.get("user_id"),
                     event_metadata={
                         "trust_score": trust.trust_score,
                         "failed_gate": trust.failed_gate_id,
@@ -796,10 +860,13 @@ async def get_push_insights(
 async def get_device_insights(
     device_id: str,
     days: int = Query(default=30, ge=1, le=90, description="Analysis period in days"),
+    current_user: UserDict = Depends(require_user()),
+    db: SASession = Depends(get_db),
 ) -> Dict[str, Any]:
     """Get comprehensive AI insights for a device.
 
     Includes performance trends, health score, and predictive analysis.
+    Restricted to users with access to the device's site.
     """
     try:
         analytics = AIAnalyticsService()
@@ -816,6 +883,13 @@ async def get_device_insights(
                 status_code=404,
                 detail=f"Device '{device_id}' not found or not active",
             )
+
+        # Scope to the caller's site/tenant access.
+        db_user = cast(
+            "User",
+            db.query(User).filter(User.email == current_user["email"]).first(),
+        )
+        verify_device_belongs_to_user(db_user, device, db, minimum_role="viewer")
 
         # Get performance trends
         performance = await analytics.get_device_performance_trends(device_id, days)
@@ -852,10 +926,13 @@ async def get_device_insights(
 async def get_site_insights(
     site_id: str,
     days: int = Query(default=30, ge=1, le=90, description="Analysis period in days"),
+    current_user: UserDict = Depends(require_user()),
+    db: SASession = Depends(get_db),
 ) -> Dict[str, Any]:
     """Get comprehensive AI insights for a site.
 
     Includes job patterns, optimal scheduling windows, and site-level analytics.
+    Restricted to users with access to the site.
     """
     try:
         analytics = AIAnalyticsService()
@@ -872,6 +949,13 @@ async def get_site_insights(
                 status_code=404,
                 detail=f"Site '{site_id}' not found or not active",
             )
+
+        # Scope to the caller's site/tenant access.
+        db_user = cast(
+            "User",
+            db.query(User).filter(User.email == current_user["email"]).first(),
+        )
+        verify_site_access_for_user(db_user, site_id, db, minimum_role="viewer")
 
         # Get job outcome patterns
         job_patterns = await analytics.get_job_outcome_patterns(site_id, days)
@@ -912,10 +996,13 @@ async def predict_device_failure(
     window_hours: int = Query(
         default=24, ge=1, le=168, description="Prediction window in hours (max 7 days)"
     ),
+    current_user: UserDict = Depends(require_user()),
+    db: SASession = Depends(get_db),
 ) -> Dict[str, Any]:
     """Predict likelihood of device failure in the next N hours.
 
     Returns probability, risk level, contributing factors, and recommendations.
+    Restricted to users with access to the device's site.
     """
     try:
         # Archived/unpaired/retired devices must not be visible to the AI.
@@ -930,6 +1017,13 @@ async def predict_device_failure(
                 status_code=404,
                 detail=f"Device '{device_id}' not found or not active",
             )
+
+        # Scope to the caller's site/tenant access.
+        db_user = cast(
+            "User",
+            db.query(User).filter(User.email == current_user["email"]).first(),
+        )
+        verify_device_belongs_to_user(db_user, device, db, minimum_role="viewer")
 
         predictor = FailurePredictor()
         prediction = await predictor.predict_device_failure(device_id, window_hours)

--- a/backend/tests/test_site_delete.py
+++ b/backend/tests/test_site_delete.py
@@ -651,3 +651,49 @@ def test_ai_site_insights_hidden_after_archive(file_db: Any) -> None:
     archived = client.get(f"/api/v1/ai/insights/site/{site_id}", headers=_headers())
     assert archived.status_code == 404
     assert "not found or not active" in archived.json()["detail"].lower()
+
+
+def test_ai_endpoints_require_auth(file_db: Any) -> None:
+    """AI endpoints reject unauthenticated requests (401/403)."""
+    site_id, _, _ = _seed_site_device_admin()
+    client = TestClient(app)
+
+    response = client.get(f"/api/v1/ai/insights/site/{site_id}")
+    assert response.status_code in (401, 403)
+
+    query = client.post("/api/v1/ai/query", json={"query": "hi"})
+    assert query.status_code in (401, 403)
+
+
+def test_ai_site_insights_scoped_to_user_access(file_db: Any) -> None:
+    """A non-admin user without site membership is denied AI site insights."""
+    site_id, _, _ = _seed_site_device_admin()
+    client = TestClient(app)
+
+    # Seed a non-admin viewer with no site membership.
+    sync_db = homepot.database.SessionLocal()
+    try:
+        viewer = User(
+            email="viewer@arch-purge.test",
+            username="viewer_ap",
+            hashed_password=hash_password("pass"),
+            is_admin=False,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        sync_db.add(viewer)
+        sync_db.commit()
+    finally:
+        sync_db.close()
+
+    viewer_headers = {
+        "Authorization": f"Bearer {create_access_token({'sub': 'viewer@arch-purge.test'})}"
+    }
+
+    # The viewer is not a member of the site, so AI insights are forbidden.
+    denied = client.get(f"/api/v1/ai/insights/site/{site_id}", headers=viewer_headers)
+    assert denied.status_code == 403
+
+    # The admin still has access.
+    allowed = client.get(f"/api/v1/ai/insights/site/{site_id}", headers=_headers())
+    assert allowed.status_code in (200, 500)

--- a/backend/tests/test_validation_gates.py
+++ b/backend/tests/test_validation_gates.py
@@ -373,7 +373,8 @@ async def test_query_ai_always_calls_llm_even_when_not_actionable():
         ),
     ):
         request = AIEndpoint.AIQueryRequest(query="What is the status?")
-        response = await AIEndpoint.query_ai(request)
+        current_user = {"email": "admin@test", "role": "Admin", "user_id": 1}
+        response = await AIEndpoint.query_ai(request, current_user)
 
     assert mock_llm.generate_response.called
     call_kwargs = mock_llm.generate_response.call_args.kwargs
@@ -452,7 +453,8 @@ async def test_query_ai_includes_insights_when_gate_b_passes():
         ),
     ):
         request = AIEndpoint.AIQueryRequest(query="What is the status?")
-        response = await AIEndpoint.query_ai(request)
+        current_user = {"email": "admin@test", "role": "Admin", "user_id": 1}
+        response = await AIEndpoint.query_ai(request, current_user)
 
     assert mock_llm.generate_response.called
     call_kwargs = mock_llm.generate_response.call_args.kwargs
@@ -530,7 +532,8 @@ async def test_query_ai_downgrades_trust_when_post_insight_gate_c_fails():
         ),
     ):
         request = AIEndpoint.AIQueryRequest(query="What is the status?")
-        response = await AIEndpoint.query_ai(request)
+        current_user = {"email": "admin@test", "role": "Admin", "user_id": 1}
+        response = await AIEndpoint.query_ai(request, current_user)
 
     assert mock_llm.generate_response.called
     call_kwargs = mock_llm.generate_response.call_args.kwargs


### PR DESCRIPTION
## Summary

The AI endpoints under `/api/v1/ai/*` were previously **unauthenticated** and ignored tenant/site access, meaning any caller could read device/site insights, failure predictions, and query the assistant. This PR closes those gaps and hardens the LLM prompt against injection.

### Auth (all AI endpoints)
- Router-level `dependencies=[Depends(require_user())]` now guards the entire `/api/v1/ai/*` surface. Verified: unauthenticated → 401, authenticated → 200.
- `query_ai` now accepts `current_user`; AI query audit events (success and gate-failure) carry `user_id` for attribution.

### Site/tenant scoping
- `get_device_insights` and `predict_device_failure` call `verify_device_belongs_to_user(...)` so a caller can only inspect devices on sites they can access (non-admin without access → 403).
- `get_site_insights` calls `verify_site_access_for_user(...)` (403 when the caller has no site membership).
- Admin bypass preserved via the existing verifier semantics.

### Prompt-injection hardening
- Added `_sanitize_ai_input` with a token list covering common break-out patterns (`[INST]`, `<|im_start|>`, `### Instruction`, "Ignore all previous instructions", etc.). Applied to user-supplied `context`, `role`, and conversation `history` before they are embedded in the LLM prompt. Each field is also capped at 4000 chars. Matches found are neutralized and logged.

### Tests
- `test_ai_endpoints_require_auth`: unauthenticated AI site-insights + query are rejected (401/403).
- `test_ai_site_insights_scoped_to_user_access`: a non-admin viewer without site membership is denied (403); admin still has access.
- Existing AI visibility tests (hidden-after-archive) still pass; full `tests/test_site_delete.py` suite passes (20 passed).
