### PR TITLE
feat(userapp): pre-fill Site ID + Bootstrap Key from start-userapp.sh args

### DIFF
--- a/scripts/start-userapp.sh
+++ b/scripts/start-userapp.sh
@@ -90,10 +90,12 @@ userapp_ready() {
 ################################################################################
 
 RESET_MODE=false
+PREFILL_SITE_ID=""
+PREFILL_BOOTSTRAP_KEY=""
 
 show_help() {
     cat <<EOF
-Usage: ./scripts/start-userapp.sh [--reset]
+Usage: ./scripts/start-userapp.sh [--reset] [--site-id <id>] [--bootstrap-key <key>]
 
 Starts the HOMEPOT User App (Agent) desktop application.
 
@@ -101,18 +103,41 @@ Options:
   -r, --reset   Clear stored device credentials and the emulator credential
                 stash, then boot directly into the Setup wizard so a new
                 device can be provisioned.
+      --site-id <id>
+                Pre-fill the Site ID in the Setup wizard.
+      --bootstrap-key <key>
+                Pre-fill the Bootstrap Key in the Setup wizard.
   -h, --help    Show this help message.
+
+Examples:
+  ./scripts/start-userapp.sh --reset --site-id SITE-7UAH-963T \\
+    --bootstrap-key homepot-dev-emulator-key
 EOF
     exit 0
 }
 
-for arg in "$@"; do
-    case "$arg" in
-        -r|--reset) RESET_MODE=true ;;
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -r|--reset) RESET_MODE=true; shift ;;
         -h|--help) show_help ;;
-        *) print_error "Unknown argument: $arg"; show_help ;;
+        --site-id)
+            if [[ -z "${2:-}" ]]; then print_error "--site-id requires a value"; show_help; fi
+            PREFILL_SITE_ID="$2"; shift 2 ;;
+        --bootstrap-key)
+            if [[ -z "${2:-}" ]]; then print_error "--bootstrap-key requires a value"; show_help; fi
+            PREFILL_BOOTSTRAP_KEY="$2"; shift 2 ;;
+        *) print_error "Unknown argument: $1"; show_help ;;
     esac
 done
+
+# Pass the pre-fill values to the User App renderer via env (read by the
+# Electron preload script and used to initialise the Setup wizard fields).
+if [ -n "$PREFILL_SITE_ID" ]; then
+    export HOMEPOT_PREFILL_SITE_ID="$PREFILL_SITE_ID"
+fi
+if [ -n "$PREFILL_BOOTSTRAP_KEY" ]; then
+    export HOMEPOT_PREFILL_BOOTSTRAP_KEY="$PREFILL_BOOTSTRAP_KEY"
+fi
 
 if [ "$RESET_MODE" = true ]; then
     print_step "Reset mode: clearing stored device credentials..."

--- a/user_app/electron/preload.ts
+++ b/user_app/electron/preload.ts
@@ -1,5 +1,13 @@
 import { contextBridge, ipcRenderer } from 'electron'
 
+// Pre-fill values passed by scripts/start-userapp.sh via env (--site-id and
+// --bootstrap-key). Exposed synchronously so the Setup wizard can initialise
+// its fields without a race.
+const prefill = {
+  siteId: process.env.HOMEPOT_PREFILL_SITE_ID || '',
+  bootstrapKey: process.env.HOMEPOT_PREFILL_BOOTSTRAP_KEY || '',
+}
+
 contextBridge.exposeInMainWorld('electronAPI', {
   credentials: {
     save: (data: Record<string, string>) => ipcRenderer.invoke('credentials:save', data),
@@ -15,6 +23,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   app: {
     getVersion: () => ipcRenderer.invoke('app:getVersion'),
     getRecentLogs: (limit = 15) => ipcRenderer.invoke('app:getRecentLogs', limit),
+    prefill,
   },
   emulator: {
     start: (config: {

--- a/user_app/src/context/AppContext.tsx
+++ b/user_app/src/context/AppContext.tsx
@@ -43,13 +43,19 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [deviceInfo, setDeviceInfo] = useState<DeviceInfo | null>(null)
   const [isProvisioned, setIsProvisioned] = useState(false)
   const [provisionedChecked, setProvisionedChecked] = useState(false)
-  const [setupState, setSetupState] = useState<SetupState>({
-    siteId: '',
-    deviceName: '',
-    deviceType: '',
-    deviceOs: 'auto',
-    bootstrapKey: '',
-    backendUrl: '',
+  const [setupState, setSetupState] = useState<SetupState>(() => {
+    // Pre-fill Site ID / Bootstrap Key from scripts/start-userapp.sh args.
+    const prefill =
+      (window as { electronAPI?: { app?: { prefill?: { siteId?: string; bootstrapKey?: string } } } })
+        .electronAPI?.app?.prefill
+    return {
+      siteId: prefill?.siteId || '',
+      deviceName: '',
+      deviceType: '',
+      deviceOs: 'auto',
+      bootstrapKey: prefill?.bootstrapKey || '',
+      backendUrl: '',
+    }
   })
   const [useEmulator, setUseEmulator] = useState<boolean | null>(null)
   const [emulatorType, setEmulatorType] = useState('linux_pos')


### PR DESCRIPTION
## Summary
Lets `./scripts/start-userapp.sh --site-id <id> --bootstrap-key <key>` pre-fill the Setup wizard so a device provisions into an existing Site without typing the values.

## Changes
- **start-userapp.sh**: new `--site-id` and `--bootstrap-key` options (values validated); exports `HOMEPOT_PREFILL_SITE_ID` / `HOMEPOT_PREFILL_BOOTSTRAP_KEY` for the app.
- **preload.ts**: reads those env vars synchronously and exposes `electronAPI.app.prefill` (`{ siteId, bootstrapKey }`).
- **AppContext.tsx**: initialises `setupState` from the prefill (Site ID + Bootstrap Key).

## Usage
```bash
./scripts/start-userapp.sh --reset --site-id SITE-7UAH-963T --bootstrap-key homepot-dev-emulator-key
```

## Validation
`tsc` (app + node), `npm run build`, and `vitest` (90 tests) pass. (The `react-refresh/only-export-components` eslint warning in AppContext is pre-existing.)
