### PR TITLE
feat: surface the full push command lifecycle in the UI

### DIFF
--- a/frontend/src/pages/Device/DeviceDetail.jsx
+++ b/frontend/src/pages/Device/DeviceDetail.jsx
@@ -264,7 +264,7 @@ export default function Device() {
               api.devices.getAuditLogs(id, 10),
               api.devices.getJobs(id, 10),
               api.devices.getErrorLogs(id, 10),
-              api.devices.getHistory(id),
+              api.devices.getCommands(id, 10),
             ]);
 
             setAuditLogs(auditData);

--- a/frontend/src/pages/Device/DeviceHistory.jsx
+++ b/frontend/src/pages/Device/DeviceHistory.jsx
@@ -1,15 +1,14 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
   ArrowLeft,
   Loader2,
   Clock,
   FileJson,
-  CheckCircle,
+  CheckCircle2,
   XCircle,
-  Trash2,
-  Eye,
   RefreshCw,
+  Eye,
   AlertCircle,
 } from 'lucide-react';
 import api from '@/services/api';
@@ -21,9 +20,36 @@ import {
   DialogHeader,
   DialogTitle,
   DialogDescription,
-  DialogFooter,
 } from '@/components/ui/dialog';
 import { Toast } from '@/components/ui/Toast';
+import {
+  lifecycleStages,
+  formatCommandType,
+  resultMessage,
+  getStatusMeta,
+} from '@/utils/commandLifecycle';
+
+function StatusBadge({ status }) {
+  const meta = getStatusMeta(status);
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full border font-medium whitespace-nowrap ${meta.color} ${meta.bg} ${meta.border}`}
+    >
+      {meta.label.toUpperCase()}
+    </span>
+  );
+}
+
+function StageStamp({ label, time }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="text-slate-500 text-[10px]">{label}</span>
+      <span className="font-mono text-[10px] text-slate-300">
+        {time ? new Date(time).toLocaleTimeString() : '—'}
+      </span>
+    </div>
+  );
+}
 
 export default function DeviceHistory() {
   const { id } = useParams();
@@ -31,99 +57,46 @@ export default function DeviceHistory() {
   const [history, setHistory] = useState([]);
   const [loading, setLoading] = useState(true);
   const [device, setDevice] = useState(null);
-  const [selectedTransaction, setSelectedTransaction] = useState(null);
+  const [selectedCommand, setSelectedCommand] = useState(null);
   const [isDetailsModalOpen, setIsDetailsModalOpen] = useState(false);
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const [itemToDelete, setItemToDelete] = useState(null);
   const [toast, setToast] = useState(null);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const [deviceData, historyData] = await Promise.all([
-          api.devices.getDeviceById(id),
-          api.devices.getHistory(id),
-        ]);
-        setDevice(deviceData);
-        setHistory(historyData || []);
-      } catch (err) {
-        console.error('Failed to load history:', err);
-        setToast({
-          title: 'Error',
-          message: 'Failed to load history data',
-          type: 'error',
-        });
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchData();
+  const fetchData = useCallback(async () => {
+    try {
+      const [deviceData, commandData] = await Promise.all([
+        api.devices.getDeviceById(id),
+        api.devices.getCommands(id, 50),
+      ]);
+      setDevice(deviceData);
+      setHistory(commandData || []);
+    } catch (err) {
+      console.error('Failed to load command history:', err);
+      setToast({ title: 'Error', message: 'Failed to load command history', type: 'error' });
+    } finally {
+      setLoading(false);
+    }
   }, [id]);
 
-  const confirmDelete = (item) => {
-    setItemToDelete(item);
-    setIsDeleteModalOpen(true);
-  };
+  useEffect(() => {
+    fetchData();
+    const interval = setInterval(fetchData, 5000);
+    return () => clearInterval(interval);
+  }, [fetchData]);
 
-  const handleDelete = async () => {
-    if (!itemToDelete) return;
-
-    try {
-      await api.devices.deleteHistoryItem(itemToDelete.id);
-      setHistory(history.filter((h) => h.id !== itemToDelete.id));
-      setToast({
-        title: 'Success',
-        message: 'History record deleted',
-        type: 'success',
-      });
-      setIsDeleteModalOpen(false);
-      setItemToDelete(null);
-    } catch (err) {
-      console.error('Failed to delete history item', err);
-      setToast({
-        title: 'Error',
-        message: 'Failed to delete history record',
-        type: 'error',
-      });
-    }
-  };
-
-  const openDetails = (item) => {
-    setSelectedTransaction(item);
+  const openDetails = (cmd) => {
+    setSelectedCommand(cmd);
     setIsDetailsModalOpen(true);
   };
 
-  const handleReuse = (item) => {
-    // 1. Determine the Command Type (Action)
-    // If the history item has a specific 'action' in its details (saved from full payload),
-    // prefer that over the generic 'action_type' column (which is often just 'automated').
-    let commandType = item.action_type || 'CUSTOM';
-    if (item.details && item.details.action) {
-      commandType = item.details.action;
-    } else if (commandType === 'automated' || commandType === 'configuration_update') {
-      // Fallback if specific action is missing but we have generic types
-      commandType = 'CUSTOM';
-    }
-
-    // 2. Extract and Clean Data
-    let reuseData = item.details;
-    if (reuseData && typeof reuseData === 'object' && reuseData.data) {
-      reuseData = { ...reuseData.data }; // Clone to avoid mutating original
-    } else if (reuseData && typeof reuseData === 'object') {
-      reuseData = { ...reuseData };
-    }
-
-    // Remove system-generated metadata fields so they don't clutter the editor
-    if (reuseData) {
-      delete reuseData.timestamp;
-      delete reuseData.command;
-      delete reuseData.message_id;
-    }
-
-    // Navigate to PushReview with initial data
+  const handleReuse = (cmd) => {
+    const data = cmd.payload?.data;
+    if (!data || typeof data !== 'object') return;
+    const reuseData = { ...data };
+    delete reuseData.timestamp;
+    delete reuseData.command;
     navigate(`/device/${id}/push-review`, {
       state: {
-        initialCommand: commandType,
+        initialCommand: cmd.command_type,
         initialData: reuseData,
       },
     });
@@ -156,7 +129,10 @@ export default function DeviceHistory() {
             <div>
               <h1 className="text-xl font-bold tracking-tight text-white">Push History</h1>
               <p className="text-sm text-gray-400">
-                History of push commands for <span className="text-teal-400">{device?.name}</span>
+                Command lifecycle for <span className="text-teal-400">{device?.name}</span>
+                <span className="ml-2 text-[10px] text-slate-500 font-mono">
+                  auto-refreshing every 5s
+                </span>
               </p>
             </div>
             <Button
@@ -172,103 +148,92 @@ export default function DeviceHistory() {
           {history.length === 0 ? (
             <Card className="p-8 text-center bg-[#06181c] border-[#0e2f37] text-gray-400">
               <Clock className="h-12 w-12 mx-auto mb-4 opacity-20" />
-              <p>No push history found for this device.</p>
+              <p>No commands have been sent to this device yet.</p>
             </Card>
           ) : (
-            history.map((item, index) => (
-              <Card
-                key={item.id || index}
-                className="p-3 bg-[#06181c] border-[#0e2f37] hover:border-teal-500/50 transition-colors group"
-              >
-                <div className="flex items-start justify-between gap-4">
-                  <div className="flex items-start gap-3 flex-1 min-w-0 max-w-[60%] overflow-hidden">
-                    <div className="mt-1">
-                      {item.status === 'success' ? (
-                        <CheckCircle className="h-4 w-4 text-green-500" />
-                      ) : item.status === 'failed' ? (
-                        <XCircle className="h-4 w-4 text-red-500" />
-                      ) : (
-                        <Clock className="h-4 w-4 text-yellow-500" />
-                      )}
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 min-w-0">
-                        <h3 className="text-sm font-medium text-white truncate min-w-0">
-                          {item.title || item.action_type || 'Push Command'}
-                        </h3>
-                        {item.config_version && (
-                          <span className="text-[10px] px-1.5 py-0.5 rounded bg-teal-500/10 text-teal-400 border border-teal-500/20 whitespace-nowrap">
-                            v{item.config_version}
-                          </span>
+            history.map((cmd) => {
+              const { meta } = lifecycleStages(cmd);
+              const done =
+                cmd.status === 'completed' || cmd.status === 'failed' || cmd.status === 'expired';
+              const message = resultMessage(cmd.result);
+              return (
+                <Card
+                  key={cmd.command_id}
+                  className="p-3 bg-[#06181c] border-[#0e2f37] hover:border-teal-500/50 transition-colors group"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex items-start gap-3 flex-1 min-w-0">
+                      <div className="mt-1 shrink-0">
+                        {done ? (
+                          cmd.status === 'completed' ? (
+                            <CheckCircle2 className="h-4 w-4 text-green-500" />
+                          ) : (
+                            <XCircle className="h-4 w-4 text-red-500" />
+                          )
+                        ) : cmd.status === 'sent' ? (
+                          <Loader2 className="h-4 w-4 text-blue-400 animate-spin" />
+                        ) : (
+                          <Clock className="h-4 w-4 text-amber-400" />
                         )}
                       </div>
-                      <p className="text-xs text-gray-400 mt-0.5">
-                        {new Date(item.timestamp).toLocaleString()}
-                      </p>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 min-w-0 flex-wrap">
+                          <h3 className="text-sm font-medium text-white truncate min-w-0">
+                            {formatCommandType(cmd.command_type)}
+                          </h3>
+                          <StatusBadge status={cmd.status} />
+                          <span className="font-mono text-[10px] text-slate-500">
+                            {cmd.command_id.substring(0, 8)}
+                          </span>
+                        </div>
 
-                      {/* Preview of details */}
-                      {item.status === 'failed' ? (
-                        <div className="mt-1.5 space-y-1 text-[10px]">
-                          <div className="flex items-start gap-1.5 text-red-400/90">
-                            <AlertCircle className="h-3.5 w-3.5 mt-px shrink-0" />
-                            <span className="font-mono break-words leading-snug">
-                              {item.details?.result?.message || 'Command failed on device'}
-                            </span>
-                          </div>
-                          <div className="pl-5 font-mono text-gray-500 space-y-0.5">
-                            {item.details?.result?.summary && (
-                              <div className="break-words">
-                                summary: {item.details.result.summary}
-                              </div>
-                            )}
-                            {item.details?.action && <div>action: {item.details.action}</div>}
-                            {item.details?.version && <div>version: {item.details.version}</div>}
-                          </div>
+                        <div className="flex items-center gap-3 mt-1.5 flex-wrap">
+                          <StageStamp label="Queued" time={cmd.created_at} />
+                          <StageStamp label="Acknowledged" time={cmd.sent_at} />
+                          <StageStamp label="Executed" time={cmd.executed_at} />
                         </div>
-                      ) : item.details ? (
-                        <div className="mt-1.5 text-[10px] text-gray-500 font-mono truncate max-w-md">
-                          {typeof item.details === 'string'
-                            ? item.details
-                            : JSON.stringify(item.details)}
-                        </div>
-                      ) : null}
+
+                        {message && (
+                          <div className="mt-1.5 text-[11px] font-mono text-slate-400 truncate max-w-lg">
+                            {message}
+                          </div>
+                        )}
+                        {!done && (
+                          <div className="mt-1 text-[10px] text-amber-400/90">
+                            {meta.description}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="flex items-center gap-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+                      {cmd.payload && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => handleReuse(cmd)}
+                          className="h-7 px-2 border-gray-700 bg-transparent text-gray-300 hover:text-white hover:bg-gray-800 text-xs"
+                          title="Reuse Command"
+                        >
+                          <RefreshCw className="h-3 w-3 mr-1" />
+                          Reuse
+                        </Button>
+                      )}
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => openDetails(cmd)}
+                        className="h-7 px-2 border-gray-700 bg-transparent text-gray-300 hover:text-white hover:bg-gray-800 text-xs"
+                        title="View Details"
+                      >
+                        <Eye className="h-3 w-3 mr-1" />
+                        Details
+                      </Button>
                     </div>
                   </div>
-
-                  <div className="flex items-center gap-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => handleReuse(item)}
-                      className="h-7 px-2 border-gray-700 bg-transparent text-gray-300 hover:text-white hover:bg-gray-800 text-xs"
-                      title="Reuse Command"
-                    >
-                      <RefreshCw className="h-3 w-3 mr-1" />
-                      Reuse
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => openDetails(item)}
-                      className="h-7 px-2 border-gray-700 bg-transparent text-gray-300 hover:text-white hover:bg-gray-800 text-xs"
-                      title="View Details"
-                    >
-                      <Eye className="h-3 w-3 mr-1" />
-                      Details
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => confirmDelete(item)}
-                      className="h-7 w-7 p-0 border-red-900/30 bg-transparent text-red-400 hover:text-red-300 hover:bg-red-900/20 hover:border-red-900/50"
-                      title="Delete Record"
-                    >
-                      <Trash2 className="h-3 w-3" />
-                    </Button>
-                  </div>
-                </div>
-              </Card>
-            ))
+                </Card>
+              );
+            })
           )}
         </div>
 
@@ -276,87 +241,86 @@ export default function DeviceHistory() {
         <Dialog open={isDetailsModalOpen} onOpenChange={setIsDetailsModalOpen}>
           <DialogContent className="max-w-2xl bg-card border-gray-800 text-white">
             <DialogHeader>
-              <DialogTitle>Transaction Details</DialogTitle>
+              <DialogTitle>Command Details</DialogTitle>
               <DialogDescription>
-                Raw payload and execution details for this command.
+                Full payload, lifecycle timestamps, and execution result.
               </DialogDescription>
             </DialogHeader>
 
-            {selectedTransaction && (
+            {selectedCommand && (
               <div className="mt-4 space-y-4">
                 <div className="grid grid-cols-2 gap-4 text-sm">
                   <div>
                     <span className="text-gray-500 block">Status</span>
-                    <span
-                      className={
-                        selectedTransaction.status === 'success'
-                          ? 'text-green-400'
-                          : selectedTransaction.status === 'failed'
-                            ? 'text-red-400'
-                            : 'text-yellow-400'
-                      }
-                    >
-                      {selectedTransaction.status?.toUpperCase()}
-                    </span>
-                  </div>
-                  <div>
-                    <span className="text-gray-500 block">Timestamp</span>
-                    <span className="text-gray-300">
-                      {new Date(selectedTransaction.timestamp).toLocaleString()}
-                    </span>
+                    <StatusBadge status={selectedCommand.status} />
                   </div>
                   <div>
                     <span className="text-gray-500 block">Command Type</span>
-                    <span className="text-gray-300">{selectedTransaction.action_type}</span>
+                    <span className="text-gray-300">
+                      {formatCommandType(selectedCommand.command_type)}
+                    </span>
                   </div>
                   <div>
-                    <span className="text-gray-500 block">Version</span>
+                    <span className="text-gray-500 block">Queued</span>
                     <span className="text-gray-300">
-                      {selectedTransaction.config_version || 'N/A'}
+                      {new Date(selectedCommand.created_at).toLocaleString()}
+                    </span>
+                  </div>
+                  <div>
+                    <span className="text-gray-500 block">Acknowledged</span>
+                    <span className="text-gray-300">
+                      {selectedCommand.sent_at
+                        ? new Date(selectedCommand.sent_at).toLocaleString()
+                        : '—'}
+                    </span>
+                  </div>
+                  <div>
+                    <span className="text-gray-500 block">Executed</span>
+                    <span className="text-gray-300">
+                      {selectedCommand.executed_at
+                        ? new Date(selectedCommand.executed_at).toLocaleString()
+                        : '—'}
+                    </span>
+                  </div>
+                  <div>
+                    <span className="text-gray-500 block">Command ID</span>
+                    <span className="text-gray-300 font-mono text-xs">
+                      {selectedCommand.command_id}
                     </span>
                   </div>
                 </div>
 
-                <div>
-                  <span className="text-gray-500 block mb-2 text-sm">Payload / Details</span>
-                  <div className="bg-black/50 rounded-md p-4 overflow-auto max-h-[300px]">
-                    <pre className="text-xs font-mono text-green-400">
-                      {typeof selectedTransaction.details === 'string'
-                        ? selectedTransaction.details
-                        : JSON.stringify(selectedTransaction.details, null, 2)}
-                    </pre>
+                {selectedCommand.payload && (
+                  <div>
+                    <span className="text-gray-500 block mb-2 text-sm">Payload</span>
+                    <div className="bg-black/50 rounded-md p-4 overflow-auto max-h-[200px]">
+                      <pre className="text-xs font-mono text-green-400">
+                        {JSON.stringify(selectedCommand.payload, null, 2)}
+                      </pre>
+                    </div>
                   </div>
-                </div>
+                )}
+
+                {selectedCommand.result && (
+                  <div>
+                    <span className="text-gray-500 block mb-2 text-sm">Result</span>
+                    <div className="bg-black/50 rounded-md p-4 overflow-auto max-h-[200px]">
+                      <pre className="text-xs font-mono text-blue-300">
+                        {JSON.stringify(selectedCommand.result, null, 2)}
+                      </pre>
+                    </div>
+                  </div>
+                )}
+
+                {!selectedCommand.result &&
+                  !['completed', 'failed', 'expired'].includes(selectedCommand.status) && (
+                    <div className="flex items-center gap-2 text-xs text-amber-400">
+                      <AlertCircle className="h-4 w-4 shrink-0" />
+                      {getStatusMeta(selectedCommand.status).description}
+                    </div>
+                  )}
               </div>
             )}
-          </DialogContent>
-        </Dialog>
-
-        {/* Delete Confirmation Modal */}
-        <Dialog open={isDeleteModalOpen} onOpenChange={setIsDeleteModalOpen}>
-          <DialogContent className="max-w-md bg-card border-gray-800 text-white">
-            <DialogHeader>
-              <DialogTitle>Delete History Record</DialogTitle>
-              <DialogDescription>
-                Are you sure you want to delete this history record? This action cannot be undone.
-              </DialogDescription>
-            </DialogHeader>
-            <DialogFooter className="mt-4 flex gap-2">
-              <Button
-                variant="outline"
-                onClick={() => setIsDeleteModalOpen(false)}
-                className="border-gray-700 text-gray-300 hover:bg-gray-800"
-              >
-                Cancel
-              </Button>
-              <Button
-                variant="destructive"
-                onClick={handleDelete}
-                className="bg-red-900/50 hover:bg-red-900 text-red-100 border border-red-900"
-              >
-                Delete Record
-              </Button>
-            </DialogFooter>
           </DialogContent>
         </Dialog>
       </div>

--- a/frontend/src/pages/Device/DeviceWidgets.jsx
+++ b/frontend/src/pages/Device/DeviceWidgets.jsx
@@ -628,6 +628,15 @@ export const CommandHistoryWidget = ({ device, history = [] }) => {
   const navigate = useNavigate();
   const deviceId = device?.device_id;
 
+  const statusMeta = (status) =>
+    ({
+      pending: { label: 'Queued', color: 'text-amber-400' },
+      sent: { label: 'Acknowledged', color: 'text-blue-400' },
+      completed: { label: 'Completed', color: 'text-emerald-400' },
+      failed: { label: 'Failed', color: 'text-red-400' },
+      expired: { label: 'Expired', color: 'text-slate-400' },
+    })[status] || { label: status || 'Unknown', color: 'text-slate-400' };
+
   return (
     <div className="space-y-4">
       <Card>
@@ -653,28 +662,36 @@ export const CommandHistoryWidget = ({ device, history = [] }) => {
             {history.map((item, i) => {
               let StatusIcon = CheckCircle2;
               let statusColor = 'text-emerald-400';
-              if (item.status === 'failed' || item.status === 'error') {
+              if (item.status === 'failed' || item.status === 'expired') {
                 StatusIcon = XCircle;
                 statusColor = 'text-red-400';
               } else if (item.status === 'pending' || item.status === 'sent') {
                 StatusIcon = Loader2;
                 statusColor = 'text-blue-400';
               }
+              const title =
+                item.command_type || item.payload?.title || item.action_type || 'Push Command';
+              const label = statusMeta(item.status).label;
 
               return (
                 <div
-                  key={item.id || i}
+                  key={item.command_id || item.id || i}
                   onClick={() => navigate(`/device/${deviceId}/history`)}
                   className="flex items-center justify-between p-2 rounded bg-[#0b2024]/50 border border-[#1f2735]/50 cursor-pointer hover:bg-[#0b2024]/80 hover:border-teal-500/30 transition-colors"
                 >
                   <div className="flex items-center gap-2 min-w-0">
                     <StatusIcon className={`w-3.5 h-3.5 shrink-0 ${statusColor}`} />
                     <span className="text-slate-200 font-medium truncate">
-                      {item.action_type || item.title || 'Push Command'}
+                      {title.replace(/_/g, ' ')}
+                    </span>
+                    <span
+                      className={`text-[9px] font-mono shrink-0 ${statusMeta(item.status).color}`}
+                    >
+                      {label.toUpperCase()}
                     </span>
                   </div>
                   <span className="text-slate-500 shrink-0 ml-2">
-                    {item.timestamp ? new Date(item.timestamp).toLocaleString() : ''}
+                    {item.created_at ? new Date(item.created_at).toLocaleString() : ''}
                   </span>
                 </div>
               );

--- a/frontend/src/pages/Device/PushReview.jsx
+++ b/frontend/src/pages/Device/PushReview.jsx
@@ -1,15 +1,20 @@
 import { Button } from '@/components/ui/button';
 import { Toast } from '@/components/ui/Toast';
 import api from '@/services/api';
+import { lifecycleStages, formatCommandType } from '@/utils/commandLifecycle';
 // Cleaned up unused imports that were causing blank page errors
 import {
   AlertTriangle,
   ArrowLeft,
+  CheckCircle2,
+  Clock,
   FileJson,
+  Loader2,
   MessageSquare,
   Rocket,
   ShieldAlert,
   Terminal,
+  XCircle,
 } from 'lucide-react';
 import React, { useEffect, useState, useRef } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
@@ -90,6 +95,92 @@ function initialTemplate(action) {
   return ACTION_TO_TEMPLATE[action] || 'APPLY_CONFIG';
 }
 
+function LifecycleTracker({ commandId, commandType, command, onViewHistory }) {
+  const { status, meta, stages, finalStage } = lifecycleStages(command || {});
+  const done = status === 'completed' || status === 'failed' || status === 'expired';
+
+  const node = (label, time, doneState, icon) => (
+    <div className="flex flex-col items-center gap-1">
+      {icon}
+      <span className="text-[10px] text-slate-400 whitespace-nowrap">{label}</span>
+      <span className="text-[9px] font-mono text-slate-500">
+        {time ? new Date(time).toLocaleTimeString() : '—'}
+      </span>
+    </div>
+  );
+
+  const connector = () => <div className="flex-1 h-px bg-slate-700 mx-2 mt-5 min-w-4" />;
+
+  const stageIcons = {
+    queued: done ? (
+      <CheckCircle2 className="h-5 w-5 shrink-0 text-emerald-400" />
+    ) : (
+      <Loader2 className="h-5 w-5 shrink-0 text-amber-400 animate-pulse" />
+    ),
+    acknowledged: done ? (
+      <CheckCircle2 className="h-5 w-5 shrink-0 text-emerald-400" />
+    ) : (
+      <Loader2 className="h-5 w-5 shrink-0 text-amber-400 animate-pulse" />
+    ),
+    executed: done ? (
+      <CheckCircle2 className="h-5 w-5 shrink-0 text-emerald-400" />
+    ) : (
+      <Loader2 className="h-5 w-5 shrink-0 text-amber-400 animate-pulse" />
+    ),
+  };
+
+  const finalIcon = done ? (
+    finalStage.label === 'Failed' || finalStage.label === 'Expired' ? (
+      <XCircle className="h-5 w-5 shrink-0 text-red-400" />
+    ) : (
+      <CheckCircle2 className="h-5 w-5 shrink-0 text-emerald-400" />
+    )
+  ) : (
+    <Loader2 className="h-5 w-5 shrink-0 text-blue-400 animate-spin" />
+  );
+
+  return (
+    <div className="shrink-0 bg-[#06181c] border border-[#0e2f37] rounded-xl p-4 mb-4">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <Clock className="h-4 w-4 text-teal-400" />
+          <span className="text-xs font-medium text-teal-100">
+            Lifecycle — {formatCommandType(commandType)}
+          </span>
+          <span className="font-mono text-[10px] text-slate-500">{commandId.substring(0, 8)}</span>
+        </div>
+        <span
+          className={`text-[10px] px-2 py-0.5 rounded-full border font-medium ${meta.color} ${meta.bg} ${meta.border}`}
+        >
+          {meta.label.toUpperCase()}
+        </span>
+      </div>
+
+      <div className="flex items-start">
+        {stages.map((stage) => (
+          <span key={stage.key} className="flex items-center flex-1">
+            {node(stage.label, stage.time, stage.done, stageIcons[stage.key])}
+            {connector()}
+          </span>
+        ))}
+        <span className="flex items-center flex-1">
+          {node(finalStage.label, finalStage.time, finalStage.done, finalIcon)}
+        </span>
+      </div>
+
+      <div className="flex items-center justify-between mt-3">
+        <p className="text-[10px] text-slate-400">{meta.description}</p>
+        <button
+          onClick={onViewHistory}
+          className="text-[10px] text-teal-400 hover:text-teal-300 font-medium"
+        >
+          View in Push History →
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export default function PushReview() {
   const { id } = useParams();
   const navigate = useNavigate();
@@ -112,6 +203,9 @@ export default function PushReview() {
       : JSON.stringify(COMMAND_TEMPLATES['APPLY_CONFIG'].defaultData, null, 2)
   );
   const [jsonError, setJsonError] = useState(null);
+  const [trackingCommandId, setTrackingCommandId] = useState(null);
+  const [trackingCommandType, setTrackingCommandType] = useState(null);
+  const [trackingData, setTrackingData] = useState(null);
 
   // Ref to track if we are initializing from reuse
   const isReuseInit = useRef(!!location.state?.initialData);
@@ -237,26 +331,62 @@ export default function PushReview() {
       };
 
       const response = await api.devices.triggerAction(id, action, finalPayload);
-      const jobId = response.command_id?.substring(0, 8) || 'queued';
+      const commandId = response.command_id;
+      setTrackingCommandId(commandId);
+      setTrackingCommandType(action);
+      setTrackingData(null);
 
       setToast({
-        message: `Command Sent Successfully! Job ID: ${jobId}`,
+        message: `Command queued (${commandId.substring(0, 8)}…) — tracking lifecycle`,
         type: 'success',
       });
-
-      setTimeout(() => {
-        navigate(`/device/${id}/history`);
-      }, 1500);
     } catch (err) {
       console.error('Failed to send push:', err);
       setToast({
-        message: `Failed to send command: ${err.message || 'Unknown error'}`,
+        message: `Failed to queue command: ${err.message || 'Unknown error'}`,
         type: 'error',
       });
     } finally {
       setSending(false);
     }
   };
+
+  // Poll the command lifecycle after queueing, then hand off to the history page
+  useEffect(() => {
+    if (!trackingCommandId) return;
+    let active = true;
+    let attempts = 0;
+    const interval = setInterval(async () => {
+      if (!active) return;
+      attempts += 1;
+      try {
+        const history = await api.devices.getCommands(id, 10);
+        const cmd = history.find((c) => c.command_id === trackingCommandId);
+        if (cmd) {
+          setTrackingData(cmd);
+          const done =
+            cmd.status === 'completed' || cmd.status === 'failed' || cmd.status === 'expired';
+          if (done) {
+            clearInterval(interval);
+            setToast({
+              message: `Command ${cmd.status.toUpperCase()} — ${cmd.command_id.substring(0, 8)}`,
+              type: cmd.status === 'completed' ? 'success' : 'error',
+            });
+            setTimeout(() => {
+              if (active) navigate(`/device/${id}/history`);
+            }, 1500);
+          }
+        }
+      } catch (pollErr) {
+        console.debug('Lifecycle poll skipped', pollErr);
+      }
+      if (attempts >= 30) clearInterval(interval);
+    }, 2000);
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
+  }, [trackingCommandId, id, navigate]);
 
   const handleRequestAccess = async () => {
     setSending(true);
@@ -324,6 +454,16 @@ export default function PushReview() {
             )}
           </Button>
         </div>
+
+        {/* Live Command Lifecycle Tracker */}
+        {trackingCommandId && (
+          <LifecycleTracker
+            commandId={trackingCommandId}
+            commandType={trackingCommandType}
+            command={trackingData}
+            onViewHistory={() => navigate(`/device/${id}/history`)}
+          />
+        )}
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 flex-1 min-h-0 overflow-hidden">
           {/* Left Column: Command Builder */}

--- a/frontend/src/utils/commandLifecycle.js
+++ b/frontend/src/utils/commandLifecycle.js
@@ -1,0 +1,79 @@
+export const COMMAND_STATUS_META = {
+  pending: {
+    label: 'Queued',
+    description: 'Queued for the device',
+    color: 'text-amber-400',
+    bg: 'bg-amber-500/10',
+    border: 'border-amber-500/30',
+  },
+  sent: {
+    label: 'Acknowledged',
+    description: 'Picked up by the device, executing',
+    color: 'text-blue-400',
+    bg: 'bg-blue-500/10',
+    border: 'border-blue-500/30',
+  },
+  completed: {
+    label: 'Completed',
+    description: 'Executed successfully on the device',
+    color: 'text-emerald-400',
+    bg: 'bg-emerald-500/10',
+    border: 'border-emerald-500/30',
+  },
+  failed: {
+    label: 'Failed',
+    description: 'Execution failed on the device',
+    color: 'text-red-400',
+    bg: 'bg-red-500/10',
+    border: 'border-red-500/30',
+  },
+  expired: {
+    label: 'Expired',
+    description: 'The device did not pick up the command in time',
+    color: 'text-slate-400',
+    bg: 'bg-slate-500/10',
+    border: 'border-slate-500/30',
+  },
+};
+
+export function getStatusMeta(status) {
+  return COMMAND_STATUS_META[status] || COMMAND_STATUS_META.pending;
+}
+
+export function lifecycleStages(command) {
+  const status = command?.status || 'pending';
+  const meta = getStatusMeta(status);
+  const stages = [
+    { key: 'queued', label: 'Queued', time: command?.created_at, done: !!command?.created_at },
+    {
+      key: 'acknowledged',
+      label: 'Acknowledged',
+      time: command?.sent_at,
+      done: !!command?.sent_at,
+    },
+    {
+      key: 'executed',
+      label: 'Executed',
+      time: command?.executed_at,
+      done: !!command?.executed_at,
+    },
+  ];
+  const finalStage = {
+    key: 'result',
+    label: meta.label,
+    time: command?.executed_at || command?.created_at,
+    done: status === 'completed' || status === 'failed' || status === 'expired',
+  };
+  return { status, meta, stages, finalStage };
+}
+
+export function formatCommandType(commandType) {
+  if (!commandType) return 'Custom Command';
+  return commandType.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function resultMessage(result) {
+  if (!result) return null;
+  if (typeof result === 'string') return result;
+  return result.message || result.error || null;
+}


### PR DESCRIPTION
## Summary
The backend already tracks a complete command lifecycle in `device_commands` (`pending` → `sent` → `completed`/`failed`/`expired`, with `created_at`/`sent_at`/`executed_at`), but the UI only ever showed a success toast on queue and a post-hoc summary on the Push History page. This PR surfaces the real lifecycle.

## What changed
- **PushReview (Compose page)**: after queueing, a live lifecycle tracker appears and polls the command status every 2s, advancing Queued → Acknowledged → Executed → Completed/Failed with per-stage timestamps, then hands off to the history page. Toast now says "Command queued…" instead of the misleading "Command Sent Successfully!".
- **DeviceHistory (Push History)**: rewritten to list the real command lifecycle — status badges (Queued/Acknowledged/Completed/Failed/Expired), queued/acknowledged/executed timestamps, command type, and the result message — with auto-refresh polling every 5s and a details modal showing payload + result + timestamps. Reuse still works from the original command payload.
- **DeviceDetail Command History widget**: now fed from the command endpoint so it reflects the live lifecycle instead of config history.
- New shared helper `src/utils/commandLifecycle.js` for status metadata and stage mapping.

## Verified
- Live backend test: queued `health_check` for the emulator → observed the full lifecycle: pending (15:41:46) → acknowledged (15:41:58) → completed (15:42:01) with the diagnostics result.
- Also observed the denial path: when the emulator's auto-consent loop revokes `command_execution`, the queue is rejected with 403 (permission missing).
- Lint, prettier, and production build pass.

## Note
The emulator's default `--permission-consent-mode auto` randomly revokes/grants permissions over time, which can make commands fail unpredictably. Use `--permission-consent-mode fixed` for a stable demo.