### PR TITLE
fix(sites): derive site online status from heartbeat recency

### DIFF
--- a/backend/src/homepot/app/api/API_v1/Endpoints/SitesEndpoint.py
+++ b/backend/src/homepot/app/api/API_v1/Endpoints/SitesEndpoint.py
@@ -1,5 +1,6 @@
 """API endpoints for managing sites in the HomePot system."""
 
+from datetime import datetime, timezone
 import logging
 from typing import Any, Dict, List, Optional, cast
 
@@ -42,6 +43,25 @@ logger = logging.getLogger(__name__)
 
 
 router = APIRouter()
+
+
+# A site counts as Online when any of its active devices has heartbeated
+# recently. This mirrors the device page's connectivity_state computation —
+# it must NOT rely on the stored Device.status field, which is only set to
+# OFFLINE on explicit events (unpair/delete) and otherwise stays ONLINE.
+_HEARTBEAT_ONLINE_SECONDS = 120
+
+
+def _device_is_online(device: Device) -> bool:
+    """Return True if the device heartbeated within the online window."""
+    heartbeat = device.last_heartbeat_at
+    if not heartbeat:
+        return False
+    if heartbeat.tzinfo is None:
+        heartbeat = heartbeat.replace(tzinfo=timezone.utc)
+    delta = datetime.now(timezone.utc) - heartbeat
+    is_online: bool = delta.total_seconds() <= _HEARTBEAT_ONLINE_SECONDS
+    return is_online
 
 
 class SiteHealthResponse(BaseModel):
@@ -212,14 +232,18 @@ async def list_sites(
 
                 # Determine status. Only ACTIVE devices contribute to the site's
                 # connectivity status — suspended/unpaired devices (e.g. on an
-                # archived site) must not make the site appear online.
+                # archived site) must not make the site appear online. Online is
+                # based on heartbeat recency (not the stored status field), and
+                # takes precedence: if any active device is online the site is
+                # Online; otherwise a device in error state makes it Warning;
+                # otherwise Offline.
                 active_devices = [d for d in devices if d.is_active]
                 status = "Offline"
                 if active_devices:
-                    if any(d.status == "error" for d in active_devices):
-                        status = "Warning"
-                    elif any(d.status == "online" for d in active_devices):
+                    if any(_device_is_online(d) for d in active_devices):
                         status = "Online"
+                    elif any(d.status == "error" for d in active_devices):
+                        status = "Warning"
 
                 # Collect OS types
                 os_types = set()

--- a/emulators/pos_engine.py
+++ b/emulators/pos_engine.py
@@ -49,6 +49,7 @@ import asyncio
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import json
+import os
 from pathlib import Path
 import random
 import signal
@@ -1749,12 +1750,20 @@ def main(
     for sig in (signal.SIGTERM, signal.SIGINT):
         loop.add_signal_handler(sig, _signal_handler)
 
+    print(
+        f"\n  Started at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+        f" (PID {os.getpid()})"
+    )
+
     try:
         loop.run_until_complete(emulator.start())
     except KeyboardInterrupt:
         pass
     finally:
-        print("  Emulator stopped.")
+        print(
+            f"  Emulator stopped at "
+            f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')} (PID {os.getpid()})"
+        )
         loop.close()
 
 

--- a/frontend/src/pages/Sites/SitesList.jsx
+++ b/frontend/src/pages/Sites/SitesList.jsx
@@ -398,7 +398,13 @@ export default function SitesList() {
                   <div className="flex flex-col gap-2 mb-3">
                     <div className="flex items-center gap-2">
                       <span
-                        className={`w-3 h-3 rounded-full ${site.status === 'Online' ? 'bg-green-400' : 'bg-red-500'}`}
+                        className={`w-3 h-3 rounded-full ${
+                          site.status === 'Online'
+                            ? 'bg-green-400'
+                            : site.status === 'Warning'
+                              ? 'bg-yellow-400'
+                              : 'bg-red-500'
+                        }`}
                       ></span>
                       <span className="text-sm">{site.status}</span>
                     </div>


### PR DESCRIPTION
## Problem

The **Manage Sites** page (and the sites list API) computed a site's status from the stored `Device.status` field. That field is only set to `OFFLINE` on explicit events (unpair/delete) and **never flips when a device stops heartbeating** — so a site stayed **Online** indefinitely after its emulator/devices went offline.

## Fix

Base the site status on **heartbeat recency** (mirroring the device page's `connectivity_state`, 120s window):

- **Online** if any *active* device heartbeated within 120s (online takes precedence)
- **Warning** if a device is in `error` state (and none online)
- otherwise **Offline**

Frontend: show a **yellow** dot for Warning (was red).

## Verification

- With the Mac emulator stopped (last heartbeat 16 min ago) but its stored `device.status` still `online`, the site now correctly reports **Offline** (old logic would say Online).
- `flake8`, `black`, `isort`, `mypy` pass; site-related pytest suite green (22 passed); frontend eslint/prettier/build pass.