### PR TITLE
fix(sites): restore full width on Site Detail container

### DIFF
--- a/frontend/src/pages/Sites/SiteDetail.jsx
+++ b/frontend/src/pages/Sites/SiteDetail.jsx
@@ -238,7 +238,7 @@ export default function SiteDetail() {
 
   return (
     <div className="h-full flex flex-col overflow-hidden bg-[#0b0e13] p-2">
-      <div className="mx-auto max-w-content h-full flex flex-col">
+      <div className="mx-auto max-w-content w-full h-full flex flex-col">
         {/* Fixed Header Section */}
         <div className="shrink-0 mb-4 space-y-4">
           <Button


### PR DESCRIPTION
The Site Detail inner container was missing `w-full` after the `max-w-content` refactor (#336) dropped the Tailwind `container` class, so the content no longer stretched and the page appeared squashed with large empty side margins.\n\nFixes it to match the other pages: `mx-auto max-w-content w-full`. Prettier and `npm run build` pass.