### PR TITLE
feat(emulators): support multiple concurrent emulator instances

### DIFF
--- a/docs/device-emulators.md
+++ b/docs/device-emulators.md
@@ -87,27 +87,35 @@ Credentials are persisted across restarts. If the emulator is stopped and re-run
 
 ### Restarting
 
-`start-emulator.sh` runs the emulator in the background, writes its output to
-`logs/emulator.log`, and records its PID in `logs/emulator.pid` (same
-convention as `backend.log`, `frontend.log`, `ai.log`).
+`start-emulator.sh` runs the emulator in the background. Each instance writes
+to its own per-instance log/PID file, named after the `--device-name` (or the
+emulator type when no name is given):
+`logs/emulator-<instance>.log` and `logs/emulator-<instance>.pid`. This means
+several emulators can run at once — just give each a unique `--device-name`.
 
 ```bash
-# Stop any running instance
+# Launch an emulator (each instance gets its own log/PID file)
+./scripts/start-emulator.sh --emulator android --device-name demo-android-1
+
+# Launch another emulator concurrently with a different name
+./scripts/start-emulator.sh --emulator macos --device-name demo-macos-1
+
+# Watch a specific instance's live output
+tail -f logs/emulator-demo-macos-1.log
+
+# Stop one instance by name (its --device-name, else emulator type)
+./scripts/stop-emulator.sh demo-macos-1
+
+# Stop ALL emulators
 ./scripts/stop-emulator.sh
-
-# Re-launch (backgrounds the process)
-./scripts/start-emulator.sh
-
-# Launch a specific OS emulator (default is linux)
-./scripts/start-emulator.sh --emulator android
-
-# Watch live output
-tail -f logs/emulator.log
 ```
 
-`start-emulator.sh` accepts an `--emulator linux|android|windows|macos|ios` flag (default `linux`)
-that selects the emulator script and its default config. Any emulator launch
-arguments, including `--os-details`, are forwarded to the Python emulator.
+`start-emulator.sh` accepts an `--emulator linux|android|windows|macos|ios`
+flag (default `linux`) that selects the emulator script and its default config.
+Any emulator launch arguments — `--backend-url`, `--site-id`, `--bootstrap-key`,
+`--device-name`, `--os-details`, `--permission-consent-mode`, … — are forwarded
+to the Python emulator. A repeat launch of the **same** instance (same name) is
+refused while it is running; different instances run side by side.
 
 **User App (Electron)** — Quit and re-open the User App. The Electron main process kills the child emulator on quit; re-opening restarts it automatically when the setup-to-home flow completes.
 
@@ -159,7 +167,7 @@ Terminal 1:  ./scripts/start-dashboard.sh
 Terminal 2:  ./scripts/start-emulator.sh --site-id site-it-demo1 --bootstrap-key <key> --device-name demo-pos-1
              # Emulator provisions, heartbeats, sends telemetry
              # Use a different --device-name per emulator to run several on one site
-             # Live output: tail -f logs/emulator.log
+             # Live output: tail -f logs/emulator-demo-pos-1.log
 
 Terminal 3:  ./scripts/start-userapp.sh
              # User App on :5174 — login and manage the emulated device

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -86,7 +86,7 @@ clean start/stop cycle, which doubles as a smoke test to catch startup issues ea
 | **Backend** (API :8000) | `backend.log`, `backend.out` | `backend.pid` | `./scripts/start-dashboard.sh` | `./scripts/stop-dashboard.sh` |
 | **Frontend** (Vite :5173) | `frontend.log` | `frontend.pid` | `./scripts/start-dashboard.sh` | `./scripts/stop-dashboard.sh` |
 | **AI / LLM** (Ollama :11434) | `ai.log` | `ai.pid` | `./scripts/setup-ollama.sh` | n/a (see note) |
-| **Emulator** (POS terminal) | `emulator.log` | `emulator.pid` | `./scripts/start-emulator.sh` | `./scripts/stop-emulator.sh` |
+| **Emulator** (POS terminal) | `emulator-<name>.log` | `emulator-<name>.pid` | `./scripts/start-emulator.sh` | `./scripts/stop-emulator.sh [name]` |
 | **User App** (Electron agent) | `userapp.log` | `userapp.pid` | `./scripts/start-userapp.sh` | `./scripts/stop-userapp.sh` |
 
 ### Full Restart (verified smoke test)

--- a/docs/verify-user-app-with-emulators.md
+++ b/docs/verify-user-app-with-emulators.md
@@ -323,7 +323,8 @@ validated:
 Still in **Terminal 2**, run the Linux POS emulator. It performs the same
 `POST /devices/bootstrap-provision` call the User App's setup wizard makes, then
 runs heartbeat/telemetry as the device would. It runs in the **background**,
-logging to `logs/emulator.log` and recording its PID in `logs/emulator.pid`:
+logging to `logs/emulator-<device_name>.log` and recording its PID in
+`logs/emulator-<device_name>.pid` (each instance gets its own files):
 
 ```bash
 # in the repository root
@@ -345,7 +346,7 @@ The script echoes `Emulator started (PID: ...)` on success. Watch the emulator's
 own output as it registers DNA, then starts its loops:
 
 ```
-tail -f logs/emulator.log
+tail -f logs/emulator-demo-pos-1.log
 ```
 
 You should see:
@@ -370,7 +371,8 @@ You should see:
   [heartbeat] OK  (13:23:25)...
 ```
 
-Stop it any time with `./scripts/stop-emulator.sh`.
+Stop it any time with `./scripts/stop-emulator.sh demo-pos-1` (by name), or
+`./scripts/stop-emulator.sh` to stop all running emulators.
 
 Notes:
 
@@ -401,7 +403,7 @@ Back in **Terminal 1** / the Dashboard browser:
    (e.g. `High Latency: 474ms`) appears, injected by the emulator via
    `POST /agent/alert` (configurable `alerts_interval_seconds`).
 7. *(Optional)* queue a command (e.g. `ping` or `restart`) from the device
-   detail page — within a few seconds `logs/emulator.log` shows it being ACKed
+   detail page — within a few seconds `logs/emulator-<device_name>.log` shows it being ACKed
    and completed, and the Dashboard records the result.
 8. *(Optional)* **Compose Command** — from the device detail page, open
    **Compose Command**, pick a command (e.g. `RUN_DIAGNOSTICS` or
@@ -500,7 +502,7 @@ On the Mac (same repo checked out, venv set up, backend reachable over LAN):
 Watch it come up (same banner as Linux, but "HOMEPOT macOS POS Emulator"):
 
 ```bash
-tail -f logs/emulator.log
+tail -f logs/emulator-demo-macos-pos-1.log
 ```
 
 Then complete **Step 5** on the host's Dashboard: the Mac-emulated device
@@ -566,7 +568,7 @@ For **push notification** testing (Compose Push → the emulator polling
 | Two emulators clash on one machine | Use different `--device-name` values (each gets its own credentials file). |
 | Emulator on the Mac never connects / no device appears | `--backend-url` must be the host's **LAN IP** (not `localhost`) and reachable from the Mac: `curl http://<host-lan-ip>:8000/api/v1/health`. Check the host firewall / WSL2 `netsh portproxy` mapping (see [macOS section](#how-it-is-set-up)). |
 | Command rejected with `403 Device owner has not granted the required permissions` | The emulator's `auto` consent loop revoked the permission (default mode toggles grants over time). Restart with `--permission-consent-mode fixed` for a stable demo. |
-| Emulator ignores recent code changes | The wrapper/engine loads at process start. `./scripts/stop-emulator.sh` then `./scripts/start-emulator.sh ...` to pick up the new code. |
+| Emulator ignores recent code changes | The wrapper/engine loads at process start. `./scripts/stop-emulator.sh <name>` then `./scripts/start-emulator.sh ...` to pick up the new code. |
 | Dashboard frontend can't reach the backend | Confirm the backend is up and CORS is configured; `curl http://localhost:8000/` should return `{"message":"I Am Alive"}`. |
 
 ## Related documentation

--- a/frontend/src/pages/Sites/SiteDetail.jsx
+++ b/frontend/src/pages/Sites/SiteDetail.jsx
@@ -238,7 +238,7 @@ export default function SiteDetail() {
 
   return (
     <div className="h-full flex flex-col overflow-hidden bg-[#0b0e13] p-2">
-      <div className="mx-auto max-w-content h-full flex flex-col">
+      <div className="mx-auto max-w-content w-full h-full flex flex-col">
         {/* Fixed Header Section */}
         <div className="shrink-0 mb-4 space-y-4">
           <Button

--- a/scripts/start-emulator.sh
+++ b/scripts/start-emulator.sh
@@ -2,19 +2,30 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
-# start-emulator.sh — Launch a HOMEPOT device emulator in the background,
-# logging to logs/emulator.log and recording its PID in logs/emulator.pid
-# (mirrors start-userapp.sh).
+# start-emulator.sh — Launch a HOMEPOT device emulator in the background.
+#
+# Each instance gets its own log/PID file, so several emulators can run at
+# once (use a unique --device-name per instance).
 #
 # Usage:
-#   ./scripts/start-emulator.sh                    # uses default (Linux) config
-#   ./scripts/start-emulator.sh --emulator android # uses the Android emulator + config
+#   ./scripts/start-emulator.sh                    # default (Linux) config
+#   ./scripts/start-emulator.sh --emulator android # select emulator + config
 #   ./scripts/start-emulator.sh --config emulators/my-device.json
-#   ./scripts/start-emulator.sh --site-id site-it-demo1 --bootstrap-key <key> --device-name demo-pos-1
+#   ./scripts/start-emulator.sh --emulator macos \
+#     --backend-url http://192.168.1.176:8000 \
+#     --site-id SITE-7UAH-963T --bootstrap-key <key> --device-name demo-macos-1
 #
 # Options:
 #   --emulator linux|android|windows|macos|ios   Select the emulator script + default config
 #                              (default: linux). Extend the map below for new OSes.
+#
+#   All other arguments (--backend-url, --site-id, --bootstrap-key,
+#   --device-name, --permission-consent-mode, ...) are forwarded to the
+#   selected emulator. --device-name is also used to name the log/PID file.
+#
+# Log/PID files:
+#   logs/emulator-<instance>.log   (instance = --device-name, else emulator type)
+#   logs/emulator-<instance>.pid
 #
 # Prerequisites:
 #   - Python virtual environment at .venv/ with httpx installed
@@ -99,19 +110,36 @@ if [[ "$#" -eq 0 ]]; then
     fi
 fi
 
+# --- Instance slug ----------------------------------------------------------
+
+# Derive a per-instance name from --device-name if provided, else the emulator
+# type. This is used to give each running emulator its own log/PID file so
+# several instances can run concurrently.
+INSTANCE="$EMULATOR"
+ARGS_COPY=("$@")
+for ((i = 0; i < ${#ARGS_COPY[@]}; i++)); do
+    if [[ "${ARGS_COPY[$i]}" == "--device-name" && -n "${ARGS_COPY[$((i + 1))]:-}" ]]; then
+        INSTANCE="${ARGS_COPY[$((i + 1))]}"
+        break
+    fi
+done
+INSTANCE_SLUG="$(printf '%s' "$INSTANCE" | tr ' /' '__')"
+
 # --- Logging ----------------------------------------------------------------
 
 mkdir -p "$PROJECT_DIR/logs"
-LOG_FILE="$PROJECT_DIR/logs/emulator.log"
-PID_FILE="$PROJECT_DIR/logs/emulator.pid"
+LOG_FILE="$PROJECT_DIR/logs/emulator-${INSTANCE_SLUG}.log"
+PID_FILE="$PROJECT_DIR/logs/emulator-${INSTANCE_SLUG}.pid"
 
 # --- Guard against duplicate instances ---------------------------------------
 
+# Only guard this instance's own PID file, so different emulators can run
+# simultaneously while a repeat launch of the same instance is refused.
 if [ -f "$PID_FILE" ]; then
     OLD_PID=$(cat "$PID_FILE")
     if ps -p "$OLD_PID" > /dev/null 2>&1; then
-        echo "Error: an emulator is already running (PID $OLD_PID)"
-        echo "  Stop it first: ./scripts/stop-emulator.sh"
+        echo "Error: emulator instance '$INSTANCE' is already running (PID $OLD_PID)"
+        echo "  Stop it first: ./scripts/stop-emulator.sh $INSTANCE"
         exit 1
     fi
 fi
@@ -119,10 +147,12 @@ fi
 # --- Run --------------------------------------------------------------------
 
 echo "Starting HOMEPOT device emulator ..."
-echo "  Emulator: $EMULATOR_SCRIPT"
-echo "  Python:   $PYTHON"
+echo "  Emulator:  $EMULATOR_SCRIPT"
+echo "  Instance:  $INSTANCE"
+echo "  Python:    $PYTHON"
 echo "  Config args: ${CONFIG_ARGS[*]:-} $*"
-echo "  Log file: $LOG_FILE"
+echo "  Log file:  $LOG_FILE"
+echo "  PID file:  $PID_FILE"
 echo ""
 
 nohup "$PYTHON" -u "$EMULATOR_SCRIPT" "${CONFIG_ARGS[@]}" "$@" \
@@ -141,4 +171,4 @@ fi
 
 echo "Emulator started (PID: $EMULATOR_PID)"
 echo "  View logs:  tail -f $LOG_FILE"
-echo "  Stop:       ./scripts/stop-emulator.sh"
+echo "  Stop:       ./scripts/stop-emulator.sh $INSTANCE"

--- a/scripts/stop-emulator.sh
+++ b/scripts/stop-emulator.sh
@@ -3,9 +3,12 @@
 ################################################################################
 # HOMEPOT Device Emulator Stop Script
 #
-# This script stops a background emulator started via start-emulator.sh.
+# Stops emulator instances started via start-emulator.sh.
 #
-# Usage: ./scripts/stop-emulator.sh
+# Usage:
+#   ./scripts/stop-emulator.sh              # stop ALL emulators
+#   ./scripts/stop-emulator.sh <instance>   # stop one instance by name
+#                                           #   (its --device-name, else type)
 ################################################################################
 
 # Colors for output
@@ -19,7 +22,7 @@ NC='\033[0m'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 
-echo -e "${CYAN}Stopping HOMEPOT device emulator...${NC}\n"
+INSTANCE="${1:-}"
 
 # Function to kill process by PID file
 kill_by_pidfile() {
@@ -44,7 +47,26 @@ kill_by_pidfile() {
     fi
 }
 
-# Stop emulator using PID file
+if [ -n "$INSTANCE" ]; then
+    # Stop a single instance by name (--device-name or emulator type)
+    SLUG="$(printf '%s' "$INSTANCE" | tr ' /' '__')"
+    echo -e "${CYAN}Stopping HOMEPOT device emulator '$INSTANCE'...${NC}\n"
+    kill_by_pidfile "$REPO_ROOT/logs/emulator-${SLUG}.pid" "emulator ($INSTANCE)"
+    echo ""
+    echo -e "${GREEN}Emulator '$INSTANCE' stop requested.${NC}"
+    exit 0
+fi
+
+# Stop ALL emulator instances
+echo -e "${CYAN}Stopping HOMEPOT device emulators...${NC}\n"
+
+for pidfile in "$REPO_ROOT"/logs/emulator-*.pid; do
+    [ -e "$pidfile" ] || continue
+    base=$(basename "$pidfile" .pid)
+    kill_by_pidfile "$pidfile" "emulator ($base)"
+done
+
+# Back-compat: the pre-multi-instance single PID file
 kill_by_pidfile "$REPO_ROOT/logs/emulator.pid" "emulator"
 
 # Fallback: kill any remaining POS emulator processes (any OS wrapper or the engine)
@@ -54,4 +76,4 @@ if pkill -f "emulators/(linux|android|windows|macos|ios)_pos_emulator.py" 2>/dev
 fi
 
 echo ""
-echo -e "${GREEN}HOMEPOT device emulator stopped.${NC}"
+echo -e "${GREEN}HOMEPOT device emulators stopped.${NC}"


### PR DESCRIPTION
## Summary

The emulator launch/stop scripts were built for a **single** emulator (shared `logs/emulator.log` + `logs/emulator.pid` and a single-instance guard). This revises them so several emulators can run at once — e.g. a macOS emulator alongside an Android one, or two of the same OS with different `--device-name`.

## Changes
- **`start-emulator.sh`**: derives a per-instance name from `--device-name` (falling back to the emulator type) and writes `logs/emulator-<instance>.log` / `.pid`. The duplicate guard now only blocks a repeat of the **same** instance, so different instances run concurrently. All other args (`--backend-url`, `--site-id`, `--bootstrap-key`, `--permission-consent-mode`, …) are still forwarded to the emulator.
- **`stop-emulator.sh`**: accepts an optional instance name — `./scripts/stop-emulator.sh <name>` stops one; no argument stops all. Back-compat for the old `emulator.pid` kept.
- **Docs** updated: `device-emulators.md`, `getting-started.md`, `verify-user-app-with-emulators.md` (per-instance log naming + multi-instance usage).

## Example
```bash
./scripts/start-emulator.sh --emulator macos --backend-url http://192.168.1.176:8000 --site-id SITE-7UAH-963T --bootstrap-key homepot-dev-emulator-key --device-name demo-macos-1

tail -f logs/emulator-demo-macos-1.log

./scripts/stop-emulator.sh demo-macos-1
```
Validated: `bash -n` on both scripts and `mkdocs build --strict` pass.