### PR TITLE
fix: Compose Command button navigates to the payload builder

### DIFF
--- a/frontend/src/pages/Device/DeviceDetail.jsx
+++ b/frontend/src/pages/Device/DeviceDetail.jsx
@@ -388,6 +388,12 @@ export default function Device() {
 
       console.log(`Triggering action: ${actionKey} for device ${id}`);
 
+      // Compose Command opens the payload builder — no backend command to queue
+      if (actionKey === 'update_settings') {
+        navigate(`/device/${id}/push-review`);
+        return;
+      }
+
       // Call the Generic API
       await api.devices.triggerAction(id, actionKey);
 
@@ -424,8 +430,6 @@ export default function Device() {
           message: `Status request sent. Job created.`,
           type: 'success',
         });
-      } else if (actionKey === 'update_settings') {
-        navigate(`/device/${id}/push-review`);
       } else {
         setToast({
           message: `Action ${actionKey.replace('_', ' ')} triggered successfully`,


### PR DESCRIPTION
## Summary
Fixes the 'Compose Command' action button, which errored for every device.

## Root cause
`handleActionClick` called `api.devices.triggerAction(id, 'update_settings')` before navigating to the compose page. `update_settings` is not a supported backend command type, so the request returned `422 Unsupported command type` and the error toast blocked navigation.

## Fix
`update_settings` now navigates directly to `/device/:id/push-review` (the payload builder) without queueing a backend command.

## Verified
- Emulator compose flow works end-to-end: queued an `update_pos_payment_config` command with the exact PushReview payload → device completed and applied the settings (volume/brightness/kiosk mode/maintenance window).
- Lint, prettier, and production build pass.