### PR TITLE
fix(emulators): avoid unbound variable on empty CONFIG_ARGS in bash 3.2

### DIFF
--- a/scripts/start-emulator.sh
+++ b/scripts/start-emulator.sh
@@ -160,7 +160,7 @@ echo "  Log file:  $LOG_FILE"
 echo "  PID file:  $PID_FILE"
 echo ""
 
-nohup "$PYTHON" -u "$EMULATOR_SCRIPT" "${CONFIG_ARGS[@]}" "$@" \
+nohup "$PYTHON" -u "$EMULATOR_SCRIPT" ${CONFIG_ARGS[@]+"${CONFIG_ARGS[@]}"} "$@" \
     > "$LOG_FILE" 2>&1 &
 EMULATOR_PID=$!
 echo "$EMULATOR_PID" > "$PID_FILE"


### PR DESCRIPTION
## Problem

When arguments are passed (e.g. `--backend-url`, `--site-id`, ...), `CONFIG_ARGS` stays an empty array. Under macOS's bash 3.2 with `set -u`, expanding `${CONFIG_ARGS[@]}` on an empty array aborts with `CONFIG_ARGS[@]: unbound variable` — so the emulator never launches (and no log is produced, since the failure happens before the nohup line).

## Fix

Use the safe empty-array idiom `${CONFIG_ARGS[@]+"${CONFIG_ARGS[@]}"}` so it expands to nothing when empty, on both bash 3.2 and 5.2.\n\n## Verification\nRan the full command under a built GNU bash 3.2:

- no `unbound variable` error
- correct script/instance/log-file resolution, and the launch proceeds (log/PID files created)