### PR TITLE
ui(sites): add max-w container to Manage Sites page

### DIFF
--- a/frontend/src/pages/Sites/SitesList.jsx
+++ b/frontend/src/pages/Sites/SitesList.jsx
@@ -175,246 +175,262 @@ export default function SitesList() {
 
   return (
     <div className="h-full max-h-screen bg-[#0b0e13] text-white p-2 flex flex-col overflow-hidden">
-      <div className="shrink-0 mb-2">
-        <Button
-          variant="ghost"
-          onClick={() => navigate('/dashboard')}
-          className="mb-2 pl-0 hover:pl-1 transition-all text-gray-400 hover:text-white hover:bg-transparent"
-        >
-          <ArrowLeft className="h-4 w-4 mr-2" />
-          Back to Dashboard
-        </Button>
-
-        <div className="flex flex-col md:flex-row justify-between items-center mb-4 gap-3">
-          <h1 className="text-xl font-semibold">Manage Sites</h1>
-        </div>
-
-        {/* Active / Archived tabs */}
-        <div className="flex gap-1 mb-4 bg-[#141a24] border border-[#1f2735] rounded-lg p-1 w-fit">
-          <button
-            onClick={() => handleTabChange('active')}
-            className={`px-4 py-1.5 text-sm rounded-md transition-colors ${
-              activeTab === 'active'
-                ? 'bg-teal-500/20 text-teal-400 border border-teal-500/30'
-                : 'text-gray-400 hover:text-white hover:bg-[#1f2735]'
-            }`}
+      <div className="max-w-[1370px] mx-auto w-full h-full flex flex-col">
+        <div className="shrink-0 mb-2">
+          <Button
+            variant="ghost"
+            onClick={() => navigate('/dashboard')}
+            className="mb-2 pl-0 hover:pl-1 transition-all text-gray-400 hover:text-white hover:bg-transparent"
           >
-            Active
-          </button>
-          <button
-            onClick={() => handleTabChange('archived')}
-            className={`px-4 py-1.5 text-sm rounded-md transition-colors ${
-              activeTab === 'archived'
-                ? 'bg-teal-500/20 text-teal-400 border border-teal-500/30'
-                : 'text-gray-400 hover:text-white hover:bg-[#1f2735]'
-            }`}
-          >
-            Archived
-          </button>
-        </div>
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back to Dashboard
+          </Button>
 
-        <div className="flex flex-col md:flex-row items-center gap-2 mb-4">
-          {/* Search input */}
-          <div className="relative w-full md:w-1/2">
-            <span className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-              <Search className="h-4 w-4 text-gray-400" />
-            </span>
-            <input
-              type="text"
-              placeholder="Search by site ID or name"
-              className="bg-[#141a24] border border-[#1f2735] text-white px-9 py-1.5 text-sm rounded-lg w-full focus:outline-none focus:border-teal-500 transition-colors"
-              value={searchTerm}
-              // onChange={(e) => setSearchTerm(e.target.value)}
+          <div className="flex flex-col md:flex-row justify-between items-center mb-4 gap-3">
+            <h1 className="text-xl font-semibold">Manage Sites</h1>
+          </div>
+
+          {/* Active / Archived tabs */}
+          <div className="flex gap-1 mb-4 bg-[#141a24] border border-[#1f2735] rounded-lg p-1 w-fit">
+            <button
+              onClick={() => handleTabChange('active')}
+              className={`px-4 py-1.5 text-sm rounded-md transition-colors ${
+                activeTab === 'active'
+                  ? 'bg-teal-500/20 text-teal-400 border border-teal-500/30'
+                  : 'text-gray-400 hover:text-white hover:bg-[#1f2735]'
+              }`}
+            >
+              Active
+            </button>
+            <button
+              onClick={() => handleTabChange('archived')}
+              className={`px-4 py-1.5 text-sm rounded-md transition-colors ${
+                activeTab === 'archived'
+                  ? 'bg-teal-500/20 text-teal-400 border border-teal-500/30'
+                  : 'text-gray-400 hover:text-white hover:bg-[#1f2735]'
+              }`}
+            >
+              Archived
+            </button>
+          </div>
+
+          <div className="flex flex-col md:flex-row items-center gap-2 mb-4">
+            {/* Search input */}
+            <div className="relative w-full md:w-1/2">
+              <span className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+                <Search className="h-4 w-4 text-gray-400" />
+              </span>
+              <input
+                type="text"
+                placeholder="Search by site ID or name"
+                className="bg-[#141a24] border border-[#1f2735] text-white px-9 py-1.5 text-sm rounded-lg w-full focus:outline-none focus:border-teal-500 transition-colors"
+                value={searchTerm}
+                // onChange={(e) => setSearchTerm(e.target.value)}
+                onChange={(e) => {
+                  setSearchTerm(e.target.value);
+
+                  // Track Search
+                  trackSearch(e.target.value, '/sites', 0);
+                }}
+              />
+            </div>
+
+            {/* Location dropdown */}
+            <select
+              className="bg-[#141a24] border border-[#1f2735] text-white w-full md:w-64 px-3 py-[7px] text-sm rounded-lg focus:outline-none focus:border-teal-500 transition-colors"
+              value={locationFilter}
+              // onChange={(e) => setLocationFilter(e.target.value)}
               onChange={(e) => {
-                setSearchTerm(e.target.value);
+                setLocationFilter(e.target.value);
 
-                // Track Search
-                trackSearch(e.target.value, '/sites', 0);
+                trackActivity(
+                  'interaction',
+                  '/sites',
+                  { selected_location: e.target.value }, // extra_data
+                  'location_filter' // element id
+                );
               }}
-            />
+            >
+              <option value="">All Locations</option>
+              {/* Extract unique locations from sites */}
+              {[...new Set(sites.map((s) => s.location).filter(Boolean))].map((loc) => (
+                <option key={loc} value={loc}>
+                  {loc}
+                </option>
+              ))}
+            </select>
           </div>
-
-          {/* Location dropdown */}
-          <select
-            className="bg-[#141a24] border border-[#1f2735] text-white w-full md:w-64 px-3 py-[7px] text-sm rounded-lg focus:outline-none focus:border-teal-500 transition-colors"
-            value={locationFilter}
-            // onChange={(e) => setLocationFilter(e.target.value)}
-            onChange={(e) => {
-              setLocationFilter(e.target.value);
-
-              trackActivity(
-                'interaction',
-                '/sites',
-                { selected_location: e.target.value }, // extra_data
-                'location_filter' // element id
-              );
-            }}
-          >
-            <option value="">All Locations</option>
-            {/* Extract unique locations from sites */}
-            {[...new Set(sites.map((s) => s.location).filter(Boolean))].map((loc) => (
-              <option key={loc} value={loc}>
-                {loc}
-              </option>
-            ))}
-          </select>
         </div>
-      </div>
 
-      <div className="flex-1 overflow-y-auto min-h-0 pb-2 pr-1 custom-scrollbar">
-        {filteredSites.length === 0 ? (
-          <div className="flex items-center justify-center h-full text-gray-500 text-sm">
-            {activeTab === 'archived'
-              ? 'No archived sites. Archive a site from the Active tab to see it here.'
-              : 'No sites found.'}
-          </div>
-        ) : (
-          <div className="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-            {filteredSites.map((site) => (
-              <div
-                key={site.id}
-                className="bg-[#141a24] border border-[#1f2735] rounded-xl p-5 hover:border-teal-400 transition-all flex flex-col group relative"
-              >
-                {/* Edit/Delete Actions - Always visible */}
-                <div className="absolute top-4 right-4 flex gap-2">
-                  {activeTab === 'archived' ? (
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-
-                        trackActivity('click', '/sites', { site_id: site.id }, 'restore_site_btn');
-
-                        handleRestoreClick(e, site);
-                      }}
-                      className="p-1.5 rounded-md bg-[#1f2735] hover:bg-teal-900/30 text-gray-400 hover:text-teal-400 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                      title="Restore"
-                      disabled={isRestoring}
-                    >
-                      <RotateCcw size={14} />
-                    </button>
-                  ) : (
-                    <>
-                      <button
-                        // onClick={(e) => handleEditClick(e, site)}
-                        onClick={(e) => {
-                          e.stopPropagation();
-
-                          trackActivity('click', '/sites', { site_id: site.id }, 'edit_site_btn');
-
-                          handleEditClick(e, site);
-                        }}
-                        className="p-1.5 rounded-md bg-[#1f2735] hover:bg-[#2a3441] text-gray-400 hover:text-white transition-colors"
-                        title="Edit"
-                      >
-                        <Edit size={14} />
-                      </button>
-                      <button
-                        // onClick={(e) => handleDeleteClick(e, site)}
-                        onClick={(e) => {
-                          e.stopPropagation();
-
-                          trackActivity('click', '/sites', { site_id: site.id }, 'delete_site_btn');
-
-                          handleDeleteClick(e, site);
-                        }}
-                        className="p-1.5 rounded-md bg-[#1f2735] hover:bg-red-900/30 text-gray-400 hover:text-red-400 transition-colors"
-                        title="Delete"
-                      >
-                        <Trash2 size={14} />
-                      </button>
-                    </>
-                  )}
-                </div>
-
-                <div className="mb-6">
-                  <h2
-                    className="text-lg font-semibold text-white text-start truncate pr-16"
-                    title={site.name}
-                  >
-                    {site.name}
-                  </h2>
-                  <div className="flex flex-col gap-1 mt-1 mb-2">
-                    <div className="flex items-center gap-1.5">
-                      <p className="text-xs font-mono text-teal-400/70 text-start truncate">
-                        Site ID: {site.site_id || site.id}
-                      </p>
-                      <button
-                        onClick={(e) => handleCopySiteId(e, site)}
-                        className="p-0.5 rounded text-gray-400 hover:text-teal-400 transition-colors shrink-0"
-                        title="Copy Site ID"
-                      >
-                        {copiedSiteId === (site.site_id || site.id) ? (
-                          <Check size={12} className="text-teal-400" />
-                        ) : (
-                          <Copy size={12} />
-                        )}
-                      </button>
-                    </div>
-                    <p className="text-sm text-gray-400 text-start truncate">
-                      {site.location || 'No location'}
-                    </p>
-                  </div>
-                </div>
-
-                <div className="flex items-center space-x-3 mb-3">
-                  {/* Render icons based on OS types present in the site */}
-                  {site.os_types && site.os_types.includes('windows') && <OsIcon type="windows" />}
-                  {site.os_types && site.os_types.includes('linux') && <OsIcon type="linux" />}
-                  {site.os_types &&
-                    (site.os_types.includes('macos') ||
-                      site.os_types.includes('ios') ||
-                      site.os_types.includes('apple')) && <OsIcon type="macos" />}
-                  {site.os_types && site.os_types.includes('android') && <OsIcon type="android" />}
-                  {site.os_types && site.os_types.includes('web') && <OsIcon type="web" />}
-                  {site.os_types &&
-                    (site.os_types.includes('iot') ||
-                      site.os_types.includes('sensor') ||
-                      site.os_types.includes('iot_sensor') ||
-                      site.os_types.includes('embedded') ||
-                      site.os_types.some((t) => t.includes('iot'))) && <OsIcon type="iot" />}
-                </div>
-
-                {site.alert && (
-                  <div className="flex items-center text-yellow-400 text-sm mb-2">
-                    <AlertTriangle size={16} className="mr-2" /> {site.alert}
-                  </div>
-                )}
-
-                <div className="flex flex-col gap-2 mb-3">
-                  <div className="flex items-center gap-2">
-                    <span
-                      className={`w-3 h-3 rounded-full ${site.status === 'Online' ? 'bg-green-400' : 'bg-red-500'}`}
-                    ></span>
-                    <span className="text-sm">{site.status}</span>
-                  </div>
-                  <div className="flex items-center gap-2 text-sm text-gray-400">
-                    <span>Registered Devices:</span>
-                    <span className="font-semibold text-white">{site.devices_count || 0}</span>
-                  </div>
-                </div>
-
-                {/* View Details button */}
-                <button
-                  onClick={(e) => handleViewDetails(e, site)}
-                  className="mt-auto w-full border border-[#1f2735] py-2 rounded-lg text-sm hover:bg-[#1f2735] text-gray-300 transition"
+        <div className="flex-1 overflow-y-auto min-h-0 pb-2 pr-1 custom-scrollbar">
+          {filteredSites.length === 0 ? (
+            <div className="flex items-center justify-center h-full text-gray-500 text-sm">
+              {activeTab === 'archived'
+                ? 'No archived sites. Archive a site from the Active tab to see it here.'
+                : 'No sites found.'}
+            </div>
+          ) : (
+            <div className="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+              {filteredSites.map((site) => (
+                <div
+                  key={site.id}
+                  className="bg-[#141a24] border border-[#1f2735] rounded-xl p-5 hover:border-teal-400 transition-all flex flex-col group relative"
                 >
-                  View Details
-                </button>
-              </div>
-            ))}
-          </div>
-        )}
+                  {/* Edit/Delete Actions - Always visible */}
+                  <div className="absolute top-4 right-4 flex gap-2">
+                    {activeTab === 'archived' ? (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+
+                          trackActivity(
+                            'click',
+                            '/sites',
+                            { site_id: site.id },
+                            'restore_site_btn'
+                          );
+
+                          handleRestoreClick(e, site);
+                        }}
+                        className="p-1.5 rounded-md bg-[#1f2735] hover:bg-teal-900/30 text-gray-400 hover:text-teal-400 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        title="Restore"
+                        disabled={isRestoring}
+                      >
+                        <RotateCcw size={14} />
+                      </button>
+                    ) : (
+                      <>
+                        <button
+                          // onClick={(e) => handleEditClick(e, site)}
+                          onClick={(e) => {
+                            e.stopPropagation();
+
+                            trackActivity('click', '/sites', { site_id: site.id }, 'edit_site_btn');
+
+                            handleEditClick(e, site);
+                          }}
+                          className="p-1.5 rounded-md bg-[#1f2735] hover:bg-[#2a3441] text-gray-400 hover:text-white transition-colors"
+                          title="Edit"
+                        >
+                          <Edit size={14} />
+                        </button>
+                        <button
+                          // onClick={(e) => handleDeleteClick(e, site)}
+                          onClick={(e) => {
+                            e.stopPropagation();
+
+                            trackActivity(
+                              'click',
+                              '/sites',
+                              { site_id: site.id },
+                              'delete_site_btn'
+                            );
+
+                            handleDeleteClick(e, site);
+                          }}
+                          className="p-1.5 rounded-md bg-[#1f2735] hover:bg-red-900/30 text-gray-400 hover:text-red-400 transition-colors"
+                          title="Delete"
+                        >
+                          <Trash2 size={14} />
+                        </button>
+                      </>
+                    )}
+                  </div>
+
+                  <div className="mb-6">
+                    <h2
+                      className="text-lg font-semibold text-white text-start truncate pr-16"
+                      title={site.name}
+                    >
+                      {site.name}
+                    </h2>
+                    <div className="flex flex-col gap-1 mt-1 mb-2">
+                      <div className="flex items-center gap-1.5">
+                        <p className="text-xs font-mono text-teal-400/70 text-start truncate">
+                          Site ID: {site.site_id || site.id}
+                        </p>
+                        <button
+                          onClick={(e) => handleCopySiteId(e, site)}
+                          className="p-0.5 rounded text-gray-400 hover:text-teal-400 transition-colors shrink-0"
+                          title="Copy Site ID"
+                        >
+                          {copiedSiteId === (site.site_id || site.id) ? (
+                            <Check size={12} className="text-teal-400" />
+                          ) : (
+                            <Copy size={12} />
+                          )}
+                        </button>
+                      </div>
+                      <p className="text-sm text-gray-400 text-start truncate">
+                        {site.location || 'No location'}
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="flex items-center space-x-3 mb-3">
+                    {/* Render icons based on OS types present in the site */}
+                    {site.os_types && site.os_types.includes('windows') && (
+                      <OsIcon type="windows" />
+                    )}
+                    {site.os_types && site.os_types.includes('linux') && <OsIcon type="linux" />}
+                    {site.os_types &&
+                      (site.os_types.includes('macos') ||
+                        site.os_types.includes('ios') ||
+                        site.os_types.includes('apple')) && <OsIcon type="macos" />}
+                    {site.os_types && site.os_types.includes('android') && (
+                      <OsIcon type="android" />
+                    )}
+                    {site.os_types && site.os_types.includes('web') && <OsIcon type="web" />}
+                    {site.os_types &&
+                      (site.os_types.includes('iot') ||
+                        site.os_types.includes('sensor') ||
+                        site.os_types.includes('iot_sensor') ||
+                        site.os_types.includes('embedded') ||
+                        site.os_types.some((t) => t.includes('iot'))) && <OsIcon type="iot" />}
+                  </div>
+
+                  {site.alert && (
+                    <div className="flex items-center text-yellow-400 text-sm mb-2">
+                      <AlertTriangle size={16} className="mr-2" /> {site.alert}
+                    </div>
+                  )}
+
+                  <div className="flex flex-col gap-2 mb-3">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={`w-3 h-3 rounded-full ${site.status === 'Online' ? 'bg-green-400' : 'bg-red-500'}`}
+                      ></span>
+                      <span className="text-sm">{site.status}</span>
+                    </div>
+                    <div className="flex items-center gap-2 text-sm text-gray-400">
+                      <span>Registered Devices:</span>
+                      <span className="font-semibold text-white">{site.devices_count || 0}</span>
+                    </div>
+                  </div>
+
+                  {/* View Details button */}
+                  <button
+                    onClick={(e) => handleViewDetails(e, site)}
+                    className="mt-auto w-full border border-[#1f2735] py-2 rounded-lg text-sm hover:bg-[#1f2735] text-gray-300 transition"
+                  >
+                    View Details
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <SiteDeleteDialog
+          isOpen={deleteDialogOpen}
+          onClose={() => setDeleteDialogOpen(false)}
+          onConfirm={handleConfirmDelete}
+          siteName={siteToDelete?.name}
+          isDeleting={isDeleting}
+        />
+
+        {toast && <Toast {...toast} onClose={() => setToast(null)} />}
       </div>
-
-      <SiteDeleteDialog
-        isOpen={deleteDialogOpen}
-        onClose={() => setDeleteDialogOpen(false)}
-        onConfirm={handleConfirmDelete}
-        siteName={siteToDelete?.name}
-        isDeleting={isDeleting}
-      />
-
-      {toast && <Toast {...toast} onClose={() => setToast(null)} />}
     </div>
   );
 }


### PR DESCRIPTION
Constrains the **Manage Sites** list to `max-w-[1370px]` with symmetric `mx-auto` margins, matching the device detail page, instead of spanning the full screen edge-to-edge. The only content change is the new wrapper div (the large line count is indentation from the added nesting level).\n\nESLint, prettier, and `npm run build` pass.