### PR TITLE
feat(emulators): log start/stop timestamps and PID

### DIFF
--- a/emulators/pos_engine.py
+++ b/emulators/pos_engine.py
@@ -49,6 +49,7 @@ import asyncio
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import json
+import os
 from pathlib import Path
 import random
 import signal
@@ -1749,12 +1750,20 @@ def main(
     for sig in (signal.SIGTERM, signal.SIGINT):
         loop.add_signal_handler(sig, _signal_handler)
 
+    print(
+        f"\n  Started at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+        f" (PID {os.getpid()})"
+    )
+
     try:
         loop.run_until_complete(emulator.start())
     except KeyboardInterrupt:
         pass
     finally:
-        print("  Emulator stopped.")
+        print(
+            f"  Emulator stopped at "
+            f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')} (PID {os.getpid()})"
+        )
         loop.close()
 
 


### PR DESCRIPTION
## Summary

Adds start/stop timestamps and the PID to the emulator log, so it is easy to tell which emulator process is which when debugging start/stop behaviour.

## Change

- On launch: `Started at <time> (PID <pid>)`
- On shutdown: `Emulator stopped at <time> (PID <pid>)`

This helps correlate the log with `ps aux` when multiple emulator instances share credentials (e.g. a leftover process still heartbeating after a stop).

## Validation

`flake8` and `black` pass; verified the messages render under a built GNU bash 3.2 run.