### PR TITLE
fix(device-detail): keep DEVICE INFO status fields in sync with device lifecycle

### DIFF
--- a/frontend/src/pages/Device/DeviceDetail.jsx
+++ b/frontend/src/pages/Device/DeviceDetail.jsx
@@ -357,7 +357,24 @@ export default function Device() {
         .catch((err) => console.debug('Alerts poll skipped', err));
     }, 2000);
 
-    return () => clearInterval(pollInterval);
+    // Refresh the device status fields (connectivity / lifecycle / health /
+    // credential) periodically so the DEVICE INFO panel stays in sync when the
+    // device starts or stops (e.g. the emulator). The emulator heartbeats every
+    // 10s and the backend flips connectivity to offline ~120s after the last
+    // heartbeat, so a 10s refresh keeps it timely without heavy polling.
+    const devicePoll = setInterval(async () => {
+      try {
+        const fresh = await api.devices.getDeviceById(id);
+        if (fresh) setDevice((prev) => ({ ...prev, ...fresh }));
+      } catch (err) {
+        console.debug('Device status poll skipped', err);
+      }
+    }, 10000);
+
+    return () => {
+      clearInterval(pollInterval);
+      clearInterval(devicePoll);
+    };
   }, [id]);
 
   useEffect(() => {

--- a/frontend/src/pages/Sites/SiteDetail.jsx
+++ b/frontend/src/pages/Sites/SiteDetail.jsx
@@ -465,27 +465,8 @@ export default function SiteDetail() {
                                 : 'bg-yellow-500/10 text-yellow-500'
                         }`}
                       >
-                        <span
-                          className={`w-1.5 h-1.5 rounded-full ${
-                            device.connectivity_state === 'online'
-                              ? 'bg-green-500'
-                              : device.connectivity_state === 'offline'
-                                ? 'bg-gray-500'
-                                : 'bg-yellow-500'
-                          }`}
-                        />
                         {device.lifecycle_state || 'Unknown'}
                       </span>
-                      {device.enrollment_method === 'emulated' ||
-                      device.device_source === 'emulator' ? (
-                        <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium bg-cyan-500/10 text-cyan-400 border border-cyan-500/20">
-                          EMU
-                        </span>
-                      ) : device.is_simulated ? (
-                        <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium bg-purple-500/10 text-purple-400 border border-purple-500/20">
-                          SIM
-                        </span>
-                      ) : null}
                       <span
                         className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium ${
                           device.health_state === 'healthy'
@@ -501,6 +482,16 @@ export default function SiteDetail() {
                       >
                         {device.health_state || 'unknown'}
                       </span>
+                      {device.enrollment_method === 'emulated' ||
+                      device.device_source === 'emulator' ? (
+                        <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium bg-cyan-500/10 text-cyan-400 border border-cyan-500/20">
+                          EMU
+                        </span>
+                      ) : device.is_simulated ? (
+                        <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium bg-purple-500/10 text-purple-400 border border-purple-500/20">
+                          SIM
+                        </span>
+                      ) : null}
                     </div>
                   </td>
                   <td className="p-4 align-middle">


### PR DESCRIPTION
## Problem

The device object on the device detail page was fetched **once** on mount. 
The 2s poll refreshed metrics/logs/audit/jobs/alerts but **not** the device, so the DEVICE INFO panel (Status / Lifecycle / Health / Credential) went stale when a device started or stopped — e.g. the running/stopping of an emulator was not reflected without a manual browser refresh.
The Site page's *Associated Devices* table already polls every 5s, which is why its badges stayed live.

## Fix
Re-fetch the device every **10s** in DeviceDetail and merge it into state, so `connectivity_state` (online/offline) updates live. 10s was chosen to match the emulator's 10s heartbeat and the backend's ~120s offline threshold without heavy polling.

## What to expect on stop/start
- **Status**: ONLINE \u2192 OFFLINE ~120s after the last heartbeat; back to ONLINE on resume. (This now updates live.)
- **Lifecycle / Health / Credential / Source**: intentionally stable on stop — lifecycle is the registered operational state, health is the last reported value, credentials remain valid.

ESLint, prettier, and `npm run build` pass.