### PR TITLE
ci: use preinstalled PostgreSQL on ubuntu-latest to avoid flaky apt hang

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -115,13 +115,16 @@ jobs:
         if [[ "${{ matrix.os }}" == "windows-latest" ]]; then EXTRAS="[agent]"; fi
         pip install ${PREFER_BINARY} -e "backend${EXTRAS}"
 
-    - name: Install PostgreSQL 16 (Ubuntu only)
+    - name: Start PostgreSQL (Ubuntu only, preinstalled on ubuntu-latest)
       if: matrix.os == 'ubuntu-latest'
+      timeout-minutes: 5
       run: |
         set -e
-        sudo apt-get update
-        sudo apt-get install -y postgresql-16 postgresql-client-16
-        sudo systemctl start postgresql
+        # ubuntu-latest (Ubuntu 24.04) ships PostgreSQL 16 preinstalled but
+        # disabled. Starting it avoids a redundant (and flaky) apt-get update,
+        # which has repeatedly hung the test job for 15+ minutes.
+        sudo systemctl start postgresql.service
+        pg_isready -q -h localhost -p 5432 -t 30
 
     - name: Create CI test role and database
       if: matrix.os == 'ubuntu-latest'
@@ -133,6 +136,7 @@ jobs:
     - name: Install TimescaleDB extension (Ubuntu only, best-effort)
       if: matrix.os == 'ubuntu-latest'
       continue-on-error: true
+      timeout-minutes: 5
       run: |
         curl -s https://packagecloud.io/install/repositories/timescale/timescaledb/script.deb.sh | sudo bash
         sudo apt-get install -y timescaledb-2-postgresql-16


### PR DESCRIPTION
## Problem

The `Test Suite (ubuntu-latest, 3.11)` job frequently hangs 15-25+ minutes on the `Install PostgreSQL 16 (Ubuntu only)` step, wasting CI time and producing false-positive failures that are unrelated to the PR's code.

## Root cause

`ubuntu-latest` has moved to Ubuntu 24.04, whose runner image **already ships PostgreSQL 16.14 preinstalled** (service simply disabled by default). The workflow still ran:

```yaml
sudo apt-get update
sudo apt-get install -y postgresql-16 postgresql-client-16
sudo systemctl start postgresql
```

The redundant `apt-get update` is what hangs (the 24.04 image has a very long apt sources list). A previous successful run completed this step in 10s; the flake is intermittent.

## Fix

- Replace the apt install with `sudo systemctl start postgresql.service` + a `pg_isready` wait — no apt involved, no hang.
- Add `timeout-minutes: 5` to that step and to the best-effort TimescaleDB step so neither can stall the job indefinitely.
- No test changes; behavior is identical (same PG16, same test DB).