### PR TITLE
fix(scripts): fully quit Electron.app on macOS in stop-userapp.sh

### DIFF
--- a/scripts/stop-userapp.sh
+++ b/scripts/stop-userapp.sh
@@ -60,6 +60,13 @@ if [ -n "$LEGACY_EMULATOR_PIDS" ]; then
     kill $LEGACY_EMULATOR_PIDS 2>/dev/null || true
 fi
 
+# macOS: the Electron.app child is not in the tracked process group (no
+# setsid) and its binary path differs from $ELECTRON_BIN, so it survives the
+# wrapper kill above. Match the npm electron dist tree to fully quit it.
+if [[ "$(uname)" == "Darwin" ]]; then
+    pkill -f "$REPO_ROOT/user_app/node_modules/electron/dist" 2>/dev/null || true
+fi
+
 # Fallback: kill anything running on port 5174
 if lsof -Pi :5174 -sTCP:LISTEN -t >/dev/null 2>&1; then
     lsof -ti:5174 | xargs kill 2>/dev/null


### PR DESCRIPTION
## Problem

On macOS, `stop-userapp.sh` kills the npm wrapper + the Vite port, but the actual **Electron.app** process survives:
- There is no `setsid` on macOS, so the npm PID is not a process-group leader and the script takes the fallback path that only kills the wrapper.
- The legacy-Electron `pgrep` pattern does not match the `.app` binary path.

## Fix

Add a Darwin-only cleanup that `pkill`s against the npm electron dist tree (`user_app/node_modules/electron/dist`), which matches the Electron.app binary, so `./scripts/stop-userapp.sh` fully quits the User App on macOS.

Linux behaviour is unchanged.
