### PR TITLE
feat(db): separate schema+admin init from demo data seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ We recommend running the project locally without Docker for the best development
     ```bash
     ./scripts/init-postgresql.sh
     ```
+    This creates a **clean** database: schema + default admin user
+    (`admin@homepot.com` / `homepot_dev_password`), with **no** devices. Devices
+    are added explicitly via simulation, emulation, or real devices.
+
+    To also load the **demo / simulated fleet** (tenants, sites, simulated
+    devices, historical analytics), run the opt-in seeder:
+    ```bash
+    ./scripts/seed-demo-data.sh
+    ```
 
 3.  **Run**:
     ```bash
@@ -123,8 +132,11 @@ Simple installation command:
 Working on the UI? Here's the fastest way to get started:
 
 ```bash
-# 1. Create PostgreSQL database
+# 1. Create PostgreSQL database (schema + admin user, no demo data)
 ./scripts/init-postgresql.sh
+
+# (optional) Load the demo/simulated fleet
+./scripts/seed-demo-data.sh
 
 # 2. Start both backend and frontend
 ./scripts/start-dashboard.sh

--- a/backend/utils/seed_data.py
+++ b/backend/utils/seed_data.py
@@ -40,6 +40,7 @@ if project_root not in sys.path:
 
 from ai.anomaly_detection import AnomalyDetector
 
+from homepot.app.api.API_v1.Endpoints.SitesEndpoint import generate_site_id
 from homepot.app.models.AnalyticsModel import (
     Alert,
     APIRequestLog,
@@ -52,7 +53,6 @@ from homepot.app.models.AnalyticsModel import (
     SiteOperatingSchedule,
     UserActivity,
 )
-from homepot.app.api.API_v1.Endpoints.SitesEndpoint import generate_site_id
 from homepot.app.models.UserModel import Base as AppBase
 from homepot.canonical_ids import generate_device_id
 from homepot.database import DatabaseService
@@ -298,13 +298,8 @@ def generate_active_alerts(device_id: str, site_id: int) -> list[Alert]:
     return alerts
 
 
-async def init_database():
-    """Initialize PostgreSQL database with schema and seed data."""
-    print("Importing database service...")
-
-    # Create database service (will use DATABASE__URL from .env)
-    db_service = DatabaseService()
-
+async def init_schema(db_service: DatabaseService) -> None:
+    """Drop existing tables and create the full schema (core + analytics)."""
     _DROP_TABLES = [
         "device_lifecycle_events",
         "lifecycle_epochs",
@@ -350,6 +345,53 @@ async def init_database():
         await conn.run_sync(AppBase.metadata.create_all)
 
     print("Database schema created")
+
+
+async def create_admin_user(db_service: DatabaseService) -> None:
+    """Create the default admin user (no demo data). Idempotent."""
+    print("\n=== Creating Admin User ===")
+    async with db_service.get_session() as session:
+        existing = await session.execute(
+            select(User).where(User.email == "admin@homepot.com")
+        )
+        if existing.scalar_one_or_none() is not None:
+            print("Admin user already exists, skipping")
+            return
+        admin_user = await create_user(
+            session,
+            username="homepot_admin",
+            email="admin@homepot.com",
+            full_name="System Administrator",
+            password="homepot_dev_password",
+            is_admin=True,
+            tenant_id=None,
+        )
+        await session.commit()
+        print(f"Created admin user: {admin_user.username}")
+
+
+async def init_database(schema_only: bool = False):
+    """Initialize the database schema and, optionally, the demo seed data.
+
+    With ``schema_only=True`` only the schema and the default admin user are
+    created — no tenants, sites, simulated devices or demo analytics data.
+    Used by ``init-postgresql.sh`` so a fresh database starts clean and
+    devices are added explicitly (simulation / emulation / real).
+    """
+    print("Importing database service...")
+
+    # Create database service (will use DATABASE__URL from .env)
+    db_service = DatabaseService()
+
+    await init_schema(db_service)
+
+    if schema_only:
+        await create_admin_user(db_service)
+        print("\n" + "=" * 50)
+        print("SCHEMA + ADMIN CREATED (no demo data)")
+        print("=" * 50)
+        await db_service.close()
+        return
 
     # --- TENANTS ---
     print("\n=== Creating Tenants ===")
@@ -531,18 +573,78 @@ async def init_database():
         )
         return device
 
-    _linux_caps = {"root_access": True, "process_monitoring": True, "filesystem_access": True, "network_monitoring": True}
-    _linux_perms = {"root_access": True, "process_monitoring": True, "filesystem_access": True, "network_monitoring": True}
-    _windows_caps = {"root_access": False, "process_monitoring": True, "filesystem_access": True, "network_monitoring": True}
-    _windows_perms = {"root_access": False, "process_monitoring": True, "filesystem_access": True, "network_monitoring": True}
-    _macos_caps = {"root_access": True, "process_monitoring": True, "filesystem_access": True, "network_monitoring": True}
-    _macos_perms = {"root_access": True, "process_monitoring": True, "filesystem_access": True, "network_monitoring": True}
-    _web_caps = {"root_access": False, "process_monitoring": False, "filesystem_access": False, "network_monitoring": True}
-    _web_perms = {"root_access": False, "process_monitoring": False, "filesystem_access": False, "network_monitoring": True}
-    _iot_caps = {"root_access": False, "process_monitoring": False, "filesystem_access": False, "network_monitoring": False}
-    _iot_perms = {"root_access": False, "process_monitoring": False, "filesystem_access": False, "network_monitoring": False}
-    _android_caps = {"root_access": False, "process_monitoring": True, "filesystem_access": True, "network_monitoring": True}
-    _android_perms = {"root_access": False, "process_monitoring": True, "filesystem_access": True, "network_monitoring": True}
+    _linux_caps = {
+        "root_access": True,
+        "process_monitoring": True,
+        "filesystem_access": True,
+        "network_monitoring": True,
+    }
+    _linux_perms = {
+        "root_access": True,
+        "process_monitoring": True,
+        "filesystem_access": True,
+        "network_monitoring": True,
+    }
+    _windows_caps = {
+        "root_access": False,
+        "process_monitoring": True,
+        "filesystem_access": True,
+        "network_monitoring": True,
+    }
+    _windows_perms = {
+        "root_access": False,
+        "process_monitoring": True,
+        "filesystem_access": True,
+        "network_monitoring": True,
+    }
+    _macos_caps = {
+        "root_access": True,
+        "process_monitoring": True,
+        "filesystem_access": True,
+        "network_monitoring": True,
+    }
+    _macos_perms = {
+        "root_access": True,
+        "process_monitoring": True,
+        "filesystem_access": True,
+        "network_monitoring": True,
+    }
+    _web_caps = {
+        "root_access": False,
+        "process_monitoring": False,
+        "filesystem_access": False,
+        "network_monitoring": True,
+    }
+    _web_perms = {
+        "root_access": False,
+        "process_monitoring": False,
+        "filesystem_access": False,
+        "network_monitoring": True,
+    }
+    _iot_caps = {
+        "root_access": False,
+        "process_monitoring": False,
+        "filesystem_access": False,
+        "network_monitoring": False,
+    }
+    _iot_perms = {
+        "root_access": False,
+        "process_monitoring": False,
+        "filesystem_access": False,
+        "network_monitoring": False,
+    }
+    _android_caps = {
+        "root_access": False,
+        "process_monitoring": True,
+        "filesystem_access": True,
+        "network_monitoring": True,
+    }
+    _android_perms = {
+        "root_access": False,
+        "process_monitoring": True,
+        "filesystem_access": True,
+        "network_monitoring": True,
+    }
 
     async with db_service.get_session() as session:
         await get_or_create_device(
@@ -884,7 +986,9 @@ async def init_database():
             session.add_all(active_alerts)
 
             # 2. Add the supporting data (High CPU metrics)
-            problem_metrics = generate_problematic_metrics(first_device.id, provenance=prov)
+            problem_metrics = generate_problematic_metrics(
+                first_device.id, provenance=prov
+            )
             session.add_all(problem_metrics)
 
             # Generate historical user activity
@@ -939,7 +1043,9 @@ async def init_database():
         site2 = await session.execute(select(Site).where(Site.site_id == site2_id))
         site2 = site2.scalar_one()
 
-        admin_user = await session.execute(select(User).where(User.username == "homepot_admin"))
+        admin_user = await session.execute(
+            select(User).where(User.username == "homepot_admin")
+        )
         admin_user = admin_user.scalar_one()
 
         now = datetime.now(timezone.utc)
@@ -1136,4 +1242,15 @@ async def init_database():
 
 
 if __name__ == "__main__":
-    asyncio.run(init_database())
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Initialize the HOMEPOT database schema and optional demo data."
+    )
+    parser.add_argument(
+        "--schema-only",
+        action="store_true",
+        help="Create the schema and the admin user only (no demo/simulated data)",
+    )
+    args = parser.parse_args()
+    asyncio.run(init_database(schema_only=args.schema_only))

--- a/docs/fresh-database-setup.md
+++ b/docs/fresh-database-setup.md
@@ -57,10 +57,16 @@ GRANT ALL PRIVILEGES ON DATABASE homepot_db TO homepot_user;
 
 ### 4. Seeding Script (`seed_data.py`)
 
-The database is populated using `backend/utils/seed_data.py`. This script is automatically executed by `init-postgresql.sh` but can also be run manually if needed.
+The schema and demo data are managed by `backend/utils/seed_data.py`:
 
-**Key Features:**
-- **Deterministic Seeding:** Creates a fixed set of 4 sites and 20 devices to ensure consistent testing environments.
+- **`init-postgresql.sh`** runs it with `--schema-only`, creating the schema +
+  the default admin user with **no** demo data. A fresh database is clean.
+- **`scripts/seed-demo-data.sh`** (opt-in) runs the full demo seed — tenants,
+  sites, simulated devices, and historical analytics — when you want the
+  simulated fleet.
+
+**Key Features (full seed):**
+- **Deterministic Seeding:** Creates a fixed set of sites and devices to ensure consistent testing environments.
 - **Credential Alignment:** Creates a single application user (`homepot_user`) that matches the database credentials, simplifying the developer experience.
 - **Sample Analytics:** Generates initial sample data for jobs, health checks, audit logs, and analytics events to populate the dashboard immediately.
 - **Dependency Handling:** Includes patches for library compatibility (e.g., `bcrypt`/`passlib`).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,13 +38,29 @@ chmod +x scripts/*.sh
 
 ### Step 2: Initialize Database
 
-Initialize the PostgreSQL database with the required schema and demo data. This script detects your local PostgreSQL installation (via Homebrew on macOS or system packages on Linux) and ensures the service is running before creating the database.
+Initialize the PostgreSQL database with the schema and default admin user
+(`admin@homepot.com` / `homepot_dev_password`). This script detects your local
+PostgreSQL installation (via Homebrew on macOS or system packages on Linux) and
+ensures the service is running before creating the database. A fresh database
+starts **clean — no devices**.
 
 ```bash
 ./scripts/init-postgresql.sh
 ```
 
 > **Note**: This setup uses a local PostgreSQL instance and does not require Docker.
+
+To load the **demo / simulated fleet** (tenants, sites, simulated devices,
+historical analytics) — e.g. for a demo or to see the simulator in action —
+run the opt-in seeder:
+
+```bash
+./scripts/seed-demo-data.sh
+```
+
+Without seeding, devices are added explicitly via **simulation**,
+**emulation**, or **real** devices (see
+[Device Emulators](device-emulators.md) and the three integration modes).
 
 
 ### Step 3: Start the Application

--- a/scripts/init-postgresql.sh
+++ b/scripts/init-postgresql.sh
@@ -150,7 +150,7 @@ if [ -f "./scripts/setup-pgpass.sh" ]; then
     ./scripts/setup-pgpass.sh
 fi
 
-echo "Initializing database schema and seed data..."
+echo "Initializing database schema and admin user..."
 
 # Determine Python executable
 if [ -f ".venv/bin/python3" ]; then
@@ -161,9 +161,11 @@ else
     PYTHON_CMD="python3"
 fi
 
-# Run Python script to initialize database
+# Run Python script to initialize the schema + default admin user only.
+# Demo data (tenants, sites, simulated devices, analytics) is opt-in via
+# ./scripts/seed-demo-data.sh so a fresh database starts clean.
 DATABASE__URL="postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}" \
-    $PYTHON_CMD backend/utils/seed_data.py
+    $PYTHON_CMD backend/utils/seed_data.py --schema-only
 
 # Upgrade alembic migration state so that schema PRs cannot silently break
 # existing installs.  This runs after the app's create_all bootstraps the

--- a/scripts/seed-demo-data.sh
+++ b/scripts/seed-demo-data.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+################################################################################
+# HOMEPOT Demo Data Seeder
+#
+# Opt-in script that seeds the full demo dataset into an existing database:
+# tenants, users, sites, simulated devices, and historical analytics data
+# (metrics, alerts, jobs, audit, enrolment intents, operating schedules).
+#
+# A fresh database from ./scripts/init-postgresql.sh is intentionally CLEAN
+# (schema + admin user only). Run this script only when you want the demo /
+# simulated fleet. For real or emulated devices you do NOT need this.
+#
+# Usage: ./scripts/seed-demo-data.sh
+################################################################################
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "=== HOMEPOT Demo Data Seeder ==="
+echo ""
+
+# Determine Python executable
+PYTHON_CMD=""
+if [ -f "$REPO_ROOT/.venv/bin/python3" ]; then
+    PYTHON_CMD="$REPO_ROOT/.venv/bin/python3"
+elif [ -f "$REPO_ROOT/.venv/bin/python" ]; then
+    PYTHON_CMD="$REPO_ROOT/.venv/bin/python"
+else
+    PYTHON_CMD="python3"
+fi
+
+# Default database connection (matches init-postgresql.sh)
+export DATABASE__URL="${DATABASE__URL:-postgresql://homepot_user:homepot_dev_password@localhost:5432/homepot_db}"
+
+echo ">> Running demo seed against $DATABASE__URL ..."
+"$PYTHON_CMD" "$REPO_ROOT/backend/utils/seed_data.py"
+
+echo ""
+echo "=== Demo data seeding complete. ==="


### PR DESCRIPTION
## Summary

`init-postgresql.sh` previously ran the full `seed_data.py`, which baked in tenants, sites, and ~10 simulated devices — polluting provenance and making a clean start for real/emulated devices impossible.

## Changes

- **`seed_data.py`** now supports `--schema-only`: creates the schema (core + analytics tables) and the default **admin user** only — no demo/simulated data. The full demo seed (tenants, users, sites, simulated devices, historical metrics/alerts/jobs/schedules) remains the default mode.
- **`init-postgresql.sh`** runs `seed_data.py --schema-only`, so a fresh database is clean (schema + admin) and devices are added explicitly via simulation / emulation / real.
- **New `scripts/seed-demo-data.sh`** (opt-in) runs the full demo seed for anyone who wants the simulated fleet.

## Verification

- `--schema-only` produces schema + admin (`homepot_admin`, `admin@homepot.com`) with **0 devices and 0 sites**.
- `create_admin_user` is idempotent (second run skips).
- CLI `--help` shows the new flag; `bash -n` on both scripts passes.