### PR TITLE
fix: response.json() is synchronous in the agent claim path

### DIFF
--- a/backend/src/homepot/agent/real_device_agent.py
+++ b/backend/src/homepot/agent/real_device_agent.py
@@ -762,7 +762,7 @@ async def bootstrap_agent(
     async with httpx.AsyncClient(**build_httpx_proxy_kwargs()) as client:
         response = await client.post(claim_url, json=claim_payload, timeout=30.0)
         response.raise_for_status()
-        result = await response.json()
+        result = response.json()
 
         device_id: str = result["device_id"]
         api_key: str = result["api_key"]

--- a/backend/tests/test_agent_bootstrap.py
+++ b/backend/tests/test_agent_bootstrap.py
@@ -99,7 +99,7 @@ async def test_bootstrap_agent_success(
     }
 
     async def _mock_post(url, **kwargs):
-        mock_resp = AsyncMock()
+        mock_resp = MagicMock()
         mock_resp.raise_for_status = MagicMock()
         if "/enrolment-intents/" in url and "/claim" in url:
             mock_resp.json.return_value = claim_response
@@ -145,7 +145,7 @@ async def test_bootstrap_agent_claim_fails(
     """When the claim endpoint returns an error, bootstrap_agent should raise."""
 
     async def _mock_post(url, **kwargs):
-        mock_resp = AsyncMock()
+        mock_resp = MagicMock()
         mock_resp.raise_for_status = MagicMock(
             side_effect=Exception("401 Unauthorized")
         )
@@ -177,7 +177,7 @@ async def test_bootstrap_agent_passes_expected_identity(
 
     async def _mock_post(url, json=None, **kwargs):
         nonlocal sent_payload
-        mock_resp = AsyncMock()
+        mock_resp = MagicMock()
         mock_resp.raise_for_status = MagicMock()
         if "/claim" in url:
             sent_payload = json or {}
@@ -217,7 +217,7 @@ async def test_bootstrap_agent_auto_detects_os_details(
 
     async def _mock_post(url, json=None, **kwargs):
         nonlocal sent_payload
-        mock_resp = AsyncMock()
+        mock_resp = MagicMock()
         mock_resp.raise_for_status = MagicMock()
         if "/claim" in url:
             sent_payload = json or {}
@@ -263,7 +263,7 @@ async def test_bootstrap_agent_windows_credential_storage(
     }
 
     async def _mock_post(url, **kwargs):
-        mock_resp = AsyncMock()
+        mock_resp = MagicMock()
         mock_resp.raise_for_status = MagicMock()
         mock_resp.json.return_value = claim_response
         return mock_resp

--- a/backend/tests/test_windows_resilience.py
+++ b/backend/tests/test_windows_resilience.py
@@ -358,7 +358,7 @@ async def test_duplicate_enrolment_overwrites(
             "site_id": "site-second",
             "epoch_id": "epoch-002",
         }
-        mock_resp = AsyncMock()
+        mock_resp = MagicMock()
         mock_resp.raise_for_status = MagicMock()
         mock_resp.json.return_value = claim_response
 


### PR DESCRIPTION
When a claim succeeded (HTTP 200), `result = await response.json()` crashed with `TypeError: object dict can't be used in 'await' expression` because httpx `Response.json()` is synchronous. This aborted the real agent bootstrap right after a successful claim, so no device was provisioned.

- Fix `real_device_agent.py` claim path to call `response.json()` without await
- Align test mocks (`test_agent_bootstrap.py`, `test_windows_resilience.py`): `response.json()` is now a synchronous `MagicMock`

Verification: black/isort/flake8/mypy clean; agent + credential + enrolment + windows-resilience tests 147 passed, 7 skipped.