### PR TITLE
feat(userapp): rename --reset to --fresh in start-userapp.sh

### DIFF
--- a/docs/get_start_userapp.md
+++ b/docs/get_start_userapp.md
@@ -45,7 +45,7 @@ Avoids running `nvm use` every time you open a new terminal.
 | Command | What it does |
 |---|---|
 | `./scripts/start-userapp.sh` | Automatically check requirements and start the App via `nohup`; if the App is already running, reopens its window |
-| `./scripts/start-userapp.sh --reset` | Clear stored device credentials and start the App **directly into the Setup wizard** so a new device can be provisioned |
+| `./scripts/start-userapp.sh --fresh` | Clear stored device credentials and start the App **directly into the Setup wizard** so a new device can be provisioned |
 | `./scripts/stop-userapp.sh` | Kill the `nohup` server processes running the user app |
 | `npm run dev` | Start local dev server at http://localhost:5174 |
 | `npm run build` | Production build → output to `dist/` |
@@ -118,12 +118,12 @@ Once provisioned, the app opens on the **Home Dashboard**. To start a fresh
 setup and provision a new device, clear those credentials **before** launching:
 
 ```bash
-# Stop the app if it is running, then relaunch in reset mode
+# Stop the app if it is running, then relaunch in fresh mode
 ./scripts/stop-userapp.sh
-./scripts/start-userapp.sh --reset
+./scripts/start-userapp.sh --fresh
 ```
 
-`--reset` deletes the stored credentials and boots the app straight into the
+`--fresh` deletes the stored credentials and boots the app straight into the
 Setup wizard. You can also run `./scripts/start-userapp.sh --help` for a list
 of options.
 

--- a/docs/verify-user-app-with-emulators.md
+++ b/docs/verify-user-app-with-emulators.md
@@ -262,13 +262,13 @@ In **Terminal 2**, first start the HOMEPOT **User App** — the device-side UI (
 
 If the User App was used before on this machine, it opens on the **Home
 Dashboard** instead of the wizard. To provision a **new** device, relaunch it in
-reset mode:
+fresh mode:
 
 ```bash
-./scripts/start-userapp.sh --reset
+./scripts/start-userapp.sh --fresh
 ```
 
-`--reset` clears the stored credentials (`~/.homepot/credentials`) so the Setup
+`--fresh` clears the stored credentials (`~/.homepot/credentials`) so the Setup
 wizard opens again.
 
 The **HOMEPOT Agent** Electron window opens with the setup wizard. Walk through
@@ -561,7 +561,7 @@ For **push notification** testing (Compose Push → the emulator polling
 |---------|-------------|
 | "Device name ... already in use" (400) | A live device in the site already uses that name (case-insensitive). Pick a different name, or retire/unpair the old device first. |
 | Emulator exits with `Provisioning failed (404): Site not found` | The `--site-id` does not exist on the backend. `site-it-demo1` is a placeholder — use a real site ID from your backend (Sites page / `SELECT site_id FROM sites;`) or create the site first. |
-| User App opens on Home instead of the Setup wizard | The device is already provisioned (`~/.homepot/credentials` exists). Relaunch with `./scripts/start-userapp.sh --reset` to clear it and start a fresh setup. |
+| User App opens on Home instead of the Setup wizard | The device is already provisioned (`~/.homepot/credentials` exists). Relaunch with `./scripts/start-userapp.sh --fresh` to clear it and start a fresh setup. |
 | User App window is gone but the app is still running | Closing the window hides it to the system tray (the process, running emulator, and setup state are preserved). Re-run `./scripts/start-userapp.sh` to reopen the window, or click the tray icon. |
 | Device never appears on the Dashboard | Bootstrap key typo, or wrong `--site-id`. The key is single-use-ish — generate a new one in Step 2. |
 | Emulator re-provisions but Dashboard shows the old device | Stale credentials file — delete `~/.homepot/emulators/<device_name>.json` and re-run **with a different `--device-name`** (the old name is still registered and the duplicate check will reject it). |

--- a/scripts/start-userapp.sh
+++ b/scripts/start-userapp.sh
@@ -5,12 +5,12 @@
 #
 # This script starts the HOMEPOT User App (Agent) locally.
 #
-# Usage: ./scripts/start-userapp.sh [--reset]
+# Usage: ./scripts/start-userapp.sh [--fresh]
 #
 # Options:
-#   -r, --reset   Clear stored device credentials and the emulator credential
+#   -f, --fresh   Clear stored device credentials and the emulator credential
 #                 stash, then boot directly into the Setup wizard so a new
-#                 device can be provisioned.
+#                 device can be provisioned. (Alias: --reset)
 #   -h, --help    Show usage information.
 ################################################################################
 
@@ -89,7 +89,7 @@ userapp_ready() {
 # Command-line Arguments
 ################################################################################
 
-RESET_MODE=false
+FRESH_MODE=false
 PREFILL_SITE_ID=""
 PREFILL_BOOTSTRAP_KEY=""
 PREFILL_DEVICE_NAME=""
@@ -98,15 +98,15 @@ PREFILL_OS_DETAILS=""
 
 show_help() {
     cat <<EOF
-Usage: ./scripts/start-userapp.sh [--reset] [--site-id <id>] [--bootstrap-key <key>]
+Usage: ./scripts/start-userapp.sh [--fresh] [--site-id <id>] [--bootstrap-key <key>]
                            [--device-name <name>] [--device-type <type>] [--os-details <os>]
 
 Starts the HOMEPOT User App (Agent) desktop application.
 
 Options:
-  -r, --reset   Clear stored device credentials and the emulator credential
+  -f, --fresh   Clear stored device credentials and the emulator credential
                 stash, then boot directly into the Setup wizard so a new
-                device can be provisioned.
+                device can be provisioned. (Alias: --reset)
       --site-id <id>
                 Pre-fill the Site ID in the Setup wizard.
       --bootstrap-key <key>
@@ -121,7 +121,7 @@ Options:
   -h, --help    Show this help message.
 
 Examples:
-  ./scripts/start-userapp.sh --reset --site-id SITE-7UAH-963T \\
+  ./scripts/start-userapp.sh --fresh --site-id SITE-7UAH-963T \\
     --bootstrap-key homepot-dev-emulator-key --device-name demo-mac-1 \\
     --device-type pos_terminal --os-details mac
 EOF
@@ -130,7 +130,7 @@ EOF
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        -r|--reset) RESET_MODE=true; shift ;;
+        -f|--fresh|-r|--reset) FRESH_MODE=true; shift ;;
         -h|--help) show_help ;;
         --site-id)
             if [[ -z "${2:-}" ]]; then print_error "--site-id requires a value"; show_help; fi
@@ -169,7 +169,7 @@ if [ -n "$PREFILL_OS_DETAILS" ]; then
     export HOMEPOT_PREFILL_OS_DETAILS="$PREFILL_OS_DETAILS"
 fi
 
-if [ "$RESET_MODE" = true ]; then
+if [ "$FRESH_MODE" = true ]; then
     print_step "Reset mode: clearing stored device credentials..."
     CREDENTIALS_FILE="$HOME/.homepot/credentials"
     if [ -f "$CREDENTIALS_FILE" ]; then
@@ -182,7 +182,7 @@ if [ "$RESET_MODE" = true ]; then
     # ~/.homepot/emulators/ (keyed by device name) and restores from them on
     # launch (_try_restore -> load_credentials). If a device was deleted on the
     # backend, leaving these behind makes a same-named emulator reuse a deleted
-    # device_id and get 403s. Empty the stash so --reset yields a clean slate.
+    # device_id and get 403s. Empty the stash so --fresh yields a clean slate.
     EMULATOR_STASH="$HOME/.homepot/emulators"
     if [ -d "$EMULATOR_STASH" ]; then
         if rm -rf "$EMULATOR_STASH" 2>/dev/null; then
@@ -359,6 +359,6 @@ echo -e "  1. The Electron User App is ready."
 echo -e "  2. Complete setup in the ${BLUE}HOMEPOT Agent${NC} desktop window."
 echo -e ""
 echo -e "  ${YELLOW}Tip:${NC} To provision a new device later, stop the app and run"
-echo -e "       ${CYAN}$SCRIPT_DIR/start-userapp.sh --reset${NC}"
+echo -e "       ${CYAN}$SCRIPT_DIR/start-userapp.sh --fresh${NC}"
 echo ""
 exit 0


### PR DESCRIPTION
## Summary
Renames the User App launch flag `--reset` to `--fresh` (`-f`), keeping `--reset` as a backward-compatible alias so existing commands keep working.

## Changes
- `start-userapp.sh`: primary flag is now `-f, --fresh`; `-r, --reset` remains as an alias. Help text, comments, and the final "provision a new device later" tip updated.
- Docs (`get_start_userapp.md`, `verify-user-app-with-emulators.md`): references updated to `--fresh`.

## Verified
`bash -n` passes; `--fresh`, `--reset`, and `-f` all set the fresh-setup mode; `mkdocs build --strict` passes.
