### PR TITLE
feat(userapp): backend-URL override + visible emulator launch errors

### DIFF
--- a/docs/user-app-frontend-guide.md
+++ b/docs/user-app-frontend-guide.md
@@ -126,6 +126,84 @@ This avoids running `nvm use` every time you open a terminal.
 
 ---
 
+## 4.5 Emulator mode (development)
+
+The setup wizard has an **emulator mode** ("Launch emulated device") that
+spawns one of the POS emulators from the **Electron** app instead of a real
+device — useful for end-to-end testing without physical hardware, and to
+validate the User App ↔ Dashboard flow on a Mac.
+
+- Requires the **Electron** app (`window.electronAPI`). The browser-only dev
+  server cannot spawn an emulator process.
+- Pick an OS in `EmulatorConfigStep` — **macOS POS** is included alongside
+  Linux/Android/Windows/iOS.
+- The **Backend URL** field lets you point the spawned emulator at a LAN
+  backend (e.g. `http://192.168.1.176:8000` when the backend runs on a
+  Windows/WSL host and the User App runs on the Mac). It defaults to the
+  configured `VITE_API_BASE_URL`.
+- If the emulator fails to start (e.g. missing `httpx` in the venv, or the
+  script can't be found), the **error is shown in the wizard** — stderr from
+  the emulator process is captured and included, and the credential poll
+  aborts as soon as the process exits instead of waiting 30s.
+
+Run it in development:
+
+```bash
+npm run electron:dev      # Electron with the Vite dev server
+```
+
+## 4.6 Packaging & running on macOS (real-device-style testing)
+
+To test the User App like a **real device** on a Mac (its emulator provisioning
+against a remote backend):
+
+**1. Configure the backend URL.** The Mac must reach the backend over the LAN,
+not `localhost`:
+
+```bash
+# user_app/.env.local
+VITE_API_BASE_URL=http://192.168.1.176:8000/api/v1
+```
+
+**2. Ensure the emulator venv is ready on the Mac.** The Electron app spawns
+the emulator via the project venv (`.venv/bin/python3`), so it must exist with
+`httpx` installed:
+
+```bash
+python3 -m venv .venv && source .venv/bin/activate && pip install httpx
+```
+
+**3. Build the packaged app:**
+
+```bash
+cd user_app
+npm install
+npm run electron:build      # electron-builder → .app / .dmg (platform of the Mac)
+```
+
+Or, for a faster dev loop without packaging:
+
+```bash
+npm run electron:dev
+```
+
+**4. Run it on the Mac** and go through setup:
+- Choose **Launch emulated device** → **macOS POS**.
+- Set the **Backend URL** to `http://192.168.1.176:8000`.
+- Enter the site ID + bootstrap key, review, and complete — the User App
+  spawns `emulators/macos_pos_emulator.py`, which provisions the device and
+  streams DNA/heartbeat/telemetry to the backend.
+
+**5. Verify on the Dashboard** (host machine): the `macOS POS` device appears
+online with the **EMU** badge, live telemetry, and an active command/history —
+the same as running the emulator directly via `./scripts/start-emulator.sh`.
+
+> The backend should be in **emulation mode** for this
+> (`./scripts/start-dashboard.sh emulation`, simulator OFF) so the emulator is
+> the sole data source for the device.
+
+---
+
 ## 5. Page Working Flow
 
 ### Page 1 — Setup / Provisioning Wizard (First Run Only)

--- a/user_app/electron/main.ts
+++ b/user_app/electron/main.ts
@@ -18,6 +18,9 @@ let mainWindow: BrowserWindow | null = null
 let tray: Tray | null = null
 let emulatorProcess: ChildProcess | null = null
 let emulatorDeviceId: string | null = null
+// Recent stderr lines from the emulator process, surfaced in the setup error
+// when the emulator fails to start (e.g. missing python/httpx).
+let emulatorStderr: string[] = []
 
 interface EmulatorFileConfig {
   emulator_type?: string
@@ -410,8 +413,12 @@ function registerIpcHandlers() {
     const creds = await pollForCredentials(credsPath, 30_000)
     if (!creds) {
       killEmulator()
+      const stderr = emulatorStderr.join('\n')
       recordAppEvent('error', 'setup', 'Device emulator setup timed out')
-      throw new Error('Emulator did not provision within 30 seconds')
+      const detail = stderr
+        ? ` Emulator output: ${stderr.slice(0, 500)}`
+        : ' The emulator did not provision within 30 seconds.'
+      throw new Error(`Device emulator failed to start.${detail}`)
     }
 
     emulatorDeviceId = creds.device_id
@@ -461,6 +468,7 @@ function startEmulatorProcess(emulatorType: string, configPath: string): void {
   }
 
   const pythonExe = findPython(projectRoot)
+  emulatorStderr = []
   const child = spawn(pythonExe, [emulatorScript, '--config', configPath], {
     cwd: projectRoot,
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -475,7 +483,11 @@ function startEmulatorProcess(emulatorType: string, configPath: string): void {
   })
 
   child.stderr?.on('data', (data: Buffer) => {
-    console.error(`[emulator:err] ${data.toString().trim()}`)
+    const lines = data.toString().split('\n').filter(Boolean)
+    for (const line of lines) {
+      console.error(`[emulator:err] ${line}`)
+    }
+    emulatorStderr = [...emulatorStderr, ...lines].slice(-15)
   })
 
   child.on('error', (error) => {
@@ -567,6 +579,13 @@ function pollForCredentials(credsPath: string, timeoutMs: number): Promise<Recor
             return
           }
         } catch { /* file may still be being written */ }
+      }
+      // Abort early if the emulator process has already exited (e.g. a python
+      // import failure like missing httpx) so the error surfaces immediately
+      // instead of waiting out the timeout.
+      if (!emulatorProcess) {
+        resolve(null)
+        return
       }
       if (Date.now() - start >= timeoutMs) {
         resolve(null)

--- a/user_app/src/context/AppContext.tsx
+++ b/user_app/src/context/AppContext.tsx
@@ -16,6 +16,9 @@ interface SetupState {
   deviceType: string
   deviceOs: string
   bootstrapKey: string
+  /** Override for the backend URL used by emulator launches (LAN IP for Mac
+   *  testing); empty means fall back to the configured apiBaseUrl. */
+  backendUrl: string
 }
 
 interface AppContextType {
@@ -46,6 +49,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
     deviceType: '',
     deviceOs: 'auto',
     bootstrapKey: '',
+    backendUrl: '',
   })
   const [useEmulator, setUseEmulator] = useState<boolean | null>(null)
   const [emulatorType, setEmulatorType] = useState('linux_pos')

--- a/user_app/src/views/SetupWizard.tsx
+++ b/user_app/src/views/SetupWizard.tsx
@@ -160,7 +160,7 @@ function Step1() {
 
   const handleNext = async () => {
     const resolvedOs = deviceOs === 'auto' ? await detectOS() : deviceOs
-    setSetupState({ siteId, deviceName, deviceType, deviceOs: resolvedOs, bootstrapKey })
+    setSetupState({ siteId, deviceName, deviceType, deviceOs: resolvedOs, bootstrapKey, backendUrl: setupState.backendUrl })
     navigate('/method')
   }
 
@@ -322,7 +322,7 @@ function ReviewStep({ onBack }: { onBack: () => void }) {
         }
         const config = {
           emulatorType,
-          backendUrl: apiBaseUrl.replace('/api/v1', ''),
+          backendUrl: setupState.backendUrl || apiBaseUrl.replace('/api/v1', ''),
           siteId,
           bootstrapKey,
           deviceName: deviceName || 'Emulated Device',
@@ -455,10 +455,17 @@ function EmulatorConfigStep() {
   const navigate = useNavigate()
   const { emulatorType, setEmulatorType, setUseEmulator, setSetupState, setupState } = useApp()
   const selected = EMULATOR_TYPES.find(t => t.value === emulatorType) ?? EMULATOR_TYPES[0]
+  const defaultBackendUrl = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000/api/v1').replace(/\/$/, '').replace(/\/api\/v1$/, '')
+  const [backendUrl, setBackendUrl] = useState(setupState.backendUrl || defaultBackendUrl)
 
   const handleNext = () => {
     setUseEmulator(true)
-    setSetupState({ ...setupState, deviceType: selected.deviceType, deviceOs: selected.os })
+    setSetupState({
+      ...setupState,
+      deviceType: selected.deviceType,
+      deviceOs: selected.os,
+      backendUrl: backendUrl.trim() || defaultBackendUrl,
+    })
     navigate('/setup/review')
   }
 
@@ -490,6 +497,25 @@ function EmulatorConfigStep() {
             <p className="text-slate-500 text-xs">{t.os}</p>
           </button>
         ))}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="emulator-backend-url" className="text-slate-300 text-xs font-medium">
+          Backend URL
+        </label>
+        <input
+          id="emulator-backend-url"
+          type="text"
+          value={backendUrl}
+          onChange={e => setBackendUrl(e.target.value)}
+          placeholder="http://192.168.1.176:8000"
+          className="w-full px-3 py-2 rounded-lg bg-slate-700/70 border border-slate-600 text-slate-200 text-sm focus:outline-none focus:border-emerald-500"
+        />
+        <p className="text-slate-500 text-xs">
+          The backend the emulator connects to. Use the host's LAN IP (e.g.
+          <span className="text-slate-400"> http://192.168.1.176:8000</span>) when
+          the backend runs on another machine (e.g. Windows/WSL) than this Mac.
+        </p>
       </div>
 
       <div className="flex gap-3 mt-2">


### PR DESCRIPTION
## Summary

Two improvements to the User App emulator mode, aimed at running the emulator from the Mac against a LAN backend (Windows/WSL host).
## 1. Backend URL override (SetupWizard)
- `EmulatorConfigStep` now has a **Backend URL** input, defaulting to the configured `apiBaseUrl`. The value is stored in `setupState.backendUrl` and used by `ReviewStep` when calling `emulator.start`, so the spawned emulator can target e.g. `http://192.168.1.176:8000` instead of `localhost`.
## 2. Visible emulator launch errors (Electron main)
- Emulator **stderr is captured** and included in the setup error when the emulator fails to start (e.g. `ModuleNotFoundError: No module named 'httpx'`).
- The credential poll **aborts early** when the emulator process exits, so failures surface immediately rather than after the 30s timeout.

## Validation
`tsc` (app + node tsconfigs), `eslint` (changed files), `npm run build`, and `vitest` (90 tests) pass. (The one `react-refresh/only-export-components` eslint warning in AppContext is pre-existing.)