### PR TITLE
feat(scripts): simulation/emulation mode switcher

### DIFF
--- a/docs/device-emulators.md
+++ b/docs/device-emulators.md
@@ -17,6 +17,26 @@ Each emulator runs as an independent process that provisions itself with the bac
     [Getting started — Simulation](getting-started.md) for what the simulator
     does when enabled.
 
+### Switching between simulation and emulation
+
+Use the helper to switch the backend between the two modes without editing
+`.env` by hand:
+
+```bash
+./scripts/set-simulation-mode.sh on    # simulation: backend simulates all devices (no emulator)
+./scripts/set-simulation-mode.sh off   # emulation: only real emulators provide data
+```
+
+- **`on`** sets `ENABLE_AGENT_SIMULATION=true`, restarts the backend, and stops
+  any running emulators first (the simulator would otherwise double-simulate
+  the emulator's device and corrupt provenance).
+- **`off`** sets `ENABLE_AGENT_SIMULATION=false` and restarts the backend; start
+  your emulator(s) afterwards.
+
+> Only **one** mode should be active at a time for a given device. With
+> simulation on, the simulator also marks the emulator's device online and
+> writes telemetry for it, even if the emulator is not running.
+
 ## Quick start
 
 > **Replace `site-it-demo1` with a real site ID from your backend.** It is an

--- a/scripts/set-simulation-mode.sh
+++ b/scripts/set-simulation-mode.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+################################################################################
+# HOMEPOT Simulation Mode Switcher
+#
+# Seamlessly toggles the backend between the two data-source modes:
+#
+#   on  (simulation)  ENABLE_AGENT_SIMULATION=true  — the in-process agent
+#                     simulator drives every active POS/IoT device (no emulator
+#                     needed). Any running emulators are stopped first so they
+#                     are not double-simulated.
+#
+#   off (emulation)   ENABLE_AGENT_SIMULATION=false — only real emulators /
+#                     devices provide data. The backend no longer simulates.
+#                     Start the emulator(s) yourself afterwards.
+#
+# Usage:
+#   ./scripts/set-simulation-mode.sh on
+#   ./scripts/set-simulation-mode.sh off
+################################################################################
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PYTHON="$REPO_ROOT/.venv/bin/python"
+ENV_FILE="$REPO_ROOT/backend/.env"
+LOG_FILE="$REPO_ROOT/logs/backend.out"
+PID_FILE="$REPO_ROOT/logs/backend.pid"
+
+if [[ ! -f "$PYTHON" ]]; then
+    echo "Error: Python virtual environment not found at .venv/"
+    exit 1
+fi
+
+# --- Parse mode --------------------------------------------------------------
+
+MODE="${1:-}"
+case "$MODE" in
+    on|true|1)  ENABLED="true";  MODE_LABEL="SIMULATION";;
+    off|false|0) ENABLED="false"; MODE_LABEL="EMULATION";;
+    *)
+        echo "Usage: $0 on|off"
+        echo "  on  = simulation mode (ENABLE_AGENT_SIMULATION=true)"
+        echo "  off = emulation mode  (ENABLE_AGENT_SIMULATION=false)"
+        exit 1
+        ;;
+esac
+
+echo "=== Switching HOMEPOT backend to $MODE_LABEL mode ==="
+
+# --- When going to simulation, stop any running emulators --------------------
+# The simulator would otherwise also simulate the emulator's device (double
+# data + provenance corruption).
+if [[ "$ENABLED" == "true" ]] && [[ -x "$SCRIPT_DIR/stop-emulator.sh" ]]; then
+    echo ">> Stopping any running emulators (simulator would double-simulate them)"
+    "$SCRIPT_DIR/stop-emulator.sh" || true
+fi
+
+# --- Stop the backend --------------------------------------------------------
+# Kill via PID file, the uvicorn reloader, and the multiprocessing worker
+# (whose cmdline is 'spawn_main' and is missed by 'uvicorn' patterns).
+kill_by_pidfile() {
+    local pidfile=$1
+    if [[ -f "$pidfile" ]]; then
+        local pid
+        pid=$(cat "$pidfile" 2>/dev/null || true)
+        if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+            kill "$pid" 2>/dev/null || true
+            sleep 1
+            kill -9 "$pid" 2>/dev/null || true
+        fi
+        rm -f "$pidfile"
+    fi
+}
+kill_by_pidfile "$PID_FILE"
+pkill -f "uvicorn homepot.app.main" 2>/dev/null || true
+pkill -f "spawn_main" 2>/dev/null || true
+sleep 2
+
+echo ">> Updating $ENV_FILE -> ENABLE_AGENT_SIMULATION=$ENABLED"
+if grep -q '^ENABLE_AGENT_SIMULATION=' "$ENV_FILE"; then
+    sed -i.bak "s/^ENABLE_AGENT_SIMULATION=.*/ENABLE_AGENT_SIMULATION=$ENABLED/" "$ENV_FILE"
+    rm -f "$ENV_FILE.bak"
+else
+    echo "ENABLE_AGENT_SIMULATION=$ENABLED" >> "$ENV_FILE"
+fi
+
+# --- Start the backend -------------------------------------------------------
+echo ">> Starting backend ($MODE_LABEL mode)..."
+mkdir -p "$REPO_ROOT/logs"
+cd "$REPO_ROOT/backend"
+setsid env ENABLE_AGENT_SIMULATION="$ENABLED" \
+    "$PYTHON" -m uvicorn homepot.app.main:app \
+    --host 0.0.0.0 --port 8000 \
+    --reload --reload-dir src --reload-dir ../ai \
+    --app-dir "$REPO_ROOT/backend/src" \
+    > "$LOG_FILE" 2>&1 < /dev/null &
+BACKEND_PID=$!
+echo "$BACKEND_PID" > "$PID_FILE"
+
+echo ">> Waiting for the backend to come up..."
+for _ in $(seq 1 30); do
+    if curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/api/v1/health 2>/dev/null | grep -q "200"; then
+        break
+    fi
+    sleep 1
+done
+
+if curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/api/v1/health 2>/dev/null | grep -q "200"; then
+    echo "=== Backend is up (PID $BACKEND_PID) in $MODE_LABEL mode ==="
+    echo "  Log: tail -f $LOG_FILE"
+else
+    echo "Error: backend did not become healthy. Check logs: $LOG_FILE"
+    exit 1
+fi

--- a/scripts/start-dashboard.sh
+++ b/scripts/start-dashboard.sh
@@ -6,7 +6,10 @@
 # This script starts both the backend and frontend servers for the complete
 # HOMEPOT dashboard experience with full integration.
 #
-# Usage: ./scripts/start-dashboard.sh
+# Usage: ./scripts/start-dashboard.sh [simulation|emulation|real]
+#   simulation  Simulated devices via the in-process agent simulator (default)
+#   emulation   Emulated devices via emulator processes started separately
+#   real        Real devices (flag provisioned; backend support pending)
 ################################################################################
 
 set -e
@@ -28,6 +31,42 @@ echo -e "${CYAN}║                                                             
 echo -e "${CYAN}║                  HOMEPOT COMPLETE DASHBOARD SETUP              ║${NC}"
 echo -e "${CYAN}║                                                                ║${NC}"
 echo -e "${CYAN}╚════════════════════════════════════════════════════════════════╝${NC}"
+echo ""
+
+################################################################################
+# Mode selection
+################################################################################
+# The dashboard can run in three data-source modes:
+#   simulation — the backend's in-process agent simulator drives the devices
+#   emulation  — emulator processes (started separately) provide the data
+#   real       — real device agents connect (flag provisioned; not yet wired)
+#
+# Emulation and real both require the simulator to be OFF; the difference is
+# only what connects. The mode is persisted to backend/.env so the backend
+# honours it regardless of how it is launched.
+MODE="${1:-simulation}"
+case "$MODE" in
+    simulation)
+        ENABLE_AGENT_SIMULATION="true"
+        MODE_LABEL="SIMULATION"
+        ;;
+    emulation)
+        ENABLE_AGENT_SIMULATION="false"
+        MODE_LABEL="EMULATION"
+        ;;
+    real)
+        ENABLE_AGENT_SIMULATION="false"
+        MODE_LABEL="REAL"
+        ;;
+    *)
+        echo "Usage: $0 [simulation|emulation|real]"
+        echo "  simulation  Simulated devices via the in-process agent simulator (default)"
+        echo "  emulation   Emulated devices via emulator processes you start separately"
+        echo "  real        Real devices (flag provisioned; backend support pending)"
+        exit 1
+        ;;
+esac
+echo -e "${CYAN}ℹ${NC} Mode: $MODE_LABEL (ENABLE_AGENT_SIMULATION=$ENABLE_AGENT_SIMULATION)"
 echo ""
 
 ################################################################################
@@ -189,12 +228,23 @@ mkdir -p "$REPO_ROOT/logs"
 # Start backend in background
 print_info "Starting backend server on http://localhost:8000..."
 cd "$REPO_ROOT/backend"
+
+# Persist the selected mode to backend/.env so the backend honours it
+# regardless of how it is launched afterwards.
+ENV_FILE="$REPO_ROOT/backend/.env"
+if [ -f "$ENV_FILE" ] && grep -q '^ENABLE_AGENT_SIMULATION=' "$ENV_FILE"; then
+    sed -i.bak "s/^ENABLE_AGENT_SIMULATION=.*/ENABLE_AGENT_SIMULATION=$ENABLE_AGENT_SIMULATION/" "$ENV_FILE"
+    rm -f "$ENV_FILE.bak"
+else
+    echo "ENABLE_AGENT_SIMULATION=$ENABLE_AGENT_SIMULATION" >> "$ENV_FILE"
+fi
+
 # Use bash -c to activate venv in the subshell
 # Redirect stdout/stderr to backend.out (overwritten on start)
 # The application handles backend.log with rotation
 # --reload-dir watches the ai/ package (outside backend/) too, so edits to the
 # AI gates/context code trigger an auto-restart alongside backend changes.
-nohup bash -c "source $REPO_ROOT/.venv/bin/activate && python -m uvicorn homepot.app.main:app --host 0.0.0.0 --port 8000 --reload --reload-dir src --reload-dir ../ai" \
+nohup bash -c "source $REPO_ROOT/.venv/bin/activate && ENABLE_AGENT_SIMULATION=$ENABLE_AGENT_SIMULATION python -m uvicorn homepot.app.main:app --host 0.0.0.0 --port 8000 --reload --reload-dir src --reload-dir ../ai" \
     > "$REPO_ROOT/logs/backend.out" 2>&1 &
 BACKEND_PID=$!
 echo $BACKEND_PID > "$REPO_ROOT/logs/backend.pid"
@@ -295,6 +345,21 @@ echo ""
 echo -e "${GREEN}Process IDs:${NC}"
 echo -e "  Backend:  $BACKEND_PID"
 echo -e "  Frontend: $FRONTEND_PID"
+echo ""
+
+echo -e "${GREEN}Mode:${NC} $MODE_LABEL"
+case "$MODE" in
+    simulation)
+        echo -e "  ${CYAN}Simulated devices are driven by the backend simulator.${NC}"
+        ;;
+    emulation)
+        echo -e "  ${CYAN}Start emulators separately, e.g.:${NC}"
+        echo -e "  ${CYAN}  ./scripts/start-emulator.sh --emulator macos --site-id <id> --bootstrap-key <key> --device-name demo-pos-1${NC}"
+        ;;
+    real)
+        echo -e "  ${YELLOW}Real-device support is provisioned but not yet wired up.${NC}"
+        ;;
+esac
 echo ""
 echo -e "${GREEN}Log Files:${NC}"
 echo -e "  Backend:  $REPO_ROOT/logs/backend.log"


### PR DESCRIPTION
## Summary

Adds `./scripts/set-simulation-mode.sh on|off` to seamlessly switch the backend between the two data-source modes, and a mode flag to `start-dashboard.sh`.

## set-simulation-mode.sh

- **`on`** (simulation): `ENABLE_AGENT_SIMULATION=true` — the in-process simulator drives every active POS/IoT device (no emulator). Any running emulators are stopped first so they are not double-simulated.
- **`off`** (emulation): `ENABLE_AGENT_SIMULATION=false` — only real emulators provide data.

The script updates `backend/.env`, stops the backend (PID file + uvicorn reloader + multiprocessing `spawn_main` worker, which is missed by plain `uvicorn` patterns), restarts with the env var set explicitly, and waits for health.

## Dashboard mode flag

`start-dashboard.sh` now accepts an optional mode:

- `simulation` (default): `ENABLE_AGENT_SIMULATION=true`, the in-process simulator drives the devices.
- `emulation`: `ENABLE_AGENT_SIMULATION=false`, emulators started separately.
- `real`: flag provisioned (same backend setting as emulation); real-device agent support is pending.

The mode is persisted to `backend/.env` and passed explicitly to uvicorn. Invalid modes print usage and exit before starting services.

## Docs

Added a 'Switching between simulation and emulation' section to `device-emulators.md`.

## Verification

Tested live both directions on the running backend: `off` → sites flip to Offline after the 120s heartbeat window; `on` → 12 simulation agents start and sites return to Online. Invalid mode → usage + exit before starting services.