### PR TITLE
feat(userapp): lightweight in-memory telemetry cache

### DIFF
--- a/user_app/src/services/telemetryCache.ts
+++ b/user_app/src/services/telemetryCache.ts
@@ -1,0 +1,32 @@
+import type { DeviceStatus, DeviceMetrics } from './api'
+
+/**
+ * Lightweight in-memory telemetry cache for the User App.
+ *
+ * Holds only the last-fetched status + metrics for the current device so page
+ * navigations render instantly (no disk, no large payloads). Cleared on unpair
+ * so a re-enrolled device never shows stale data.
+ */
+interface TelemetrySnapshot {
+  status: DeviceStatus | null
+  metrics: DeviceMetrics | null
+  updatedAt: number
+}
+
+const cache = new Map<string, TelemetrySnapshot>()
+
+export function getCachedTelemetry(deviceId: string): TelemetrySnapshot | undefined {
+  return cache.get(deviceId)
+}
+
+export function setCachedTelemetry(
+  deviceId: string,
+  status: DeviceStatus | null,
+  metrics: DeviceMetrics | null,
+): void {
+  cache.set(deviceId, { status, metrics, updatedAt: Date.now() })
+}
+
+export function clearCachedTelemetry(deviceId: string): void {
+  cache.delete(deviceId)
+}

--- a/user_app/src/views/DeviceInfo.tsx
+++ b/user_app/src/views/DeviceInfo.tsx
@@ -4,6 +4,7 @@ import TabBar from '../components/TabBar'
 import { useApp } from '../context/AppContext'
 import { credentialStorage } from '../services/credentialStorage'
 import { fetchDevice, unpairDevice, ApiError } from '../services/api'
+import { clearCachedTelemetry } from '../services/telemetryCache'
 import type { DeviceRecord } from '../services/api'
 
 function formatDeviceType(v: string) {
@@ -116,6 +117,7 @@ export default function DeviceInfo() {
         reason: 'User-initiated unpair from device settings',
         idempotencyKey,
       })
+      clearCachedTelemetry(deviceId)
       setUnpairStatus('confirmed')
       await credentialStorage.clear()
       setIsProvisioned(false)
@@ -126,6 +128,7 @@ export default function DeviceInfo() {
         setUnpairStatus('error')
       } else {
         // Network failure — perform local-only reset
+        clearCachedTelemetry(deviceId)
         await credentialStorage.clear()
         setIsProvisioned(false)
         setUnpairStatus('pending-revocation')

--- a/user_app/src/views/HomeDashboard.tsx
+++ b/user_app/src/views/HomeDashboard.tsx
@@ -3,6 +3,7 @@ import TabBar from '../components/TabBar'
 import GaugeRing from '../components/GaugeRing'
 import { credentialStorage } from '../services/credentialStorage'
 import { fetchDeviceStatus, fetchDeviceMetrics } from '../services/api'
+import { getCachedTelemetry, setCachedTelemetry } from '../services/telemetryCache'
 import type { DeviceStatus, DeviceMetrics } from '../services/api'
 
 function formatUptime(totalSeconds: number | null): string {
@@ -52,7 +53,10 @@ export default function HomeDashboard() {
       const aKey = apiKeyRef.current
       if (!dId || !aKey) return
       try {
-        setStatus(await fetchDeviceStatus(dId, aKey))
+        const fresh = await fetchDeviceStatus(dId, aKey)
+        setStatus(fresh)
+        const cached = getCachedTelemetry(dId)
+        setCachedTelemetry(dId, fresh, cached?.metrics ?? null)
       } catch {
         // silently degrade
       }
@@ -62,12 +66,24 @@ export default function HomeDashboard() {
       const aKey = apiKeyRef.current
       if (!dId || !aKey) return
       try {
-        setMetrics(await fetchDeviceMetrics(dId, aKey))
+        const fresh = await fetchDeviceMetrics(dId, aKey)
+        setMetrics(fresh)
+        const cached = getCachedTelemetry(dId)
+        setCachedTelemetry(dId, cached?.status ?? null, fresh)
       } catch {
         // silently degrade
       }
     }
     if (!deviceIdRef.current || !apiKeyRef.current) return
+
+    // Render any cached telemetry immediately, then refresh from the backend.
+    const dId = deviceIdRef.current
+    const cached = getCachedTelemetry(dId)
+    if (cached) {
+      if (cached.status) setStatus(cached.status)
+      if (cached.metrics) setMetrics(cached.metrics)
+    }
+
     fetchStatus()
     fetchMetrics()
     const statusInterval = setInterval(fetchStatus, 30000)


### PR DESCRIPTION
## Summary

Adds a small **in-memory** telemetry cache to the User App so switching pages renders the device status + metrics instantly, then refreshes from the backend as before.

## Why lightweight

- **No disk** — a plain `Map` keyed by the single device id (fits limited-memory devices).
- The backend remains the source of truth; the cache is display-only and bounded to one device.
- Existing 15s/30s polls continue to refresh it.

## Changes

- `telemetryCache.ts` — `get/set/clear` for `{ status, metrics, updatedAt }`.
- `HomeDashboard.tsx` — hydrate from the cache on mount (instant render), update it after each fetch.
- `DeviceInfo.tsx` — clear the cache on unpair (successful or local-only reset) so a re-enrolled device never shows stale data.

## Validation

`tsc`, `npm run build`, and `vitest` (90 tests) pass.
