### PR TITLE
ui(device-detail): widen page container to reduce symmetric side margins

### DIFF
--- a/frontend/src/pages/Device/DeviceDetail.jsx
+++ b/frontend/src/pages/Device/DeviceDetail.jsx
@@ -729,7 +729,7 @@ export default function Device() {
       )}
 
       <div className="h-full bg-gradient-to-b from-[#041014] to-[#03121a] text-slate-200 p-2 font-sans flex flex-col overflow-hidden">
-        <div className="max-w-[1582px] mx-auto w-full h-full flex flex-col">
+        <div className="max-w-[1370px] mx-auto w-full h-full flex flex-col">
           {/* Fixed Header Section */}
           <div className="shrink-0 space-y-2 mb-4">
             <Button

--- a/frontend/src/pages/Device/DeviceDetail.jsx
+++ b/frontend/src/pages/Device/DeviceDetail.jsx
@@ -729,7 +729,7 @@ export default function Device() {
       )}
 
       <div className="h-full bg-gradient-to-b from-[#041014] to-[#03121a] text-slate-200 p-2 font-sans flex flex-col overflow-hidden">
-        <div className="max-w-[1613px] mx-auto w-full h-full flex flex-col">
+        <div className="max-w-[1582px] mx-auto w-full h-full flex flex-col">
           {/* Fixed Header Section */}
           <div className="shrink-0 space-y-2 mb-4">
             <Button

--- a/frontend/src/pages/Device/DeviceDetail.jsx
+++ b/frontend/src/pages/Device/DeviceDetail.jsx
@@ -729,7 +729,7 @@ export default function Device() {
       )}
 
       <div className="h-full bg-gradient-to-b from-[#041014] to-[#03121a] text-slate-200 p-2 font-sans flex flex-col overflow-hidden">
-        <div className="max-w-7xl mx-auto w-full h-full flex flex-col">
+        <div className="max-w-screen-2xl mx-auto w-full h-full flex flex-col">
           {/* Fixed Header Section */}
           <div className="shrink-0 space-y-2 mb-4">
             <Button

--- a/frontend/src/pages/Device/DeviceDetail.jsx
+++ b/frontend/src/pages/Device/DeviceDetail.jsx
@@ -729,7 +729,7 @@ export default function Device() {
       )}
 
       <div className="h-full bg-gradient-to-b from-[#041014] to-[#03121a] text-slate-200 p-2 font-sans flex flex-col overflow-hidden">
-        <div className="max-w-screen-2xl mx-auto w-full h-full flex flex-col">
+        <div className="max-w-[1613px] mx-auto w-full h-full flex flex-col">
           {/* Fixed Header Section */}
           <div className="shrink-0 space-y-2 mb-4">
             <Button


### PR DESCRIPTION
Reduces the empty space between the page content and the screen edges on the device detail page, giving the **DEVICE INFO** sidebar (and main column) a bit more horizontal room while keeping both side margins equal.

- `max-w-7xl` (1280px) → `max-w-screen-2xl` (1536px) on the page container.
- On a 1920px screen: side margin drops from ~320px to ~192px per side; the `w-1/4` DEVICE INFO sidebar grows from ~320px to ~384px.

ESLint, prettier, and `npm run build` pass.