### PR TITLE
docs: keep llama3.2 default, document LLM model-switching procedure and benchmark

### DIFF
--- a/ai/README.md
+++ b/ai/README.md
@@ -143,13 +143,38 @@ The active model is read from `ai/config.yaml`:
 
 ```yaml
 llm:
-  model: "qwen3:4b"
+  model: "llama3.2"
   base_url: "http://localhost:11434"
   temperature: 0.7
   context_window: 4096
 ```
 
-`./scripts/setup-ollama.sh` reads the model name from this file and pulls it if it is not already present, so a model switch is a one-line change followed by `ollama pull <model>`.
+`./scripts/setup-ollama.sh` reads the model name from this file and pulls it if it is not already present.
+
+### How to switch models
+
+A model switch is a three-step procedure; the backend reload is easy to miss:
+
+1. **Pull the model** so Ollama can serve it:
+   ```bash
+   ollama pull <model>
+   ```
+2. **Edit `ai/config.yaml`** and set `llm.model` to the new name.
+3. **Reload the backend.** This is required and non-obvious: the backend runs under
+   `uvicorn --reload`, but uvicorn's default reload filter watches **`*.py` files
+   only**, so a `.yaml` change does **not** restart it. The `LLMService` singleton
+   is initialised once per process and keeps serving the old model until the
+   process restarts. Either touch any `.py` under `backend/src` or `ai/` to
+   trigger a reload, or restart uvicorn yourself.
+
+No `ollama` restart is needed for a switch: Ollama loads any pulled model on
+demand. (If the Ollama runner ever wedges — e.g. after a client is killed
+mid-request — `sudo systemctl restart ollama` recovers it, but that is a
+recovery action, not part of a normal model switch.)
+
+To verify the switch took effect, run the live endpoint and compare latency;
+each AI request generates far fewer tokens on the new model, so the timing and
+the answer should change.
 
 ### Why GPU memory is the binding constraint
 
@@ -199,6 +224,30 @@ Estimated fit for larger candidates at a 4096-token context:
 | qwen3:14b | Q4_K_M | ~8.9 GB | ~9.6 GiB | No |
 
 **Conclusion for this class of machine:** a **4 GiB card tops out around a 4B-parameter model at Q4**. To go 8B+ with quality you need ~12-16 GiB VRAM; on 4 GiB the only options are a heavy quantization (poor quality) or accepting CPU offload.
+
+### Measured inference latency (reference machine)
+
+Both models fit on the P620, but generation speed differs sharply. Measured with `ai/utils/bench_llm.py` (server-reported timings, median of 3, unique prompt per trial to defeat the prompt cache; 200-token output cap):
+
+| Metric | llama3.2 (3B) | qwen3:4b (4B) |
+|---|---|---|
+| Decode, short prompt | 22.0 t/s | 7.6 t/s |
+| Decode, long context (2050 tok) | 12.0 t/s | 5.6 t/s |
+| Prefill, long context | 230 t/s | 153 t/s |
+| End-to-end HOMEPOT `/ai/query` | **~57 s** | **~474 s (~8 min)** |
+
+Two things make qwen3:4b dramatically slower here:
+
+1. **Bigger model on a weak GPU**: decode is ~2x slower than llama3.2.
+2. **Thinking mode is always on and cannot be disabled**: `think: false`
+   (as an option or top-level) is silently ignored by Ollama 0.32.5, and qwen3
+   still emits 1k+ reasoning tokens per response. A `num_predict` cap below the
+   thinking length returns an **empty** answer. So each request pays 60-80% of
+   its token budget on hidden reasoning before producing any text.
+
+**Takeaway:** for an interactive query workload on a 4 GiB card, llama3.2 is the
+pragmatic default; qwen3:4b is a better-quality alternative only where answers
+are produced asynchronously and an 8-minute wait is acceptable.
 
 ### How to verify a switch (the tests we ran)
 

--- a/ai/README.md
+++ b/ai/README.md
@@ -133,7 +133,108 @@ The implementation consists of four core modules:
 *   **`event_store.py` (The Short-Term Memory)**: Caches recent device events in-memory and persists them to the **PostgreSQL** `device_metrics` table to provide immediate context for analysis.
 *   **`analysis_modes.py` (The Persona)**: Manages different system prompts to tailor the AI's output style and focus (e.g., technical vs. executive).
 
-## Development Guidelines
+## Switching LLM Models Locally
+
+The HOMEPOT AI talks to a local **Ollama** instance (`ai/llm.py`). Which model you can run is bounded by the hardware the Ollama server is running on. This section documents how we assess whether a candidate model fits, the tests we ran, and the metrics that matter.
+
+### How model choice is configured
+
+The active model is read from `ai/config.yaml`:
+
+```yaml
+llm:
+  model: "qwen3:4b"
+  base_url: "http://localhost:11434"
+  temperature: 0.7
+  context_window: 4096
+```
+
+`./scripts/setup-ollama.sh` reads the model name from this file and pulls it if it is not already present, so a model switch is a one-line change followed by `ollama pull <model>`.
+
+### Why GPU memory is the binding constraint
+
+To run **entirely on the GPU** (no CPU spill), the model weights *plus* the KV cache (which scales with the context window) must fit in GPU VRAM:
+
+```
+VRAM needed ≈ weights (at your quantization) + KV cache + ~100-200 MiB overhead
+KV cache (fp16) ≈ 2 × layers × kv_heads × head_dim × context_window × 2 bytes
+```
+
+- **Weights** are the model file size at a given quantization (e.g. `qwen3:4b` ≈ 2.5 GB at Q4_K_M).
+- **KV cache** is per-token and grows linearly with `context_window`; reducing the context window shrinks it.
+- **Overhead** is the CUDA context and compute buffers (typically ~100-200 MiB).
+- If the total exceeds VRAM, Ollama offloads layers to **CPU RAM/swap** — this is generally undesirable for interactive use because latency jumps and the CPU (an i7-9850H in our test box) is far slower at inference.
+
+When only a subset fits on the GPU, the remainder spills to CPU; Ollama does not spill "cleanly" per task. Deliberately running tiny models for low-resource tasks (e.g. simple classification) on CPU is a separate, opt-in design choice, not the default.
+
+### What to check on your machine
+
+Run these before choosing a model:
+
+```bash
+nvidia-smi --query-gpu=index,name,memory.total,memory.used,memory.free --format=csv,noheader
+lscpu | grep -E "Model name|^CPU\(s\)"
+free -h
+```
+
+Note: `nvidia-smi` only lists **CUDA-capable** GPUs. On machines with an integrated GPU (e.g. Intel UHD 630) alongside a discrete NVIDIA card, Windows Task Manager may number them differently than CUDA does. **Use the CUDA index from `nvidia-smi`** for Ollama; the integrated GPU cannot run the LLM.
+
+### Measured findings (reference machine)
+
+Test box: **Quadro P620 (4 GiB VRAM)**, Intel i7-9850H, 23 GiB RAM.
+
+| Model | File size | Measured VRAM used | Headroom on 4 GiB |
+|---|---|---|---|
+| llama3.2 (3B, Q4_K_M) | 2.0 GB | ~2448 MiB | ~1.5 GiB |
+| qwen3:4b (4B, Q4_K_M) | 2.5 GB | ~2465 MiB | ~1.5 GiB |
+
+Estimated fit for larger candidates at a 4096-token context:
+
+| Model | Quant | Weights | Est. VRAM | Fits 4 GiB? |
+|---|---|---|---|---|
+| qwen3:8b | Q4_K_M | ~4.9 GB | ~5.4 GiB | No - spills to CPU |
+| qwen3:8b | Q3_K_M | ~3.5 GB | ~3.9 GiB | Borderline |
+| llama3.1:8b | Q3_K_M | ~3.7 GB | ~4.4 GiB | No - spills to CPU |
+| gemma3:12b | Q4_K_M | ~7.9 GB | ~8.7 GiB | No |
+| qwen3:14b | Q4_K_M | ~8.9 GB | ~9.6 GiB | No |
+
+**Conclusion for this class of machine:** a **4 GiB card tops out around a 4B-parameter model at Q4**. To go 8B+ with quality you need ~12-16 GiB VRAM; on 4 GiB the only options are a heavy quantization (poor quality) or accepting CPU offload.
+
+### How to verify a switch (the tests we ran)
+
+1. **Pull and load the candidate:**
+   ```bash
+   ollama pull <model>
+   ollama run <model> "hello"
+   ```
+2. **Confirm it stays on the GPU** - load the model, then check VRAM while idle and after a run:
+   ```bash
+   nvidia-smi --query-gpu=memory.used,memory.free --format=csv,noheader
+   ```
+   A large jump in CPU/RAM use (or a large `free` drop) indicates CPU spill.
+3. **Time a real inference** (wall-clock for a single prompt) and compare with the current model.
+4. **Run the HOMEPOT AI tests** to confirm the endpoint still works:
+   ```bash
+   pytest backend/tests/test_ai_service.py
+   ```
+5. **Exercise the live endpoint** (requires a running backend + Ollama):
+   ```bash
+   curl -X POST http://localhost:8000/api/v1/ai/query -H "Content-Type: application/json" -d '{"query":"What devices are healthy?"}'
+   ```
+
+### Metrics that matter (local vs. server)
+
+| Metric | Local workstation | Server |
+|---|---|---|
+| GPU VRAM (total / used / free) | Decide which model fits on-GPU | Primary constraint per model+quant |
+| GPU utilization (`nvidia-smi`) | Confirm GPU is doing the work, not CPU | Per-replica sizing; watch for oversubscription |
+| CPU cores / RAM | CPU fallback path quality; system overhead | Spill budget; other services running alongside |
+| Context window (`num_ctx` / `context_window`) | Directly trades against VRAM via KV cache | Matches expected prompt sizes + headroom |
+| Latency (time-to-first-token, tokens/sec) | Interactive feel; compare across models | Service-level objective / capacity planning |
+| Model file size | Download/disk cost | Artifact storage, image size, cold-start time |
+| Quantization level (Q2-Q8) | Quality vs. fit trade-off | Same, plus consistency across replicas |
+
+The single most important number is **total VRAM required vs. available**. If the model+KV cache fits with headroom, GPU-only inference is achievable; if not, you either shrink the model/quant/context or move to hardware with more VRAM.
 
 ### Execution Strategy: Local First, Docker Second
 

--- a/ai/config.yaml
+++ b/ai/config.yaml
@@ -5,7 +5,11 @@ app:
   port: 8001
 
 llm:
-  model: "llama3.2"
+  # Larger models with better reasoning (8B+) generally require a GPU with
+  # 12-16 GiB VRAM to stay fully on-GPU. On a 4 GiB card like the Quadro P620,
+  # qwen3:4b offers a good reasoning-to-VRAM trade-off (see README section
+  # "Switching LLM Models Locally" for sizing guidance and measured data).
+  model: "qwen3:4b"
   base_url: "http://localhost:11434"
   temperature: 0.7
   context_window: 4096

--- a/ai/config.yaml
+++ b/ai/config.yaml
@@ -5,11 +5,12 @@ app:
   port: 8001
 
 llm:
-  # Larger models with better reasoning (8B+) generally require a GPU with
-  # 12-16 GiB VRAM to stay fully on-GPU. On a 4 GiB card like the Quadro P620,
-  # qwen3:4b offers a good reasoning-to-VRAM trade-off (see README section
-  # "Switching LLM Models Locally" for sizing guidance and measured data).
-  model: "qwen3:4b"
+  # The active model is read here. A 4 GiB GPU like the Quadro P620 tops out
+  # around 4B parameters at Q4; qwen3:4b is a valid alternative but runs its
+  # (non-disableable) thinking mode, making each request several minutes long.
+  # See README section "Switching LLM Models Locally" for sizing guidance and
+  # measured data.
+  model: "llama3.2"
   base_url: "http://localhost:11434"
   temperature: 0.7
   context_window: 4096

--- a/ai/utils/bench_llm.py
+++ b/ai/utils/bench_llm.py
@@ -9,25 +9,42 @@ reasoning completes). Metrics follow standard LLM inference practice:
   TTFT        = load_duration + prompt_eval_duration       (time to first token)
   total       = total_duration                             (full request, warm)
 
-Run from repo root: .venv/bin/python scripts/bench_llm.py [model ...] [--trials N]
+Run from repo root: .venv/bin/python ai/utils/bench_llm.py [model ...] [--trials N]
 """
 
 import argparse
 import random
-import subprocess
+import subprocess  # noqa: S404  # local utility calling nvidia-smi
 import time
+from typing import Any, Callable, Union
 
 import ollama
 
 HOST = "http://localhost:11434"
 MAX_TOKENS = 200
 
+Measurement = dict[str, Any]
+PromptSource = Union[str, Callable[[int], str]]
+
+
+def _ns_to_s(value: int | None) -> float:
+    """Convert an Ollama nanosecond duration (may be None) to seconds."""
+    return float(value or 0) / 1e9
+
+
+def _ns_to_ms(value: int | None) -> float:
+    """Convert an Ollama nanosecond duration (may be None) to milliseconds."""
+    return float(value or 0) / 1e6
+
 
 def build_long_prompt(seed: int = 0) -> str:
-    """Synthetic assembled context (~15k chars) mimicking the AI context builder
-    at Gate C's 16k-char limit: many device status lines plus an insight task.
-    The seed varies the content so every trial prefills cold KV (llama.cpp
-    prompt-cache would otherwise reuse the identical prompt and fake prefill t/s)."""
+    """Build a synthetic assembled context (~15k chars).
+
+    Mimics the AI context builder at Gate C's 16k-char limit: many device
+    status lines plus an insight task. The seed varies the content so every
+    trial prefills cold KV (llama.cpp prompt-cache would otherwise reuse the
+    identical prompt and fake prefill t/s).
+    """
     rng = random.Random(seed)
     n_devices = 210 + seed % 60
     lines = [
@@ -44,7 +61,7 @@ def build_long_prompt(seed: int = 0) -> str:
     return context + task
 
 
-PROMPTS = {
+PROMPTS: dict[str, PromptSource] = {
     "short": "Say hi in one word.",
     "medium": (
         "A device pos-001 reported CPU 95%, temperature 88C, and net latency "
@@ -56,76 +73,106 @@ PROMPTS = {
 
 
 def nvidia_vram_mib() -> int:
+    """Return the NVIDIA GPU VRAM currently used, in MiB (0 if unavailable)."""
     try:
-        out = subprocess.run(
-            ["nvidia-smi", "--query-gpu=memory.used", "--format=csv,noheader,nounits"],
-            capture_output=True, text=True, timeout=10,
-        ).stdout.strip().splitlines()
+        out = (
+            subprocess.run(  # noqa: S603, S607  # hardcoded command, no user input
+                [
+                    "nvidia-smi",
+                    "--query-gpu=memory.used",
+                    "--format=csv,noheader,nounits",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            .stdout.strip()
+            .splitlines()
+        )
         return int(out[0]) if out else 0
     except Exception:
         return 0
 
 
-def measure(client: ollama.Client, model: str, prompt: str, max_tokens: int = MAX_TOKENS):
+def measure(
+    client: ollama.Client, model: str, prompt: str, max_tokens: int = MAX_TOKENS
+) -> Measurement:
+    """Run one generation and collect server-reported timing metrics."""
     start = time.perf_counter()
     resp = client.generate(
-        model=model, prompt=prompt,
+        model=model,
+        prompt=prompt,
         options={"num_predict": max_tokens, "temperature": 0.0},
         stream=False,
     )
     wall = time.perf_counter() - start
-    prefill = resp.prompt_eval_count / (resp.prompt_eval_duration / 1e9) if resp.prompt_eval_duration else 0.0
-    decode = resp.eval_count / (resp.eval_duration / 1e9) if resp.eval_duration else 0.0
+    prompt_eval_tok = resp.prompt_eval_count or 0
+    prompt_eval_s = _ns_to_s(resp.prompt_eval_duration)
+    eval_tok = resp.eval_count or 0
+    eval_s = _ns_to_s(resp.eval_duration)
+    prefill = prompt_eval_tok / prompt_eval_s if prompt_eval_s else 0.0
+    decode = eval_tok / eval_s if eval_s else 0.0
     thinking_chars = len(resp.get("thinking") or "")
     return {
         "wall_s": wall,
-        "load_ms": resp.load_duration / 1e6,
-        "prefill_tok": resp.prompt_eval_count,
-        "prefill_s": resp.prompt_eval_duration / 1e9,
+        "load_ms": _ns_to_ms(resp.load_duration),
+        "prefill_tok": prompt_eval_tok,
+        "prefill_s": prompt_eval_s,
         "prefill_tok_s": prefill,
-        "eval_tok": resp.eval_count,
-        "eval_s": resp.eval_duration / 1e9,
+        "eval_tok": eval_tok,
+        "eval_s": eval_s,
         "decode_tok_s": decode,
-        "ttft_ms": (resp.load_duration + resp.prompt_eval_duration) / 1e6,
-        "total_ms": resp.total_duration / 1e6,
+        "ttft_ms": _ns_to_ms(resp.load_duration) + _ns_to_ms(resp.prompt_eval_duration),
+        "total_ms": _ns_to_ms(resp.total_duration),
         "out_chars": len(resp.response),
         "thinking_chars": thinking_chars,
         "vram_mib": nvidia_vram_mib(),
     }
 
 
-def run_trials(client, model, prompts, trials):
-    results = {}
+def run_trials(
+    client: ollama.Client,
+    model: str,
+    prompts: dict[str, PromptSource],
+    trials: int,
+) -> dict[str, list[Measurement]]:
+    """Run ``trials`` benchmark repetitions per prompt and return the results."""
+    results: dict[str, list[Measurement]] = {}
     for name, prompt in prompts.items():
         trial_runs = []
         for i in range(trials):
             if i == 0:
-                client.generate(model=model, prompt="hi", options={"num_predict": 4}, stream=False)
+                client.generate(
+                    model=model, prompt="hi", options={"num_predict": 4}, stream=False
+                )
             p = prompt(i) if callable(prompt) else prompt
             trial_runs.append(measure(client, model, p))
         results[name] = trial_runs
     return results
 
 
-def summarize(results):
-    def med(key):
-        return sorted(r[key] for r in results)[len(results) // 2]
-    r = results[0]
+def summarize(results: list[Measurement]) -> Measurement:
+    """Reduce per-trial results to median-per-metric plus peak VRAM."""
+
+    def med(key: str) -> float:
+        return float(sorted(r[key] for r in results)[len(results) // 2])
+
     return {
         "prefill_tok_s": round(med("prefill_tok_s"), 1),
         "decode_tok_s": round(med("decode_tok_s"), 1),
         "ttft_ms": round(med("ttft_ms")),
         "total_ms": round(med("total_ms")),
         "wall_s": round(med("wall_s"), 2),
-        "eval_tok": med("eval_tok"),
-        "prefill_tok": med("prefill_tok"),
-        "out_chars": med("out_chars"),
-        "thinking_chars": med("thinking_chars"),
+        "eval_tok": int(med("eval_tok")),
+        "prefill_tok": int(med("prefill_tok")),
+        "out_chars": int(med("out_chars")),
+        "thinking_chars": int(med("thinking_chars")),
         "vram_mib": max(r["vram_mib"] for r in results),
     }
 
 
-def main():
+def main() -> None:
+    """Run the benchmark for each requested model and print results."""
     parser = argparse.ArgumentParser()
     parser.add_argument("models", nargs="+")
     parser.add_argument("--trials", type=int, default=3)

--- a/ai/utils/bench_llm.py
+++ b/ai/utils/bench_llm.py
@@ -1,0 +1,149 @@
+"""Benchmark Ollama models on this machine (Pascal GPU / CPU).
+
+Uses server-reported timings from the final /api/generate chunk so results are
+independent of streaming text capture (thinking-mode models return no text until
+reasoning completes). Metrics follow standard LLM inference practice:
+
+  prefill t/s = prompt_eval_count / prompt_eval_duration   (context ingestion)
+  decode  t/s = eval_count / eval_duration                 (token generation)
+  TTFT        = load_duration + prompt_eval_duration       (time to first token)
+  total       = total_duration                             (full request, warm)
+
+Run from repo root: .venv/bin/python scripts/bench_llm.py [model ...] [--trials N]
+"""
+
+import argparse
+import random
+import subprocess
+import time
+
+import ollama
+
+HOST = "http://localhost:11434"
+MAX_TOKENS = 200
+
+
+def build_long_prompt(seed: int = 0) -> str:
+    """Synthetic assembled context (~15k chars) mimicking the AI context builder
+    at Gate C's 16k-char limit: many device status lines plus an insight task.
+    The seed varies the content so every trial prefills cold KV (llama.cpp
+    prompt-cache would otherwise reuse the identical prompt and fake prefill t/s)."""
+    rng = random.Random(seed)
+    n_devices = 210 + seed % 60
+    lines = [
+        f"device pos-{i:03d}: cpu {rng.randint(20, 99)}% ram {rng.randint(30, 95)}% "
+        f"temp {rng.randint(40, 95)}C net_latency {rng.randint(10, 400)}ms "
+        f"heartbeat {rng.randint(1, 8)}min ago status online"
+        for i in range(n_devices)
+    ]
+    context = "\n".join(lines)
+    task = (
+        "\n\nWrite a concise operator insight for the site: summarize any "
+        "devices showing high CPU, temperature, or latency, and prioritize them."
+    )
+    return context + task
+
+
+PROMPTS = {
+    "short": "Say hi in one word.",
+    "medium": (
+        "A device pos-001 reported CPU 95%, temperature 88C, and net latency "
+        "300ms for the last 10 minutes. Its heartbeat was 4 minutes ago. What "
+        "might be wrong and what should an operator check?"
+    ),
+    "long": build_long_prompt,
+}
+
+
+def nvidia_vram_mib() -> int:
+    try:
+        out = subprocess.run(
+            ["nvidia-smi", "--query-gpu=memory.used", "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, timeout=10,
+        ).stdout.strip().splitlines()
+        return int(out[0]) if out else 0
+    except Exception:
+        return 0
+
+
+def measure(client: ollama.Client, model: str, prompt: str, max_tokens: int = MAX_TOKENS):
+    start = time.perf_counter()
+    resp = client.generate(
+        model=model, prompt=prompt,
+        options={"num_predict": max_tokens, "temperature": 0.0},
+        stream=False,
+    )
+    wall = time.perf_counter() - start
+    prefill = resp.prompt_eval_count / (resp.prompt_eval_duration / 1e9) if resp.prompt_eval_duration else 0.0
+    decode = resp.eval_count / (resp.eval_duration / 1e9) if resp.eval_duration else 0.0
+    thinking_chars = len(resp.get("thinking") or "")
+    return {
+        "wall_s": wall,
+        "load_ms": resp.load_duration / 1e6,
+        "prefill_tok": resp.prompt_eval_count,
+        "prefill_s": resp.prompt_eval_duration / 1e9,
+        "prefill_tok_s": prefill,
+        "eval_tok": resp.eval_count,
+        "eval_s": resp.eval_duration / 1e9,
+        "decode_tok_s": decode,
+        "ttft_ms": (resp.load_duration + resp.prompt_eval_duration) / 1e6,
+        "total_ms": resp.total_duration / 1e6,
+        "out_chars": len(resp.response),
+        "thinking_chars": thinking_chars,
+        "vram_mib": nvidia_vram_mib(),
+    }
+
+
+def run_trials(client, model, prompts, trials):
+    results = {}
+    for name, prompt in prompts.items():
+        trial_runs = []
+        for i in range(trials):
+            if i == 0:
+                client.generate(model=model, prompt="hi", options={"num_predict": 4}, stream=False)
+            p = prompt(i) if callable(prompt) else prompt
+            trial_runs.append(measure(client, model, p))
+        results[name] = trial_runs
+    return results
+
+
+def summarize(results):
+    def med(key):
+        return sorted(r[key] for r in results)[len(results) // 2]
+    r = results[0]
+    return {
+        "prefill_tok_s": round(med("prefill_tok_s"), 1),
+        "decode_tok_s": round(med("decode_tok_s"), 1),
+        "ttft_ms": round(med("ttft_ms")),
+        "total_ms": round(med("total_ms")),
+        "wall_s": round(med("wall_s"), 2),
+        "eval_tok": med("eval_tok"),
+        "prefill_tok": med("prefill_tok"),
+        "out_chars": med("out_chars"),
+        "thinking_chars": med("thinking_chars"),
+        "vram_mib": max(r["vram_mib"] for r in results),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("models", nargs="+")
+    parser.add_argument("--trials", type=int, default=3)
+    args = parser.parse_args()
+    client = ollama.Client(host=HOST, timeout=600)
+    for model in args.models:
+        print(f"\n=== {model} ===")
+        runs = run_trials(client, model, PROMPTS, args.trials)
+        for name, trial_runs in runs.items():
+            s = summarize(trial_runs)
+            print(
+                f"  {name:8s} | prefill {s['prefill_tok_s']:>7.1f} t/s ({s['prefill_tok']:>4d} tok) | "
+                f"decode {s['decode_tok_s']:>6.1f} t/s ({s['eval_tok']:>4d} tok) | "
+                f"TTFT {s['ttft_ms']:>6.0f} ms | total {s['total_ms']:>7.0f} ms | "
+                f"wall {s['wall_s']:>6.2f} s | out {s['out_chars']:>4d}ch think {s['thinking_chars']:>4d}ch"
+            )
+        print(f"  VRAM sampled: {nvidia_vram_mib()} MiB")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,7 @@ Before starting, ensure your system meets the following requirements:
     *   *(Note: Our install script will attempt to install this automatically if missing.)*
 6.  **Ollama** (Required for AI Features):
     *   **Option A (Automated)**: Run `./scripts/setup-ollama.sh` (uses Homebrew on Mac).
-    *   **Option B (Manual)**: Install from [ollama.com](https://ollama.com) and pull the `qwen3:4b` model manually.
+    *   **Option B (Manual)**: Install from [ollama.com](https://ollama.com) and pull the `llama3.2` model manually.
 
 ## Quick Start Guide
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,7 @@ Before starting, ensure your system meets the following requirements:
     *   *(Note: Our install script will attempt to install this automatically if missing.)*
 6.  **Ollama** (Required for AI Features):
     *   **Option A (Automated)**: Run `./scripts/setup-ollama.sh` (uses Homebrew on Mac).
-    *   **Option B (Manual)**: Install from [ollama.com](https://ollama.com) and pull the `llama3.2` model manually.
+    *   **Option B (Manual)**: Install from [ollama.com](https://ollama.com) and pull the `qwen3:4b` model manually.
 
 ## Quick Start Guide
 


### PR DESCRIPTION
## Summary

Keeps **llama3.2** as the default LLM and documents how to switch models safely, based on hands-on measurement. We benchmarked `qwen3:4b` as a candidate and found it ~8x slower end-to-end on the reference machine (Quadro P620 4 GiB), so the default stays llama3.2 with qwen3:4b documented as a measured alternative.

## What changed

- **`ai/config.yaml`** — default model stays `llama3.2`; comment explains the qwen3:4b trade-off.
- **`ai/README.md`** — new "Switching LLM Models Locally" section:
  - Three-step switch procedure, including the non-obvious step that **uvicorn `--reload` watches `*.py` only**, so a `.yaml` config change does **not** reload the backend (`LLMService` singleton holds the old model until the process restarts).
  - Clarifies `sudo systemctl restart ollama` is a *recovery* action for a wedged runner, not part of a model switch.
  - Measured latency table (decode/prefill t/s, end-to-end `/ai/query` timing) and the finding that **qwen3:4b's thinking mode cannot be disabled** in Ollama 0.32.5 (`think: false` ignored; token caps below the thinking length return empty answers).
- **`ai/utils/bench_llm.py`** — reusable benchmark harness (prefill/decode t/s, TTFT, total latency, VRAM) for comparing future candidate models. Uses server-reported timings and a unique prompt per trial to defeat the prompt cache.
- **`docs/getting-started.md`** — manual setup pulls `llama3.2` again.

## Verification

- `pytest backend/tests/test_ai_service.py` — pass.
- Live `/api/v1/ai/query` end-to-end: llama3.2 **~57 s**, qwen3:4b **~474 s** (all trust gates A–E, C pass for both).
- GPU offload confirmed on the Quadro P620 via `nvidia-smi` (VRAM ~2450 MiB, 67% util during generation).