### PR TITLE
feat: end-to-end push notification delivery lifecycle

### DIFF
--- a/backend/src/homepot/app/api/API_v1/Endpoints/AgentsEndpoints.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/AgentsEndpoints.py
@@ -199,6 +199,27 @@ async def send_push_notification(
     verify_device_belongs_to_user(db_user, device, sync_db, minimum_role="operator")
     notification_data = {**notification_data, "action": "notification"}
 
+    # Persist the push lifecycle record so the device can pick it up and ack it
+    import uuid
+
+    from homepot.app.models.AnalyticsModel import PushNotificationLog
+
+    message_id = str(uuid.uuid4())
+    notification_data = {**notification_data, "message_id": message_id}
+    try:
+        push_log = PushNotificationLog(
+            message_id=message_id,
+            device_id=device_id,
+            provider="web_push",
+            payload=notification_data,
+            sent_at=datetime.utcnow(),
+            status="sent",
+        )
+        sync_db.add(push_log)
+        sync_db.commit()
+    except Exception as e:
+        logger.warning(f"Failed to persist push log for {device_id}: {e}")
+
     try:
         from homepot.agents import get_agent_manager
 
@@ -215,12 +236,14 @@ async def send_push_notification(
             "status": "success",
             "message": "Notification accepted for device agent",
             "device_id": device_id,
+            "message_id": message_id,
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
 
     return {
         "message": f"Push notification sent to {device_id}",
         "device_id": device_id,
+        "message_id": message_id,
         "response": response,
     }
 

--- a/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/DevicesEndpoints.py
@@ -2113,36 +2113,45 @@ async def get_device_error_logs(
 
 @router.get("/device/{device_id}/push-logs", tags=["Devices"])
 async def get_device_push_logs(device_id: str, limit: int = 50) -> List[Dict[str, Any]]:
-    """Get push notification logs for a specific device."""
+    """Get push notification delivery logs for a specific device."""
     try:
-        # device_id column removed from schema due to mismatch.
-        # Returning empty list until schema migration catches up.
-        return []
+        from sqlalchemy import select
 
-        # db_service = await get_database_service()
-        # async with db_service.get_session() as session:
-        #     # Note: PushNotificationLog uses string device_id
-        #     logs_result = await session.execute(
-        #         select(analytics_models.PushNotificationLog)
-        #         .where(analytics_models.PushNotificationLog.device_id == device_id)
-        #         .order_by(desc(analytics_models.PushNotificationLog.sent_at))
-        #         .limit(limit)
-        #     )
-        #     logs = logs_result.scalars().all()
-        #
-        #     return [
-        #         {
-        #             "message_id": log.message_id,
-        #             "provider": log.provider,
-        #             "status": log.status,
-        #             "sent_at": log.sent_at.isoformat(),
-        #             "received_at": (
-        #                 log.received_at.isoformat() if log.received_at else None
-        #             ),
-        #             "error_message": log.error_message,
-        #         }
-        #         for log in logs
-        #     ]
+        from homepot.app.models.AnalyticsModel import PushNotificationLog
+
+        db_service = await get_database_service()
+        async with db_service.get_session() as session:
+            logs_result = await session.execute(
+                select(PushNotificationLog)
+                .where(PushNotificationLog.device_id == device_id)
+                .order_by(PushNotificationLog.sent_at.desc())
+                .limit(limit)
+            )
+            logs = logs_result.scalars().all()
+
+        return [
+            {
+                "message_id": log.message_id,
+                "provider": log.provider,
+                "status": log.status,
+                "title": payload.get("title", ""),
+                "body": payload.get("body", ""),
+                "sent_at": log.sent_at.isoformat() if log.sent_at else None,
+                "received_at": (
+                    log.received_at.isoformat() if log.received_at else None
+                ),
+                "latency_ms": log.latency_ms,
+                "error_message": log.error_message,
+            }
+            for log in logs
+            for payload in [
+                (
+                    log.payload
+                    if isinstance(log.payload, dict)
+                    else ({} if log.payload is None else {"data": log.payload})
+                )
+            ]
+        ]
     except Exception as e:
         logger.error(f"Failed to get push logs for {device_id}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Internal Server Error")

--- a/backend/src/homepot/app/api/API_v1/Endpoints/PushNotificationEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/PushNotificationEndpoint.py
@@ -9,12 +9,14 @@ import logging
 from typing import Any, Dict, List, Optional
 import uuid
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
+from homepot.app.auth_utils import get_current_device
 from homepot.app.models.AnalyticsModel import PushNotificationLog
 from homepot.audit import AuditEventType, get_audit_logger
 from homepot.database import get_database_service
+from homepot.models import Device
 from homepot.push_notifications.factory import PushNotificationProvider
 
 # Configure logging
@@ -562,3 +564,49 @@ async def acknowledge_push_notification(ack_request: PushAckRequest) -> Dict[str
             "status": "error",
             "message": "An internal error occurred processing the acknowledgment",
         }
+
+
+@router.get("/pending", tags=["Push Notifications"])
+async def get_pending_pushes(
+    current_device: Device = Depends(get_current_device),
+) -> Dict[str, Any]:
+    """Get undelivered push notifications for the authenticated device.
+
+    The device polls this endpoint and acknowledges each push once it has
+    been received/displayed, advancing the delivery lifecycle (sent -> delivered).
+    """
+    try:
+        from sqlalchemy import select
+
+        db_service = await get_database_service()
+        async with db_service.get_session() as session:
+            result = await session.execute(
+                select(PushNotificationLog)
+                .where(
+                    PushNotificationLog.device_id == current_device.device_id,
+                    PushNotificationLog.status == "sent",
+                )
+                .order_by(PushNotificationLog.sent_at.asc())
+                .limit(50)
+            )
+            pushes = result.scalars().all()
+
+        return {
+            "device_id": current_device.device_id,
+            "pushes": [
+                {
+                    "message_id": p.message_id,
+                    "provider": p.provider,
+                    "payload": p.payload,
+                    "sent_at": p.sent_at.isoformat() if p.sent_at else None,
+                    "status": p.status,
+                }
+                for p in pushes
+            ],
+        }
+    except Exception as e:
+        logger.error(f"Failed to fetch pending pushes: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to fetch pending pushes",
+        )

--- a/backend/src/homepot/app/models/AnalyticsModel.py
+++ b/backend/src/homepot/app/models/AnalyticsModel.py
@@ -288,10 +288,12 @@ class PushNotificationLog(Base):
     message_id = Column(String(100), unique=True, index=True, nullable=False)
 
     # Context
-    # device_id removed because it does not exist in the database schema yet
-    # device_id = Column(String(100), index=True, nullable=True)
+    device_id = Column(String(100), index=True, nullable=True)
     job_id = Column(String(100), index=True, nullable=True)
     provider = Column(String(20), nullable=False)  # fcm, apns, mqtt, wns, web_push
+
+    # Payload snapshot so the recipient/consumer can render the notification
+    payload = Column(JSON, nullable=True)
 
     # Timestamps
     sent_at = Column(DateTime, nullable=False, default=datetime.utcnow)
@@ -307,7 +309,7 @@ class PushNotificationLog(Base):
 
     __table_args__ = (
         Index("idx_push_message_id", "message_id"),
-        # Index("idx_push_device", "device_id"),
+        Index("idx_push_device", "device_id"),
         Index("idx_push_status", "status"),
     )
 

--- a/backend/src/homepot/database.py
+++ b/backend/src/homepot/database.py
@@ -125,6 +125,58 @@ def _ensure_device_dna_columns(bind: Any) -> None:
             raise
 
 
+def _ensure_push_log_columns(bind: Any) -> None:
+    """Ensure new columns exist on the push_notification_logs table.
+
+    SQLAlchemy `create_all()` does not alter existing tables, so this helper
+    applies safe additive `ALTER TABLE` statements to pick up the `device_id`
+    and `payload` columns added to ``PushNotificationLog`` without dropping data.
+    """
+    inspector = inspect(bind)
+    if "push_notification_logs" not in inspector.get_table_names():
+        return
+
+    existing_columns = {
+        column["name"] for column in inspector.get_columns("push_notification_logs")
+    }
+    dialect = bind.dialect.name
+
+    if dialect == "sqlite":
+        ddl_map = {
+            "device_id": "ALTER TABLE push_notification_logs ADD COLUMN device_id VARCHAR(100)",
+            "payload": "ALTER TABLE push_notification_logs ADD COLUMN payload JSON",
+        }
+    elif dialect == "postgresql":
+        ddl_map = {
+            "device_id": "ALTER TABLE push_notification_logs ADD COLUMN device_id VARCHAR(100)",
+            "payload": "ALTER TABLE push_notification_logs ADD COLUMN payload JSON",
+        }
+    else:
+        ddl_map = {
+            "device_id": "ALTER TABLE push_notification_logs ADD COLUMN device_id VARCHAR(100)",
+            "payload": "ALTER TABLE push_notification_logs ADD COLUMN payload JSON",
+        }
+
+    for column_name, ddl in ddl_map.items():
+        if column_name in existing_columns:
+            continue
+        try:
+            bind.execute(text(ddl))
+            logger.info("Added missing push_notification_logs.%s column", column_name)
+        except Exception as e:
+            error_text = str(e).lower()
+            duplicate_markers = (
+                "duplicate column",
+                "already exists",
+            )
+            if any(marker in error_text for marker in duplicate_markers):
+                logger.info(
+                    "push_notification_logs.%s already exists, skipping", column_name
+                )
+                continue
+            raise
+
+
 class DatabaseService:
     """Async database service for HOMEPOT operations."""
 
@@ -189,6 +241,7 @@ class DatabaseService:
             async with self.engine.begin() as conn:
                 await conn.run_sync(Base.metadata.create_all)
                 await conn.run_sync(_ensure_device_dna_columns)
+                await conn.run_sync(_ensure_push_log_columns)
 
             logger.info("Database initialized successfully")
 

--- a/emulators/pos_engine.py
+++ b/emulators/pos_engine.py
@@ -184,6 +184,7 @@ class EmulatorConfig:
     heartbeat_interval: float = 10.0
     telemetry_interval: float = 15.0
     command_poll_interval: float = 15.0
+    push_poll_interval: float = 15.0
     logs_interval: float = 15.0
     audit_interval: float = 60.0
     jobs_interval: float = 30.0
@@ -208,6 +209,7 @@ class EmulatorConfig:
             heartbeat_interval=float(d.get("heartbeat_interval_seconds", 10)),
             telemetry_interval=float(d.get("telemetry_interval_seconds", 15)),
             command_poll_interval=float(d.get("command_poll_interval_seconds", 15)),
+            push_poll_interval=float(d.get("push_poll_interval_seconds", 15)),
             logs_interval=float(d.get("logs_interval_seconds", 15)),
             audit_interval=float(d.get("audit_interval_seconds", 60)),
             jobs_interval=float(d.get("jobs_interval_seconds", 30)),
@@ -941,6 +943,116 @@ class POSEmulator:
 
             await self._wait_or_shutdown(self.config.command_poll_interval)
 
+    async def _push_loop(self) -> None:
+        """Poll undelivered push notifications and model the delivery lifecycle.
+
+        The dashboard sends non-executable notifications via the backend, which
+        persists them as ``sent``. This loop picks them up and acks them so the
+        lifecycle advances to ``delivered`` (with latency) exactly like a real
+        push-capable agent.
+        """
+        while not self._shutdown_event.is_set():
+            try:
+                resp = await self._http.get(
+                    f"{self._backend}/push/pending", headers=self._headers()
+                )
+                if resp.status_code >= 400:
+                    print(f"  [push] poll error: {resp.status_code} {resp.text[:120]}")
+                    await self._wait_or_shutdown(self.config.push_poll_interval)
+                    continue
+
+                body = resp.json()
+                pushes = body.get("pushes", []) if isinstance(body, dict) else []
+                if not pushes:
+                    print(
+                        f"  [push] none pending ({datetime.now(timezone.utc).strftime('%H:%M:%S')})"
+                    )
+                else:
+                    print(f"  [push] {len(pushes)} pending")
+                    for push in pushes:
+                        await self._deliver_push(push)
+            except httpx.RequestError as exc:
+                print(f"  [push] connection error: {exc}")
+
+            await self._wait_or_shutdown(self.config.push_poll_interval)
+
+    async def _deliver_push(self, push: dict) -> None:
+        message_id = push.get("message_id", "")
+        payload = push.get("payload")
+        payload = payload if isinstance(payload, dict) else {}
+        title = payload.get("title") or "Push notification"
+        body = payload.get("body") or ""
+        channel = self._push_delivery_note("push")
+
+        await asyncio.sleep(random.uniform(0.2, 1.5))
+        failed = self._command_should_fail()
+        received_at = datetime.now(timezone.utc).isoformat()
+        ack = {
+            "message_id": message_id,
+            "device_id": self.device_id,
+            "status": "failed" if failed else "delivered",
+        }
+        if not failed:
+            ack["received_at"] = received_at
+        else:
+            ack["error_message"] = random.choice(
+                [
+                    "Client connection lost before delivery",
+                    "Message dropped by push service",
+                ]
+            )
+
+        resp = await self._http.post(
+            f"{self._backend}/push/ack",
+            json=ack,
+            headers=self._headers(),
+        )
+        if resp.status_code >= 400:
+            print(
+                f"  [push] ack failed for {message_id}: {resp.status_code} {resp.text[:120]}"
+            )
+            return
+
+        note = f" [{channel}]" if channel else ""
+        if failed:
+            print(
+                f"  [push] delivery FAILED for {message_id}{note}: {ack['error_message']}"
+            )
+        else:
+            print(f"  [push] delivered {title!r}{note} ({message_id[:8]})")
+
+        await self._report_push_log(payload, title, body, failed)
+
+    async def _report_push_log(
+        self, payload: dict, title: str, body: str, failed: bool
+    ) -> None:
+        extra = ""
+        if body:
+            extra = f" | {body[:120]}"
+        if payload.get("action") and payload.get("action") != "notification":
+            extra += f" | action={payload['action']}"
+        message = (
+            f"Push notification delivered: {title}{extra}"
+            if not failed
+            else f"Push notification delivery failed: {title}"
+        )
+        log_payload = {
+            "device_id": self.device_id,
+            "level": "error" if failed else "info",
+            "category": "push",
+            "message": message,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        resp = await self._http.post(
+            f"{self._backend}/agent/logs",
+            json=log_payload,
+            headers=self._headers(),
+        )
+        if resp.status_code >= 400:
+            print(f"  [push] log failed: {resp.status_code} {resp.text[:120]}")
+        else:
+            print("  [push] delivery logged to Live Logs")
+
     async def _handle_command(self, cmd: dict) -> None:
         cid = cmd["command_id"]
         ctype = cmd["command_type"]
@@ -1394,6 +1506,7 @@ class POSEmulator:
                 f" (heartbeat={self.config.heartbeat_interval}s"
                 f", telemetry={self.config.telemetry_interval}s"
                 f", commands={self.config.command_poll_interval}s"
+                f", pushes={self.config.push_poll_interval}s"
                 f", logs={self.config.logs_interval}s"
                 f", audits={self.config.audit_interval}s"
                 f", jobs={self.config.jobs_interval}s"
@@ -1406,6 +1519,7 @@ class POSEmulator:
                 self._heartbeat_loop(),
                 self._telemetry_loop(),
                 self._command_poll_loop(),
+                self._push_loop(),
                 self._logs_loop(),
                 self._audit_loop(),
                 self._jobs_loop(),
@@ -1500,6 +1614,12 @@ def parse_args(
         help="Command poll interval (seconds)",
     )
     parser.add_argument(
+        "--push-poll-interval",
+        type=float,
+        default=15.0,
+        help="Push notification poll interval (seconds)",
+    )
+    parser.add_argument(
         "--logs-interval",
         type=float,
         default=15.0,
@@ -1590,6 +1710,7 @@ def build_config(
         heartbeat_interval=args.heartbeat_interval,
         telemetry_interval=args.telemetry_interval,
         command_poll_interval=args.command_poll_interval,
+        push_poll_interval=args.push_poll_interval,
         logs_interval=args.logs_interval,
         audit_interval=args.audit_interval,
         jobs_interval=args.jobs_interval,


### PR DESCRIPTION
## Summary
Wires up the full push notification lifecycle so the emulator actually receives and acknowledges pushes.

## Backend
- `POST /agents/{device_id}/push` now persists a `PushNotificationLog` row (new `device_id` + `payload` columns) instead of returning success with no record.
- New `GET /push/pending` (device auth via `X-Device-ID`/`X-API-Key`) returns undelivered notifications for a device to poll.
- `POST /push/ack` tracks `received_at` + `latency_ms`; delivery is fully queryable via `GET /devices/device/{id}/push-logs` (previously stubbed `[]`).
- `database.py`: safe `_ensure_push_log_columns` ALTER helper for existing installs.

## Emulator
- New `_push_loop`: polls `/push/pending`, simulates delivery delay, occasionally fails (via `_command_should_fail`), and acks back.
- `push_poll_interval` config + `--push-poll-interval` CLI (default 15s); wired into the asyncio gather and run banner.

## Verified (live, against emulator device)
send push \u2192 pending (1, title matches) \u2192 ack (delivered, 481ms latency) \u2192 push-logs shows both entries.
Quality gates: black, isort, flake8, mypy all clean.