### PR TITLE
fix(emulators): honor backend_url from the config file

### DIFF
--- a/emulators/pos_engine.py
+++ b/emulators/pos_engine.py
@@ -1545,9 +1545,7 @@ def parse_args(
     parser = argparse.ArgumentParser(description="HOMEPOT POS Device Emulator")
     d = defaults or {}
     parser.add_argument("--config", "-c", type=str, help="Path to JSON config file")
-    parser.add_argument(
-        "--backend-url", type=str, default=DEFAULT_BACKEND_URL, help="Backend URL"
-    )
+    parser.add_argument("--backend-url", type=str, default=None, help="Backend URL")
     parser.add_argument(
         "--site-id", type=str, default="", help="Site ID to provision under"
     )
@@ -1682,7 +1680,8 @@ def build_config(
         with open(path) as f:
             cfg = json.load(f)
         config = EmulatorConfig.from_dict({**d, **cfg})
-        config.backend_url = args.backend_url
+        if args.backend_url:
+            config.backend_url = args.backend_url
         if args.os_details:
             config.os_details = args.os_details
         if args.device_type:
@@ -1698,7 +1697,7 @@ def build_config(
         return config
 
     return EmulatorConfig(
-        backend_url=args.backend_url,
+        backend_url=args.backend_url or DEFAULT_BACKEND_URL,
         site_id=args.site_id,
         bootstrap_key=args.bootstrap_key,
         device_name=args.device_name.strip(),


### PR DESCRIPTION
## Problem

`build_config` unconditionally did `config.backend_url = args.backend_url`, and `--backend-url` defaulted to `http://localhost:8000`. So launching the emulator with `--config <file>` but **no** `--backend-url` — exactly what the User App does via `emulator:start` — always overrode the config file's `backend_url` with `localhost`.

This is why the User App wrote the correct `backend_url` (`http://192.168.1.176:8000`) into the temp config, yet the emulator banner showed `Backend: http://localhost:8000` and failed with `ConnectError`.

## Fix

- `--backend-url` default → `None`.
- In the config-file path, apply `args.backend_url` only when explicitly provided (matching the `if args.X:` guards used by every other field).
- In the no-config path, use `args.backend_url or DEFAULT_BACKEND_URL`.

## Verified

- config-file only → honours the file's `backend_url`
- config-file + explicit `--backend-url` → CLI wins
- no args → defaults to `http://localhost:8000`

`flake8`, `black`, `isort`, `mypy` pass.
