### PR TITLE
feat: device status badges (connectivity/status/health/source) on Dashboard + docs

### DIFF
--- a/docs/device-emulators.md
+++ b/docs/device-emulators.md
@@ -19,6 +19,12 @@ Each emulator runs as an independent process that provisions itself with the bac
 
 ## Quick start
 
+> **Replace `site-it-demo1` with a real site ID from your backend.** It is an
+> example placeholder only — if the site does not exist, provisioning fails
+> with `404 Site not found`. Find your site IDs via the Dashboard (Sites) or
+> `SELECT site_id FROM sites;` on the database, or create a new site first
+> (Sites → *Create Site* / `POST /api/v1/sites`).
+
 ```bash
 # 1. Start the Dashboard (backend + frontend)
 ./scripts/start-dashboard.sh
@@ -26,7 +32,7 @@ Each emulator runs as an independent process that provisions itself with the bac
 # 2. Generate a bootstrap key for your site (via API or operator UI)
 #    POST /api/v1/sites/{site_id}/bootstrap-key
 
-# 3. Run the Linux POS emulator
+# 3. Run the Linux POS emulator (replace site-it-demo1 with a real site ID)
 ./scripts/start-emulator.sh --site-id site-it-demo1 --bootstrap-key <key> --device-name demo-pos-1
 #    Use a different --device-name per emulator to run several on one site
 

--- a/docs/device-lifecycle-and-ownership.md
+++ b/docs/device-lifecycle-and-ownership.md
@@ -525,40 +525,57 @@ The Site Detail page (`frontend/src/pages/Sites/SiteDetail.jsx`) displays a tabl
 |---|---|---|
 | **Name** | `device.name` | Clickable link to Device Detail page |
 | **Type** | `device.device_type` | Uppercase, underscores replaced with spaces |
-| **Status** | `lifecycle_state` + `connectivity_state` + `health_state` | Badge + connectivity dot + health pill (see colour reference below) |
+| **Connectivity** | `device.connectivity_state` | Badge: `ONLINE` / `OFFLINE` / `UNKNOWN` (see colour reference below) |
+| **Status** | `device.lifecycle_state` | Badge: `ACTIVE` / `SUSPENDED` / `UNPAIRED` (see colour reference below) |
+| **Health** | `device.health_state` | Badge: `HEALTHY` / `WARNING` / `ERROR` / `MAINTENANCE` (see colour reference below) |
+| **Mode** | `device.enrollment_method` / `device.device_source` / `device.is_simulated` | Badge: `EMU` (cyan), `SIM` (purple), `REAL` (slate) |
 | **Enrollment** | `device.enrollment_method` | Pill: `self-enrolled` (purple) or `Pre-Provisioned` (blue) |
 | **Alerts** | `device.active_alerts` | Count with icon; green checkmark when zero |
 | **Last Seen** | `device.last_seen` + `device.last_heartbeat_at` | Timestamp plus heartbeat timestamp on a second line |
 | **Actions** | — | Edit and Delete icon buttons |
 
-#### Status column colour reference
+#### Status columns colour reference
 
-**Lifecycle badge (background + text):**
+Each status badge uses **background + text** colours. Green always means "OK",
+red always means "not OK" / needs attention; neutral states (unpaired, unknown)
+are gray.
 
-| State | Colour |
-|---|---|
-| `active` | green-500 on green-500/10 |
-| `suspended` | orange-500 on orange-500/10 |
-| `unpaired` | gray-500 on gray-500/10 |
-| `pending`, `retired`, or unknown | yellow-500 on yellow-500/10 |
-
-**Connectivity dot (within the lifecycle badge):**
+**Connectivity badge:**
 
 | State | Colour |
 |---|---|
-| `online` | green-500 |
-| `offline` | gray-500 |
-| `unknown` | yellow-500 |
+| `online` | emerald-400 text on emerald-500/10, emerald border |
+| `offline` | red-400 text on red-500/10, red border |
+| `unknown` | yellow-400 text on yellow-500/10, yellow border |
 
-**Health pill (separate pill next to the lifecycle badge):**
+**Status badge (lifecycle):**
 
 | State | Colour |
 |---|---|
-| `healthy` | green-400 on green-500/10 |
-| `warning` | yellow-400 on yellow-500/10 |
-| `error` | red-400 on red-500/10 |
-| `maintenance` | blue-400 on blue-500/10 |
-| `unknown` or absent | gray-400 on gray-500/10 |
+| `active` | green-500 text on green-500/10 |
+| `suspended` | orange-500 text on orange-500/10 |
+| `unpaired` | gray-500 text on gray-500/10 |
+| `pending`, `retired`, or unknown | yellow-500 text on yellow-500/10 |
+
+**Health badge:**
+
+| State | Colour |
+|---|---|
+| `healthy` | green-400 text on green-500/10 |
+| `warning` | yellow-400 text on yellow-500/10 |
+| `error` | red-400 text on red-500/10 |
+| `maintenance` | blue-400 text on blue-500/10 |
+| `unknown` or absent | gray-400 text on gray-500/10 |
+
+**Mode badge:**
+
+| State | Colour |
+|---|---|
+| `EMU` (emulated) | cyan-400 text on cyan-500/10, cyan border |
+| `SIM` (simulated) | purple-400 text on purple-500/10, purple border |
+| `REAL` (physical) | slate-400 text on slate-500/10, slate border |
+
+> All badges are rendered **uppercase** at a uniform `text-xs` size.
 
 ## Windows adaptation
 Only after the Linux real-device contract works:

--- a/docs/verify-user-app-with-emulators.md
+++ b/docs/verify-user-app-with-emulators.md
@@ -560,6 +560,7 @@ For **push notification** testing (Compose Push → the emulator polling
 | Symptom | Cause / fix |
 |---------|-------------|
 | "Device name ... already in use" (400) | A live device in the site already uses that name (case-insensitive). Pick a different name, or retire/unpair the old device first. |
+| Emulator exits with `Provisioning failed (404): Site not found` | The `--site-id` does not exist on the backend. `site-it-demo1` is a placeholder — use a real site ID from your backend (Sites page / `SELECT site_id FROM sites;`) or create the site first. |
 | User App opens on Home instead of the Setup wizard | The device is already provisioned (`~/.homepot/credentials` exists). Relaunch with `./scripts/start-userapp.sh --reset` to clear it and start a fresh setup. |
 | User App window is gone but the app is still running | Closing the window hides it to the system tray (the process, running emulator, and setup state are preserved). Re-run `./scripts/start-userapp.sh` to reopen the window, or click the tray icon. |
 | Device never appears on the Dashboard | Bootstrap key typo, or wrong `--site-id`. The key is single-use-ish — generate a new one in Step 2. |

--- a/frontend/src/pages/Device/DeviceWidgets.jsx
+++ b/frontend/src/pages/Device/DeviceWidgets.jsx
@@ -511,7 +511,7 @@ export const DeviceInfoWidget = ({ device }) => (
         </span>
       </div>
       <div className="flex justify-between">
-        <span className="text-slate-400">Mode</span>
+        <span className="text-slate-400">Source</span>
         {device?.enrollment_method === 'emulated' || device?.device_source === 'emulator' ? (
           <span className="px-2 py-0.5 rounded text-xs font-medium bg-cyan-500/10 text-cyan-400 border border-cyan-500/20">
             EMU

--- a/frontend/src/pages/Device/DeviceWidgets.jsx
+++ b/frontend/src/pages/Device/DeviceWidgets.jsx
@@ -470,23 +470,23 @@ export const DeviceInfoWidget = ({ device }) => (
               ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20'
               : device?.connectivity_state === 'offline'
                 ? 'bg-red-500/10 text-red-400 border border-red-500/20'
-                : 'bg-slate-700 text-slate-300'
+                : 'bg-yellow-500/10 text-yellow-400 border border-yellow-500/20'
           }`}
         >
           {device?.connectivity_state || 'UNKNOWN'}
         </span>
       </div>
       <div className="flex justify-between">
-        <span className="text-slate-400">Lifecycle</span>
+        <span className="text-slate-400">Status</span>
         <span
           className={`px-2 py-0.5 rounded text-xs font-medium uppercase ${
             device?.lifecycle_state === 'active'
-              ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20'
+              ? 'bg-green-500/10 text-green-500 border border-green-500/20'
               : device?.lifecycle_state === 'suspended'
-                ? 'bg-orange-500/10 text-orange-400 border border-orange-500/20'
+                ? 'bg-orange-500/10 text-orange-500 border border-orange-500/20'
                 : device?.lifecycle_state === 'unpaired'
-                  ? 'bg-gray-500/10 text-gray-400 border border-gray-500/20'
-                  : 'bg-yellow-500/10 text-yellow-400 border border-yellow-500/20'
+                  ? 'bg-gray-500/10 text-gray-500 border border-gray-500/20'
+                  : 'bg-yellow-500/10 text-yellow-500 border border-yellow-500/20'
           }`}
         >
           {device?.lifecycle_state || 'N/A'}
@@ -497,18 +497,34 @@ export const DeviceInfoWidget = ({ device }) => (
         <span
           className={`px-2 py-0.5 rounded text-xs font-medium uppercase ${
             device?.health_state === 'healthy'
-              ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20'
+              ? 'bg-green-500/10 text-green-400 border border-green-500/20'
               : device?.health_state === 'warning'
                 ? 'bg-yellow-500/10 text-yellow-400 border border-yellow-500/20'
                 : device?.health_state === 'error'
                   ? 'bg-red-500/10 text-red-400 border border-red-500/20'
                   : device?.health_state === 'maintenance'
                     ? 'bg-blue-500/10 text-blue-400 border border-blue-500/20'
-                    : 'bg-slate-700 text-slate-300'
+                    : 'bg-gray-500/10 text-gray-400 border border-gray-500/20'
           }`}
         >
           {device?.health_state || 'UNKNOWN'}
         </span>
+      </div>
+      <div className="flex justify-between">
+        <span className="text-slate-400">Mode</span>
+        {device?.enrollment_method === 'emulated' || device?.device_source === 'emulator' ? (
+          <span className="px-2 py-0.5 rounded text-xs font-medium bg-cyan-500/10 text-cyan-400 border border-cyan-500/20">
+            EMU
+          </span>
+        ) : device?.is_simulated ? (
+          <span className="px-2 py-0.5 rounded text-xs font-medium bg-purple-500/10 text-purple-400 border border-purple-500/20">
+            SIM
+          </span>
+        ) : (
+          <span className="px-2 py-0.5 rounded text-xs font-medium bg-slate-500/10 text-slate-400 border border-slate-500/20">
+            REAL
+          </span>
+        )}
       </div>
       <div className="flex justify-between">
         <span className="text-slate-400">Credential</span>
@@ -522,21 +538,6 @@ export const DeviceInfoWidget = ({ device }) => (
           {device?.credential_status || 'N/A'}
         </span>
       </div>
-      {device?.enrollment_method === 'emulated' || device?.device_source === 'emulator' ? (
-        <div className="flex justify-between">
-          <span className="text-slate-400">Source</span>
-          <span className="px-2 py-0.5 rounded text-xs font-medium bg-cyan-500/10 text-cyan-400 border border-cyan-500/20">
-            EMULATED
-          </span>
-        </div>
-      ) : device?.is_simulated ? (
-        <div className="flex justify-between">
-          <span className="text-slate-400">Source</span>
-          <span className="px-2 py-0.5 rounded text-xs font-medium bg-purple-500/10 text-purple-400 border border-purple-500/20">
-            SIMULATED
-          </span>
-        </div>
-      ) : null}
       <div className="flex justify-between">
         <span className="text-slate-400">IP Address</span>
         <span className="text-slate-200 font-mono">

--- a/frontend/src/pages/Device/DeviceWidgets.jsx
+++ b/frontend/src/pages/Device/DeviceWidgets.jsx
@@ -463,7 +463,7 @@ export const DeviceInfoWidget = ({ device }) => (
     <div className="border-t border-[#1f2735] mb-3"></div>
     <div className="space-y-3 text-sm">
       <div className="flex justify-between items-center">
-        <span className="text-slate-400">Status</span>
+        <span className="text-slate-400">Connectivity</span>
         <span
           className={`px-2 py-0.5 rounded text-xs font-medium uppercase ${
             device?.connectivity_state === 'online'

--- a/frontend/src/pages/Sites/SiteDetail.jsx
+++ b/frontend/src/pages/Sites/SiteDetail.jsx
@@ -417,7 +417,10 @@ export default function SiteDetail() {
               columns={[
                 { key: 'name', label: 'Name' },
                 { key: 'type', label: 'Type' },
+                { key: 'conn', label: 'Conn' },
                 { key: 'status', label: 'Status' },
+                { key: 'health', label: 'Health' },
+                { key: 'mode', label: 'Mode' },
                 { key: 'enrollment', label: 'Enrollment' },
                 { key: 'alerts', label: 'Alerts' },
                 { key: 'last_seen', label: 'Last Seen' },
@@ -453,66 +456,74 @@ export default function SiteDetail() {
                     )}
                   </td>
                   <td className="p-4 align-middle">
-                    <div className="flex items-center gap-2">
+                    <span
+                      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium uppercase ${
+                        device.connectivity_state === 'online'
+                          ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20'
+                          : device.connectivity_state === 'offline'
+                            ? 'bg-gray-500/10 text-gray-400 border border-gray-500/20'
+                            : 'bg-yellow-500/10 text-yellow-400 border border-yellow-500/20'
+                      }`}
+                    >
                       <span
-                        className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium uppercase ${
+                        className={`w-1.5 h-1.5 rounded-full ${
                           device.connectivity_state === 'online'
-                            ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20'
+                            ? 'bg-emerald-400'
                             : device.connectivity_state === 'offline'
-                              ? 'bg-gray-500/10 text-gray-400 border border-gray-500/20'
-                              : 'bg-yellow-500/10 text-yellow-400 border border-yellow-500/20'
+                              ? 'bg-gray-400'
+                              : 'bg-yellow-400'
                         }`}
-                      >
-                        <span
-                          className={`w-1.5 h-1.5 rounded-full ${
-                            device.connectivity_state === 'online'
-                              ? 'bg-emerald-400'
-                              : device.connectivity_state === 'offline'
-                                ? 'bg-gray-400'
-                                : 'bg-yellow-400'
-                          }`}
-                        />
-                        {device.connectivity_state || 'unknown'}
+                      />
+                      {device.connectivity_state || 'unknown'}
+                    </span>
+                  </td>
+                  <td className="p-4 align-middle">
+                    <span
+                      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                        device.lifecycle_state === 'active'
+                          ? 'bg-green-500/10 text-green-500'
+                          : device.lifecycle_state === 'suspended'
+                            ? 'bg-orange-500/10 text-orange-500'
+                            : device.lifecycle_state === 'unpaired'
+                              ? 'bg-gray-500/10 text-gray-500'
+                              : 'bg-yellow-500/10 text-yellow-500'
+                      }`}
+                    >
+                      {device.lifecycle_state || 'Unknown'}
+                    </span>
+                  </td>
+                  <td className="p-4 align-middle">
+                    <span
+                      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                        device.health_state === 'healthy'
+                          ? 'bg-green-500/10 text-green-400'
+                          : device.health_state === 'warning'
+                            ? 'bg-yellow-500/10 text-yellow-400'
+                            : device.health_state === 'error'
+                              ? 'bg-red-500/10 text-red-400'
+                              : device.health_state === 'maintenance'
+                                ? 'bg-blue-500/10 text-blue-400'
+                                : 'bg-gray-500/10 text-gray-400'
+                      }`}
+                    >
+                      {device.health_state || 'unknown'}
+                    </span>
+                  </td>
+                  <td className="p-4 align-middle">
+                    {device.enrollment_method === 'emulated' ||
+                    device.device_source === 'emulator' ? (
+                      <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium bg-cyan-500/10 text-cyan-400 border border-cyan-500/20">
+                        EMU
                       </span>
-                      <span
-                        className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                          device.lifecycle_state === 'active'
-                            ? 'bg-green-500/10 text-green-500'
-                            : device.lifecycle_state === 'suspended'
-                              ? 'bg-orange-500/10 text-orange-500'
-                              : device.lifecycle_state === 'unpaired'
-                                ? 'bg-gray-500/10 text-gray-500'
-                                : 'bg-yellow-500/10 text-yellow-500'
-                        }`}
-                      >
-                        {device.lifecycle_state || 'Unknown'}
+                    ) : device.is_simulated ? (
+                      <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium bg-purple-500/10 text-purple-400 border border-purple-500/20">
+                        SIM
                       </span>
-                      <span
-                        className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium ${
-                          device.health_state === 'healthy'
-                            ? 'bg-green-500/10 text-green-400'
-                            : device.health_state === 'warning'
-                              ? 'bg-yellow-500/10 text-yellow-400'
-                              : device.health_state === 'error'
-                                ? 'bg-red-500/10 text-red-400'
-                                : device.health_state === 'maintenance'
-                                  ? 'bg-blue-500/10 text-blue-400'
-                                  : 'bg-gray-500/10 text-gray-400'
-                        }`}
-                      >
-                        {device.health_state || 'unknown'}
+                    ) : (
+                      <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium bg-slate-500/10 text-slate-400 border border-slate-500/20">
+                        REAL
                       </span>
-                      {device.enrollment_method === 'emulated' ||
-                      device.device_source === 'emulator' ? (
-                        <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium bg-cyan-500/10 text-cyan-400 border border-cyan-500/20">
-                          EMU
-                        </span>
-                      ) : device.is_simulated ? (
-                        <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium bg-purple-500/10 text-purple-400 border border-purple-500/20">
-                          SIM
-                        </span>
-                      ) : null}
-                    </div>
+                    )}
                   </td>
                   <td className="p-4 align-middle">
                     <span

--- a/frontend/src/pages/Sites/SiteDetail.jsx
+++ b/frontend/src/pages/Sites/SiteDetail.jsx
@@ -485,7 +485,7 @@ export default function SiteDetail() {
                   </td>
                   <td className="p-4 align-middle">
                     <span
-                      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium uppercase ${
+                      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium uppercase ${
                         device.health_state === 'healthy'
                           ? 'bg-green-500/10 text-green-400'
                           : device.health_state === 'warning'
@@ -503,15 +503,15 @@ export default function SiteDetail() {
                   <td className="p-4 align-middle">
                     {device.enrollment_method === 'emulated' ||
                     device.device_source === 'emulator' ? (
-                      <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium bg-cyan-500/10 text-cyan-400 border border-cyan-500/20">
+                      <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium bg-cyan-500/10 text-cyan-400 border border-cyan-500/20">
                         EMU
                       </span>
                     ) : device.is_simulated ? (
-                      <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium bg-purple-500/10 text-purple-400 border border-purple-500/20">
+                      <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium bg-purple-500/10 text-purple-400 border border-purple-500/20">
                         SIM
                       </span>
                     ) : (
-                      <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium bg-slate-500/10 text-slate-400 border border-slate-500/20">
+                      <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium bg-slate-500/10 text-slate-400 border border-slate-500/20">
                         REAL
                       </span>
                     )}

--- a/frontend/src/pages/Sites/SiteDetail.jsx
+++ b/frontend/src/pages/Sites/SiteDetail.jsx
@@ -420,7 +420,7 @@ export default function SiteDetail() {
                 { key: 'conn', label: 'Connectivity' },
                 { key: 'status', label: 'Status' },
                 { key: 'health', label: 'Health' },
-                { key: 'mode', label: 'Mode' },
+                { key: 'mode', label: 'Source' },
                 { key: 'enrollment', label: 'Enrollment' },
                 { key: 'alerts', label: 'Alerts' },
                 { key: 'last_seen', label: 'Last Seen' },

--- a/frontend/src/pages/Sites/SiteDetail.jsx
+++ b/frontend/src/pages/Sites/SiteDetail.jsx
@@ -455,6 +455,26 @@ export default function SiteDetail() {
                   <td className="p-4 align-middle">
                     <div className="flex items-center gap-2">
                       <span
+                        className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium uppercase ${
+                          device.connectivity_state === 'online'
+                            ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20'
+                            : device.connectivity_state === 'offline'
+                              ? 'bg-gray-500/10 text-gray-400 border border-gray-500/20'
+                              : 'bg-yellow-500/10 text-yellow-400 border border-yellow-500/20'
+                        }`}
+                      >
+                        <span
+                          className={`w-1.5 h-1.5 rounded-full ${
+                            device.connectivity_state === 'online'
+                              ? 'bg-emerald-400'
+                              : device.connectivity_state === 'offline'
+                                ? 'bg-gray-400'
+                                : 'bg-yellow-400'
+                          }`}
+                        />
+                        {device.connectivity_state || 'unknown'}
+                      </span>
+                      <span
                         className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${
                           device.lifecycle_state === 'active'
                             ? 'bg-green-500/10 text-green-500'

--- a/frontend/src/pages/Sites/SiteDetail.jsx
+++ b/frontend/src/pages/Sites/SiteDetail.jsx
@@ -417,7 +417,7 @@ export default function SiteDetail() {
               columns={[
                 { key: 'name', label: 'Name' },
                 { key: 'type', label: 'Type' },
-                { key: 'conn', label: 'Conn' },
+                { key: 'conn', label: 'Connectivity' },
                 { key: 'status', label: 'Status' },
                 { key: 'health', label: 'Health' },
                 { key: 'mode', label: 'Mode' },
@@ -465,21 +465,12 @@ export default function SiteDetail() {
                             : 'bg-yellow-500/10 text-yellow-400 border border-yellow-500/20'
                       }`}
                     >
-                      <span
-                        className={`w-1.5 h-1.5 rounded-full ${
-                          device.connectivity_state === 'online'
-                            ? 'bg-emerald-400'
-                            : device.connectivity_state === 'offline'
-                              ? 'bg-gray-400'
-                              : 'bg-yellow-400'
-                        }`}
-                      />
                       {device.connectivity_state || 'unknown'}
                     </span>
                   </td>
                   <td className="p-4 align-middle">
                     <span
-                      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium uppercase ${
                         device.lifecycle_state === 'active'
                           ? 'bg-green-500/10 text-green-500'
                           : device.lifecycle_state === 'suspended'
@@ -489,12 +480,12 @@ export default function SiteDetail() {
                               : 'bg-yellow-500/10 text-yellow-500'
                       }`}
                     >
-                      {device.lifecycle_state || 'Unknown'}
+                      {device.lifecycle_state || 'UNKNOWN'}
                     </span>
                   </td>
                   <td className="p-4 align-middle">
                     <span
-                      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium uppercase ${
                         device.health_state === 'healthy'
                           ? 'bg-green-500/10 text-green-400'
                           : device.health_state === 'warning'
@@ -506,7 +497,7 @@ export default function SiteDetail() {
                                 : 'bg-gray-500/10 text-gray-400'
                       }`}
                     >
-                      {device.health_state || 'unknown'}
+                      {device.health_state || 'UNKNOWN'}
                     </span>
                   </td>
                   <td className="p-4 align-middle">

--- a/frontend/src/pages/Sites/SiteDetail.jsx
+++ b/frontend/src/pages/Sites/SiteDetail.jsx
@@ -461,7 +461,7 @@ export default function SiteDetail() {
                         device.connectivity_state === 'online'
                           ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20'
                           : device.connectivity_state === 'offline'
-                            ? 'bg-gray-500/10 text-gray-400 border border-gray-500/20'
+                            ? 'bg-red-500/10 text-red-400 border border-red-500/20'
                             : 'bg-yellow-500/10 text-yellow-400 border border-yellow-500/20'
                       }`}
                     >


### PR DESCRIPTION
## Summary

Single consolidated PR for the device status badge work across the Dashboard and its documentation.

## UI (Site Detail & Device pages)

- **Site Detail → Associated Devices**: split the single Status column into labeled **Connectivity / Status / Health / Source** columns, so a device's online/offline state is trackable from the site page.
- **Connectivity** badge: ONLINE (green) / OFFLINE (red) / UNKNOWN (yellow).
- **Status** badge (lifecycle): ACTIVE (green) / SUSPENDED (orange) / UNPAIRED (gray).
- **Health** badge: HEALTHY (green) / WARNING (yellow) / ERROR (red) / MAINTENANCE (blue).
- **Source** badge: EMU (cyan) / SIM (purple) / REAL (slate) — always shown.
- All badges uppercase, uniform `text-xs`, consistent green=OK / red=not-OK colour scheme.
- **Device page DEVICE INFO** (right side): now presents the same scheme — Connectivity, Status (was Lifecycle), Health, Source (was Mode), Credential — with matching colours.

## Docs

- `device-lifecycle-and-ownership.md`: colour reference for the Status columns.
- `device-emulators.md` / `verify-user-app-with-emulators.md`: clarify that `site-it-demo1` is a placeholder site ID (provisioning 404s if the site doesn't exist).

## Validation

ESLint, prettier, `npm run build`, and `mkdocs build --strict` all pass.

Consolidates `ui/connectivity-badges`, `docs/status-colour-reference`, and `docs/site-id-placeholder-clarify`.